### PR TITLE
fix: remove schema definitions from payment gateway entity

### DIFF
--- a/entities/payment_processing/payment_gateway.json
+++ b/entities/payment_processing/payment_gateway.json
@@ -15,8 +15,10 @@
     },
     "default_locale": {
       "type": "string",
-      "description": "Specifies the fallback locale for the gateway's textual content. If a translation or string is missing, this locale will be used by default.",
-      "$ref": "#/definitions/locale"
+      "enum": [
+        "en", "fr", "de", "it", "pl", "pt", "es", "nl", "he", "en_gb"
+      ],
+      "description": "Specifies the fallback locale for the gateway's textual content. If a translation or string is missing, this locale will be used by default."
     },
     "gateway_type": {
       "type": "string",
@@ -39,12 +41,54 @@
       "description": "The date and time the payment gateway was last updated."
     },
     "main_gateway_benefits": {
+      "type": "array",
       "description": "A clear 3-4 bullet list highlighting the unique features and value of the gateway, aimed at encouraging merchants to connect with it. This information is stored per locale.",
-      "$ref": "#/definitions/localizedBenefitsList"
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "object",
+        "properties": {
+          "locale": {
+            "type": "string",
+            "enum": [
+              "en", "fr", "de", "it", "pl", "pt", "es", "nl", "he", "en_gb"
+            ]
+          },
+          "benefits": {
+            "type": "array",
+            "description": "A list of benefits in the specified locale.",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": ["locale", "benefits"]
+      }
     },
     "brief_benefit_highlights": {
+      "type": "array",
       "description": "A brief, 2-4 word version of the gateway benefits, tailored for compact displays or mobile interfaces. This information is stored per locale.",
-      "$ref": "#/definitions/localizedHighlightsList"
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "object",
+        "properties": {
+          "locale": {
+            "type": "string",
+            "enum": [
+              "en", "fr", "de", "it", "pl", "pt", "es", "nl", "he", "en_gb"
+            ]
+          },
+          "highlights": {
+            "type": "array",
+            "description": "A list of short benefit highlights in the specified locale.",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": ["locale", "highlights"]
+      }
     },
     "supported_countries": {
       "type": "array",
@@ -152,58 +196,6 @@
     "payment_methods",
     "processing_features"
   ],
-  "definitions": {
-    "locale": {
-      "type": "string",
-      "enum": [
-        "en", "fr", "de", "it", "pl", "pt", "es", "nl", "he", "en_gb"
-      ]
-    },
-    "localizedBenefitsList": {
-      "type": "array",
-      "description": "List of localized benefits. Each item is a locale-benefits pair: locale is a locale (from enum), benefits is an array of strings. Each locale can appear only once.",
-      "minItems": 1,
-      "uniqueItems": true,
-      "items": {
-        "type": "object",
-        "properties": {
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "benefits": {
-            "type": "array",
-            "description": "A list of benefits in the specified locale.",
-            "items": {
-              "type": "string"
-            }
-          }
-        },
-        "required": ["locale", "benefits"]
-      }
-    },
-    "localizedHighlightsList": {
-      "type": "array",
-      "description": "List of localized highlights. Each item is a locale-highlights pair: locale is a locale (from enum), highlights is an array of strings. Each locale can appear only once.",
-      "minItems": 1,
-      "uniqueItems": true,
-      "items": {
-        "type": "object",
-        "properties": {
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "highlights": {
-            "type": "array",
-            "description": "A list of short benefit highlights in the specified locale.",
-            "items": {
-              "type": "string"
-            }
-          }
-        },
-        "required": ["locale", "highlights"]
-      }
-    }
-  },
   "example": {
     "uid": "pgw_abc123def456",
     "app_code_name": "stripe_payments_v2",


### PR DESCRIPTION
- Removed problematic 'definitions' section from payment gateway entity
- Inlined all  references directly into properties
- Fixed import errors by converting schema-like structure to proper entity format
- Maintained all validation and functionality without schema components