### PR TITLE
Fix CREATE PaymentGateway token type

### DIFF
--- a/swagger/sales/payment_gateway.json
+++ b/swagger/sales/payment_gateway.json
@@ -128,7 +128,7 @@
             },
             "post": {
                 "summary": "Create a PaymentGateway",
-                "description": "Create a new payment gateway - **Only available for Directory Tokens**",
+                "description": "Create a new payment gateway - **Only available for Application Tokens**",
                 "requestBody": {
                     "required": true,
                     "content": {


### PR DESCRIPTION
## Fix
Changes CREATE PaymentGateway API from Directory Tokens to Application Tokens.

## Change
- Line 131: Directory Tokens → Application Tokens

Assignment API remains Directory Tokens as intended.