### PR TITLE
VCITA2-3563 - Sales dashboard

### DIFF
--- a/swagger/sales/sales_reports.json
+++ b/swagger/sales/sales_reports.json
@@ -1,14 +1,14 @@
 {
     "openapi": "3.0.0",
     "info": {
-        "title": "Sales Reports",
-        "description": "An set of endpoints to manage sales dashboard data in the inTandem platform",
+        "title": "Sales Reports API",
+        "description": "A set of endpoints to manage and retrieve sales dashboard data within the inTandem platform, providing detailed insights on payments and forecasts.",
         "version": "3.0"
     },
     "servers": [
         {
             "url": "https://api.vcita.biz",
-            "description": "API Gateway server"
+            "description": "Main API Gateway server for accessing sales reports"
         }
     ],
     "components": {
@@ -16,7 +16,7 @@
         "Bearer": {
           "type": "http",
           "scheme": "bearer",
-          "description": "Provide a valid bearer token in the Authorization header. Example: 'Authorization: Bearer {app_token}'"
+          "description": "Authentication method using a Bearer token. Include the token in the Authorization header. Example: 'Authorization: Bearer {app_token}'"
         }
       },
       "schemas": {
@@ -26,65 +26,65 @@
                 "total_payments_due": {
                     "type": "number",
                     "format": "double",
-                    "description": "The total amount of payments due"
+                    "description": "The total outstanding amount due for payment requests"
                 },
                 "total_payments": {
                     "type": "object",
                     "properties": {
-                    "current_year": {
-                        "type": "number",
-                        "description": "Total payments for the current year"
-                    },
-                    "last_year": {
-                        "type": "string",
-                        "description": "Total payments for the last year"
-                    }
+                        "current_year": {
+                            "type": "number",
+                            "description": "Total payment amount collected for the current year."
+                        },
+                        "last_year": {
+                            "type": "string",
+                            "description": "Total payment amount collected in the previous year."
+                        }
                     }
                 },
                 "overdue_payments_summary": {
                     "type": "object",
                     "properties": {
-                    "total_overdue": {
-                        "type": "string",
-                        "description": "Total overdue payments"
-                    },
-                    "total_overdue_count": {
-                        "type": "number",
-                        "description": "Total count of overdue payments"
-                    },
-                    "last_week": {
-                        "type": "string",
-                        "description": "Overdue payments from last week"
-                    },
-                    "last_week_count": {
-                        "type": "number",
-                        "description": "Count of overdue payments from last week"
-                    },
-                    "last_month": {
-                        "type": "string",
-                        "description": "Overdue payments from last month"
-                    },
-                    "last_month_count": {
-                        "type": "number",
-                        "description": "Count of overdue payments from last month"
-                    },
-                    "old": {
-                        "type": "string",
-                        "description": "Old overdue payments"
-                    },
-                    "old_count": {
-                        "type": "number",
-                        "description": "Count of old overdue payments"
-                    }
+                        "total_overdue": {
+                            "type": "string",
+                            "description": "The total overdue amount of payment requests."
+                        },
+                        "total_overdue_count": {
+                            "type": "number",
+                            "description": "The total number of overdue payment requests."
+                        },
+                        "last_week": {
+                            "type": "string",
+                            "description": "Total overdue payment requests amount from the last week."
+                        },
+                        "last_week_count": {
+                            "type": "number",
+                            "description": "Number of overdue payment requests from the last week."
+                        },
+                        "last_month": {
+                            "type": "string",
+                            "description": "Total overdue payment requests amount from the last month."
+                        },
+                        "last_month_count": {
+                            "type": "number",
+                            "description": "Number of overdue payment requests from the last month."
+                        },
+                        "old": {
+                            "type": "string",
+                            "description": "The total amount for overdue payment requests that are older than 30 days."
+                        },
+                        "old_count": {
+                            "type": "number",
+                            "description": "Count of older overdue payment request transactions that are older than 30 days."
+                        }
                     }
                 },
                 "pending_estimates": {
                     "type": "object",
                     "properties": {
-                    "count": {
-                        "type": "number",
-                        "description": "Count of pending estimates"
-                    }
+                        "count": {
+                            "type": "number",
+                            "description": "The total count of pending payment estimates that have not yet been confirmed."
+                        }
                     }
                 }
             }
@@ -93,19 +93,19 @@
             "type": "object",
             "properties": {
                 "payment_forcast": {
-                    "description": "List of payments forcasted per month",
+                    "description": "An array of forecasted payment details for each month.",
                     "type": "array",
                     "items": {
                         "properties": {
                             "date": {
                                 "type": "string",
                                 "format": "date-time",
-                                "description": "The date of the payments"
+                                "description": "The date representing the forecasted payment period."
                             },
                             "amount": {
                                 "type": "number",
                                 "format": "double",
-                                "description": "The $ amount of the payments"
+                                "description": "The forecasted payment amount for the given date."
                             }
                         }
                     }
@@ -117,23 +117,11 @@
     "paths": {
         "/v3/sales/reports/payments_widget": {
             "get": {
-                "summary": "Payments general widget",
-                "description": "Get summerarized data for the Payments widget - Available for **Staff Tokens**",
-                "parameters": [
-                  {
-                    "name": "view",
-                    "in": "query",
-                    "schema": {  
-                      "type": "string",
-                      "enum": ["staff", "team"]
-                    },
-                    "description": "Filter parameter to get the widget data for staff or team view",
-                    "required": true
-                  }
-                ],
+                "summary": "Retrieve Payments Widget Data",
+                "description": "Fetch summarized data for the Payments widget, including total payments, overdue payments, and pending estimates. This endpoint is accessible with **Staff Tokens** only.",
                 "responses": {
                   "200": {
-                      "description": "",
+                      "description": "Successful response containing Payments widget data.",
                       "content": {
                           "application/json": {
                               "schema": {
@@ -162,23 +150,11 @@
         },
         "/v3/sales/reports/forecast_payments": {
             "get": {
-                "summary": "Payments forecast widget",
-                "description": "Get summerarized data for the Payments widget - Available for **Staff Tokens**",
-                "parameters": [
-                  {
-                    "name": "view",
-                    "in": "query",
-                    "schema": {  
-                      "type": "string",
-                      "enum": ["staff", "team"]
-                    },
-                    "description": "Filter parameter to get the widget data for staff or team view",
-                    "required": true
-                  }
-                ],
+                "summary": "Retrieve Payments Forecast Data",
+                "description": "Fetch detailed data for the Payments forecast widget, providing predictions of future payments on a month-by-month basis. This endpoint is accessible with **Staff Tokens** only.",
                 "responses": {
                   "200": {
-                      "description": "",
+                      "description": "Successful response containing Payments forecast data.",
                       "content": {
                           "application/json": {
                               "schema": {
@@ -206,4 +182,4 @@
             }
         }
     }
-  }
+}


### PR DESCRIPTION
Introduces a new endpoint for retrieving sales report forecasts. The following changes have been made:

- SalesReportForecast: An object with date keys (in YYYY-MM-DD format) and numeric values representing the forecasted amounts for those dates.

 - Added a new path /sales_report_forecast with a GET method to retrieve the sales report forecast.
The response schema for this endpoint references the newly added SalesReportForecast schema.

- Added SalesReportForecast schema under components.schemas.
