### PR TITLE
VCITA2-8049 - import job update

### DIFF
--- a/entities/integrations/importJob.json
+++ b/entities/integrations/importJob.json
@@ -119,9 +119,9 @@
           "type": "string",
           "description": "Locale setting for the import job"
         },
-        "global_entity_data": {
+        "shared_entity_data": {
           "type": "object",
-          "description": "Global entity data for the import job"
+          "description": "Shared entity data for the import job, this data is shared between all the import job items"
         }
       },
       "description": "Additional metadata for the import job"
@@ -156,7 +156,12 @@
     },
     "metadata": {
       "data_row_index": 5,
-      "locale": "en"
+      "locale": "en",
+      "shared_entity_data": {
+        "tax_ids": [
+          "12345678yyu90", "heuh39759nmf"
+        ]
+      }
     },
     "created_at": "2023-01-15T08:00:00.000Z",
     "updated_at": "2023-01-15T08:30:00.000Z"

--- a/swagger/integrations/import.json
+++ b/swagger/integrations/import.json
@@ -106,35 +106,17 @@
             "type": "string",
             "enum": ["en", "he", "es", "fr", "de", "it", "nl", "pt", "zh"],
             "description": "The locale of the import job, in use for translating error messages of the import job items"
+          },
+          "shared_entity_data": {
+            "type": "object",
+            "description": "Shared entity data for the import job, this data is shared between all import job items"
           }
         },
         "required": [
           "provider_type"
         ]
       },
-      "UpdateImportJobRequestDto": {
-        "type": "object",
-        "properties": {
-          "uid": {
-            "type": "string",
-            "description": "The UID of the import job to update"
-          },
-          "metadata": {
-            "type": "object",
-            "properties": {
-              "shared_entity_data": {
-                "type": "object",
-                "description": "Shared entity data for the import job, this data is shared between all the import job items"
-              }
-            },
-            "description": "Additional metadata for the import job"
-          }
-        },
-        "required": [
-          "uid",
-          "metadata"
-        ]
-      },
+
       "MultiImportJobItemsResponseDto": {
         "type": "object",
         "properties": {
@@ -233,63 +215,6 @@
                       "properties": {
                         "data": {
                           "$ref": "https://vcita.github.io/developers-hub/entities/integrations/importJob.json"
-                        }
-                      }
-                    }
-                  ]
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "Bearer": []
-          }
-        ]
-      },
-      "put": {
-        "tags": [
-          "Import"
-        ],
-        "summary": "Update an ImportJob",
-        "description": "Update an import job by its UID\n\nAvailable for **Staff Tokens**. Restriction: only metadata.shared_entity_data can be updated",
-        "operationId": "ImportJobsController_update",
-        "parameters": [
-          {
-            "name": "uid",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UpdateImportJobRequestDto"
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Import job created successfully",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/Response"
-                    },
-                    {
-                      "properties": {
-                        "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/integrations/importJob.json",
-                          "description": "Import job details"
                         }
                       }
                     }

--- a/swagger/integrations/import.json
+++ b/swagger/integrations/import.json
@@ -112,6 +112,9 @@
           "provider_type"
         ]
       },
+      "UpdateImportJobRequestDto": {
+        "$ref": "https://vcita.github.io/developers-hub/entities/integrations/importJob.json"
+      },
       "MultiImportJobItemsResponseDto": {
         "type": "object",
         "properties": {
@@ -224,7 +227,64 @@
             "Bearer": []
           }
         ]
-      }
+      },
+      "put": {
+        "tags": [
+          "Import"
+        ],
+        "summary": "Update an ImportJob",
+        "description": "Update an import job by its UID\n\nAvailable for **Staff Tokens**. Restriction: only metadata.shared_entity_data can be updated",
+        "operationId": "ImportJobsController_update",
+        "parameters": [
+          {
+            "name": "uid",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateImportJobRequestDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Import job created successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Response"
+                    },
+                    {
+                      "properties": {
+                        "data": {
+                          "$ref": "https://vcita.github.io/developers-hub/entities/integrations/importJob.json",
+                          "description": "Import job details"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "Bearer": []
+          }
+        ]
+      } 
     },
     "/v3/integrations/import_job_items": {
       "get": {

--- a/swagger/integrations/import.json
+++ b/swagger/integrations/import.json
@@ -113,7 +113,27 @@
         ]
       },
       "UpdateImportJobRequestDto": {
-        "$ref": "https://vcita.github.io/developers-hub/entities/integrations/importJob.json"
+        "type": "object",
+        "properties": {
+          "uid": {
+            "type": "string",
+            "description": "The UID of the import job to update"
+          },
+          "metadata": {
+            "type": "object",
+            "properties": {
+              "shared_entity_data": {
+                "type": "object",
+                "description": "Shared entity data for the import job, this data is shared between all the import job items"
+              }
+            },
+            "description": "Additional metadata for the import job"
+          }
+        },
+        "required": [
+          "uid",
+          "metadata"
+        ]
       },
       "MultiImportJobItemsResponseDto": {
         "type": "object",

--- a/swagger/integrations/import.json
+++ b/swagger/integrations/import.json
@@ -116,7 +116,6 @@
           "provider_type"
         ]
       },
-
       "MultiImportJobItemsResponseDto": {
         "type": "object",
         "properties": {
@@ -229,7 +228,7 @@
             "Bearer": []
           }
         ]
-      } 
+      }
     },
     "/v3/integrations/import_job_items": {
       "get": {


### PR DESCRIPTION
This pull request introduces updates to the `importJob` entity and its associated API definitions to support shared entity data and enable updates to import job metadata. The most significant changes include renaming a property in the `importJob` schema, adding support for `shared_entity_data` in metadata, and introducing a new API endpoint for updating import jobs.

### Updates to the `importJob` schema:

* Renamed the property `global_entity_data` to `shared_entity_data` in `entities/integrations/importJob.json` to better reflect its purpose. Updated the description to clarify that the data is shared across all import job items.

* Added a new `shared_entity_data` field to the `metadata` object in `entities/integrations/importJob.json`, allowing for the inclusion of shared data such as `tax_ids`.

### API updates:

* Added a new schema reference, `UpdateImportJobRequestDto`, in `swagger/integrations/import.json`, linking it to the updated `importJob` entity.

* Introduced a new `PUT` endpoint in `swagger/integrations/import.json` to update import job metadata. This endpoint allows updates specifically to the `shared_entity_data` field and includes detailed request and response specifications.