### PR TITLE
Vcita2 8049 import job create changes

### DIFF
--- a/entities/integrations/importJob.json
+++ b/entities/integrations/importJob.json
@@ -119,9 +119,9 @@
           "type": "string",
           "description": "Locale setting for the import job"
         },
-        "global_entity_data": {
+        "shared_entity_data": {
           "type": "object",
-          "description": "Global entity data for the import job"
+          "description": "Shared entity data for the import job, this data is shared between all the import job items"
         }
       },
       "description": "Additional metadata for the import job"
@@ -156,7 +156,12 @@
     },
     "metadata": {
       "data_row_index": 5,
-      "locale": "en"
+      "locale": "en",
+      "shared_entity_data": {
+        "tax_ids": [
+          "12345678yyu90", "heuh39759nmf"
+        ]
+      }
     },
     "created_at": "2023-01-15T08:00:00.000Z",
     "updated_at": "2023-01-15T08:30:00.000Z"

--- a/swagger/integrations/import.json
+++ b/swagger/integrations/import.json
@@ -106,35 +106,17 @@
             "type": "string",
             "enum": ["en", "he", "es", "fr", "de", "it", "nl", "pt", "zh"],
             "description": "The locale of the import job, in use for translating error messages of the import job items"
+          },
+          "shared_entity_data": {
+            "type": "object",
+            "description": "Shared entity data for the import job, this data is shared between all import job items"
           }
         },
         "required": [
           "provider_type"
         ]
       },
-      "UpdateImportJobRequestDto": {
-        "type": "object",
-        "properties": {
-          "uid": {
-            "type": "string",
-            "description": "The UID of the import job to update"
-          },
-          "metadata": {
-            "type": "object",
-            "properties": {
-              "shared_entity_data": {
-                "type": "object",
-                "description": "Shared entity data for the import job, this data is shared between all the import job items"
-              }
-            },
-            "description": "Additional metadata for the import job"
-          }
-        },
-        "required": [
-          "uid",
-          "metadata"
-        ]
-      },
+
       "MultiImportJobItemsResponseDto": {
         "type": "object",
         "properties": {
@@ -233,63 +215,6 @@
                       "properties": {
                         "data": {
                           "$ref": "https://vcita.github.io/developers-hub/entities/integrations/importJob.json"
-                        }
-                      }
-                    }
-                  ]
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "Bearer": []
-          }
-        ]
-      },
-      "put": {
-        "tags": [
-          "Import"
-        ],
-        "summary": "Update an ImportJob",
-        "description": "Update an import job by its UID\n\nAvailable for **Staff Tokens**. Restriction: only metadata.shared_entity_data can be updated",
-        "operationId": "ImportJobsController_update",
-        "parameters": [
-          {
-            "name": "uid",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UpdateImportJobRequestDto"
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Import job created successfully",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/Response"
-                    },
-                    {
-                      "properties": {
-                        "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/integrations/importJob.json",
-                          "description": "Import job details"
                         }
                       }
                     }

--- a/swagger/integrations/import.json
+++ b/swagger/integrations/import.json
@@ -112,6 +112,9 @@
           "provider_type"
         ]
       },
+      "UpdateImportJobRequestDto": {
+        "$ref": "https://vcita.github.io/developers-hub/entities/integrations/importJob.json"
+      },
       "MultiImportJobItemsResponseDto": {
         "type": "object",
         "properties": {
@@ -224,7 +227,64 @@
             "Bearer": []
           }
         ]
-      }
+      },
+      "put": {
+        "tags": [
+          "Import"
+        ],
+        "summary": "Update an ImportJob",
+        "description": "Update an import job by its UID\n\nAvailable for **Staff Tokens**. Restriction: only metadata.shared_entity_data can be updated",
+        "operationId": "ImportJobsController_update",
+        "parameters": [
+          {
+            "name": "uid",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateImportJobRequestDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Import job created successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Response"
+                    },
+                    {
+                      "properties": {
+                        "data": {
+                          "$ref": "https://vcita.github.io/developers-hub/entities/integrations/importJob.json",
+                          "description": "Import job details"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "Bearer": []
+          }
+        ]
+      } 
     },
     "/v3/integrations/import_job_items": {
       "get": {

--- a/swagger/integrations/import.json
+++ b/swagger/integrations/import.json
@@ -113,7 +113,27 @@
         ]
       },
       "UpdateImportJobRequestDto": {
-        "$ref": "https://vcita.github.io/developers-hub/entities/integrations/importJob.json"
+        "type": "object",
+        "properties": {
+          "uid": {
+            "type": "string",
+            "description": "The UID of the import job to update"
+          },
+          "metadata": {
+            "type": "object",
+            "properties": {
+              "shared_entity_data": {
+                "type": "object",
+                "description": "Shared entity data for the import job, this data is shared between all the import job items"
+              }
+            },
+            "description": "Additional metadata for the import job"
+          }
+        },
+        "required": [
+          "uid",
+          "metadata"
+        ]
       },
       "MultiImportJobItemsResponseDto": {
         "type": "object",

--- a/swagger/integrations/import.json
+++ b/swagger/integrations/import.json
@@ -116,7 +116,6 @@
           "provider_type"
         ]
       },
-
       "MultiImportJobItemsResponseDto": {
         "type": "object",
         "properties": {
@@ -229,7 +228,7 @@
             "Bearer": []
           }
         ]
-      } 
+      }
     },
     "/v3/integrations/import_job_items": {
       "get": {


### PR DESCRIPTION
This pull request updates the schema for import job entities to introduce `shared_entity_data`, which consolidates shared data across import job items. It also modifies the locale metadata and updates the Swagger documentation to reflect these changes.

### Schema Updates for Import Job Entities:

* **Renaming and Enhancing Field**: Renamed `global_entity_data` to `shared_entity_data` in `entities/integrations/importJob.json`, with an updated description emphasizing its role in sharing data across all import job items.
* **New Metadata Field**: Added `shared_entity_data` to the `metadata` section in `entities/integrations/importJob.json`, including an example with `tax_ids`.

### Documentation Updates:

* **Swagger Schema Update**: Added the `shared_entity_data` field to the Swagger documentation (`swagger/integrations/import.json`), ensuring consistency with the updated entity schema.