### PR TITLE
Remove app_code_name from UPDATE PaymentGateway

### DIFF
--- a/swagger/sales/payment_gateway.json
+++ b/swagger/sales/payment_gateway.json
@@ -421,10 +421,6 @@
                             "schema": {
                                 "type": "object",
                                 "properties": {
-                                    "app_code_name": {
-                                        "type": "string",
-                                        "description": "The unique code name of the pre-created gateway's app, created via the API- Creates an app, https://api.vcita.biz/platform/v1/apps"
-                                    },
                                     "gateway_logo_url": {
                                         "type": "string",
                                         "description": "The URL to the logo of the gateway"

--- a/swagger/sales/payment_gateway.json
+++ b/swagger/sales/payment_gateway.json
@@ -128,7 +128,7 @@
             },
             "post": {
                 "summary": "Create a PaymentGateway",
-                "description": "Create a new payment gateway - **Only available for Application Tokens**",
+                "description": "Create a new payment gateway - **Only available for Directory Tokens**",
                 "requestBody": {
                     "required": true,
                     "content": {


### PR DESCRIPTION
## Fix
Removes app_code_name parameter from UPDATE PaymentGateway request body.

The app_code_name should not be updatable after gateway creation - it should only be set during CREATE.