### PR TITLE
HOTFIX: Fix CREATE PaymentGateway token type

### DIFF
--- a/swagger/sales/payment_gateway.json
+++ b/swagger/sales/payment_gateway.json
@@ -128,7 +128,7 @@
             },
             "post": {
                 "summary": "Create a PaymentGateway",
-                "description": "Create a new payment gateway - **Only available for Directory Tokens**",
+                "description": "Create a new payment gateway - **Only available for Application Tokens**",
                 "requestBody": {
                     "required": true,
                     "content": {


### PR DESCRIPTION
## 🚨 Production Hotfix
Fixes CREATE PaymentGateway API token type from Directory Tokens → Application Tokens.

## Issue
Previous merge accidentally set CREATE PaymentGateway to require Directory Tokens, breaking the API.

## Fix  
Restores correct token type: **Application Tokens**