### PR TITLE
VCITA2-8397: Fix CREATE PaymentGateway token type

### DIFF
--- a/swagger/sales/payment_gateway.json
+++ b/swagger/sales/payment_gateway.json
@@ -128,7 +128,7 @@
             },
             "post": {
                 "summary": "Create a PaymentGateway",
-                "description": "Create a new payment gateway - **Only available for Directory Tokens**",
+                "description": "Create a new payment gateway - **Only available for Application Tokens**",
                 "requestBody": {
                     "required": true,
                     "content": {


### PR DESCRIPTION
Fixes CREATE PaymentGateway token type from Directory Tokens to Application Tokens.