### PR TITLE
VCITA2-7029 Add exclude_booking_uid parameter to availability_slots API

### DIFF
--- a/swagger/scheduling/availability_slots.json
+++ b/swagger/scheduling/availability_slots.json
@@ -138,6 +138,15 @@
               "type": "integer",
               "minimum": 0
             }
+          },
+          {
+            "name": "exclude_booking_uid",
+            "in": "query",
+            "required": false,
+            "description": "Unique identifier of a booking to exclude from busy slots calculation when determining availability. When provided, the specified booking is temporarily removed from the busy slots list before calculating available time slots. This is essential for rescheduling scenarios where you need to check if the original time slot would be available without the current booking, or for conflict detection when validating potential overlaps. Example: If booking 'abc123' is scheduled from 2:00-3:00 PM and you want to reschedule it, passing exclude_booking_uid=abc123 will show 2:00-3:00 PM as available (assuming no other bookings conflict). If other bookings exist during that time, the slot remains busy.",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {


### PR DESCRIPTION
https://myvcita.atlassian.net/browse/VCITA2-7029

This pull request adds a new query parameter to the `availability_slots` endpoint in the `swagger/scheduling/availability_slots.json` file. The new parameter allows excluding a specific booking from the availability calculation.

* **API enhancement**:
  * [`swagger/scheduling/availability_slots.json`](diffhunk://#diff-295f3bc7892fdf8d4cec74f41f61f670fe064e0e07591325592cddc9010927dfR141-R149): Added a new optional query parameter `exclude_booking_uid`. This parameter, if provided, ensures that availability slots are calculated without considering the booking identified by the given UID.