### PR TITLE
Add scheduling_enabled attribute to BusinessAvailability entity

### DIFF
--- a/entities/scheduling/businessAvailability.json
+++ b/entities/scheduling/businessAvailability.json
@@ -1,30 +1,56 @@
 {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "BusinessAvailability",
+    "description": "Represents the availability information for a business, including booking time slots and scheduling configuration.",
     "type": "object",
-    "required": [
-      "booking_slots",
-      "business_uid"
-    ],
     "properties": {
-      "booking_slots": {
-        "type": "array",
-        "description": "Array of available booking time slots in ISO format",
-        "items": {
-          "type": "string",
-          "format": "date-time"
+        "uid": {
+            "type": "string",
+            "description": "Unique identifier for the business availability record"
+        },
+        "business_uid": {
+            "type": "string",
+            "description": "Unique identifier for the business account"
+        },
+        "booking_slots": {
+            "type": "array",
+            "description": "Array of available booking time slots in ISO format",
+            "items": {
+                "type": "string",
+                "format": "date-time"
+            }
+        },
+        "scheduling_enabled": {
+            "type": "boolean",
+            "description": "Flag indicating whether scheduling is enabled for this business"
+        },
+        "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "The date and time when the business availability record was created"
+        },
+        "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "The date and time when the business availability record was last updated"
         }
-      },
-      "business_uid": {
-        "type": "string",
-        "description": "Unique identifier for a business account"
-      }
     },
-  "example": 
-    {
-      "booking_slots": [
-        "2023-03-15T09:00:00Z",
-        "2023-03-15T09:30:00Z",
-        "2023-03-15T10:00:00Z"
-      ],
-      "business_uid": "c4kektjxu9o2nqw6"
+    "required": [
+        "business_uid",
+        "booking_slots",
+        "scheduling_enabled"
+    ],
+    "readOnly": ["uid", "created_at", "updated_at"],
+    "example": {
+        "uid": "d290f1ee-6c54-4b01-90e6-d701748f0851",
+        "business_uid": "c4kektjxu9o2nqw6",
+        "booking_slots": [
+            "2023-03-15T09:00:00Z",
+            "2023-03-15T09:30:00Z",
+            "2023-03-15T10:00:00Z"
+        ],
+        "scheduling_enabled": true,
+        "created_at": "2023-03-15T08:00:00Z",
+        "updated_at": "2023-03-15T08:30:00Z"
     }
 } 


### PR DESCRIPTION
https://myvcita.atlassian.net/browse/VCITA2-6674

## Summary
- Added `scheduling_enabled` boolean attribute to indicate if scheduling is enabled for a business

## Impact
- Existing availability API endpoints will now include the `scheduling_enabled` field in responses
- No breaking changes - only additive modifications to the entity structure