### PR TITLE
PGW: Add Payment Gateway Assignment API

### DIFF
--- a/entities/payment_processing/paymentGatewayAssignment.json
+++ b/entities/payment_processing/paymentGatewayAssignment.json
@@ -1,0 +1,39 @@
+{
+  "type": "object",
+  "properties": {
+    "uid": {
+      "type": "string",
+      "description": "A unique identifier for the payment gateway assignment record."
+    },
+    "gateway_uid": {
+      "type": "string",
+      "description": "The unique identifier of the payment gateway being assigned."
+    },
+    "directory_uid": {
+      "type": "string",
+      "description": "The unique identifier of the directory to which the payment gateway is assigned."
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "The date and time when the payment gateway assignment was created."
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "The date and time when the payment gateway assignment was last updated."
+    }
+  },
+  "required": [
+    "gateway_uid",
+    "directory_uid"
+  ],
+  "example": {
+    "uid": "pga_abc123def456",
+    "gateway_uid": "pgw_stripe_v2_789",
+    "directory_uid": "dir_main_directory_123",
+    "created_at": "2025-01-27T10:08:54.156Z",
+    "updated_at": "2025-01-27T10:08:54.156Z"
+  },
+  "description": "A payment gateway assignment entity that defines the relationship between a payment gateway and a directory."
+} 

--- a/swagger/payment_processing/payment_gateway_assignments.json
+++ b/swagger/payment_processing/payment_gateway_assignments.json
@@ -1,0 +1,111 @@
+{
+    "openapi": "3.0.0",
+    "info": {
+        "title": "Payment Gateway Assignments",
+        "description": "Manage Payment Gateway Assignments with this API endpoint, allowing you to define the relationship between a payment gateway to one or more directories for payment processing. Designed for partners handling multiple directories, it provides straightforward gateway assignment",
+        "version": "3.0"
+    },
+    "servers": [
+        {
+            "url": "https://api.vcita.biz",
+            "description": "API Gateway server"
+        }
+    ],
+    "components": {
+        "securitySchemes": {
+            "Bearer": {
+                "type": "http",
+                "scheme": "bearer",
+                "description": "Provide a valid bearer token in the Authorization header. Example: 'Authorization: Bearer {directory_token}'"
+            }
+        },
+        "schemas": {
+            "CreatePaymentGatewayAssignmentRequestDto": {
+                "type": "object",
+                "properties": {
+                    "gateway_uid": {
+                        "type": "string",
+                        "description": "The unique identifier of the payment gateway to assign"
+                    },
+                    "directory_uid": {
+                        "type": "string",
+                        "description": "The unique identifier of the directory to assign the payment gateway to"
+                    }
+                },
+                "required": [
+                    "gateway_uid",
+                    "directory_uid"
+                ]
+            }
+        }
+    },
+    "paths": {
+        "/v3/payment_processing/payment_gateway_assignments": {
+            "post": {
+                "summary": "Create a PaymentGatewayAssignment",
+                "description": "Assign a payment gateway to a directory - **Only available for Directory Tokens**",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CreatePaymentGatewayAssignmentRequestDto"
+                            },
+                            "example": {
+                                "gateway_uid": "pgw_stripe_v2_789",
+                                "directory_uid": "dir_main_directory_123"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "Payment gateway assignment created successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "allOf": [
+                                        {
+                                            "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                                        },
+                                        {
+                                            "properties": {
+                                                "data": {
+                                                    "type": "object",
+                                                    "$ref": "https://vcita.github.io/developers-hub/entities/payment_processing/paymentGatewayAssignment.json"
+                                                }
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request. Invalid input data or assignment already exists."
+                    },
+                    "401": {
+                        "description": "Unauthorized. The bearer token is missing or invalid."
+                    },
+                    "403": {
+                        "description": "Forbidden. You do not have access to this resource."
+                    },
+                    "404": {
+                        "description": "Not found. Payment gateway or directory not found."
+                    },
+                    "500": {
+                        "description": "Internal server error."
+                    }
+                },
+                "tags": [
+                    "Payment Gateway Assignments"
+                ],
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ]
+            }
+        }
+    }
+} 

--- a/swagger/sales/payment_gateway.json
+++ b/swagger/sales/payment_gateway.json
@@ -16,7 +16,7 @@
             "Bearer": {
                 "type": "http",
                 "scheme": "bearer",
-                "description": "Provide a valid bearer token in the Authorization header. Example: 'Authorization: Bearer {token}'"
+                "description": "Provide a valid bearer token in the Authorization header. Example: 'Authorization: Bearer {directory_token}'"
             }
         },
         "schemas": {
@@ -111,7 +111,7 @@
             },
             "post": {
                 "summary": "Create a PaymentGateway",
-                "description": "Create a new payment gateway - Available for **Application Tokens**",
+                "description": "Create a new payment gateway - **Only available for Directory Tokens**",
                 "requestBody": {
                     "required": true,
                     "content": {


### PR DESCRIPTION
## Summary
Implements the Payment Gateway Assignment API for VCITA2-8397.

## What's Added
- **Entity**: paymentGatewayAssignment.json - Defines the relationship between a payment gateway and directory
- **API**: POST /v3/payment_processing/payment_gateway_assignments - Enables assignment of payment gateways to directories

## Use Case
Allows partners to assign payment gateways to their directories with a simple API call:
```json
{
  "gateway_uid": "pgw_stripe_v2_789",
  "directory_uid": "dir_main_directory_123"
}
```

## Ticket
Closes: VCITA2-8397