### PR TITLE
VCITA2-7074 - added metadata to import hob entity

### DIFF
--- a/entities/integrations/importJob.json
+++ b/entities/integrations/importJob.json
@@ -111,7 +111,7 @@
     "metadata": {
       "type": "object",
       "properties": {
-        "dataRowIndex": {
+        "data_row_index": {
           "type": "number",
           "description": "Index of the data row being processed"
         },
@@ -119,7 +119,7 @@
           "type": "string",
           "description": "Locale setting for the import job"
         },
-        "globalEntityData": {
+        "global_entity_data": {
           "type": "object",
           "description": "Global entity data for the import job"
         }
@@ -155,7 +155,7 @@
       "pending": 55
     },
     "metadata": {
-      "header_row_line": 5,
+      "data_row_index": 5,
       "locale": "en"
     },
     "created_at": "2023-01-15T08:00:00.000Z",

--- a/entities/integrations/importJob.json
+++ b/entities/integrations/importJob.json
@@ -107,6 +107,24 @@
       "type": "string",
       "format": "date-time",
       "description": "Last update timestamp"
+    },
+    "metadata": {
+      "type": "object",
+      "properties": {
+        "dataRowIndex": {
+          "type": "number",
+          "description": "Index of the data row being processed"
+        },
+        "locale": {
+          "type": "string",
+          "description": "Locale setting for the import job"
+        },
+        "globalEntityData": {
+          "type": "object",
+          "description": "Global entity data for the import job"
+        }
+      },
+      "description": "Additional metadata for the import job"
     }
   },
   "required": [
@@ -135,6 +153,10 @@
       "done": 42,
       "error": 3,
       "pending": 55
+    },
+    "metadata": {
+      "header_row_line": 5,
+      "locale": "en"
     },
     "created_at": "2023-01-15T08:00:00.000Z",
     "updated_at": "2023-01-15T08:30:00.000Z"

--- a/swagger/integrations/import.json
+++ b/swagger/integrations/import.json
@@ -101,6 +101,11 @@
             ],
             "default": "execute",
             "description": "The type of job operation. 'validate' will go over the lines and return errors, use /v3/integrations/import_job_items to get detailed errors about each line.\n'execute' will run the import job. use /v3/integrations/import_job to get the progress of the import task."
+          },
+          "locale": {
+            "type": "string",
+            "enum": ["en", "he", "es", "fr", "de", "it", "nl", "pt", "zh"],
+            "description": "The locale of the import job"
           }
         },
         "required": [
@@ -259,6 +264,15 @@
             "required": true,
             "in": "query",
             "description": "Import job UID",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "status",
+            "required": false,
+            "in": "query",
+            "description": "Status of the import job item",
             "schema": {
               "type": "string"
             }

--- a/swagger/integrations/import.json
+++ b/swagger/integrations/import.json
@@ -105,7 +105,7 @@
           "locale": {
             "type": "string",
             "enum": ["en", "he", "es", "fr", "de", "it", "nl", "pt", "zh"],
-            "description": "The locale of the import job"
+            "description": "The locale of the import job, in use for translating error messages of the import job items"
           }
         },
         "required": [


### PR DESCRIPTION
This pull request introduces enhancements to the import job schema and API to support additional metadata and query parameters. The most significant changes include adding metadata fields to the `importJob` schema, extending the API to handle `locale` and `status` parameters, and improving flexibility for import job operations.

### Schema Enhancements:
* Added a `metadata` object to the `importJob` schema in `entities/integrations/importJob.json`. This includes properties such as `dataRowIndex`, `locale`, and `globalEntityData` to provide additional context for the import job.
* Updated the example data in `importJob.json` to include a `metadata` field with sample values for `header_row_line` and `locale`.

### API Enhancements:
* Added a `locale` parameter to the `swagger/integrations/import.json` API schema, allowing users to specify the locale for the import job. Supported values include languages such as "en", "es", "fr", etc.
* Introduced an optional `status` query parameter to the API, enabling users to filter import job items by their status.