### PR TITLE
Update payment gateway endpoint: replace 'app_code_name' param with 'gateway_name'

### DIFF
--- a/swagger/sales/payment_gateway.json
+++ b/swagger/sales/payment_gateway.json
@@ -85,9 +85,9 @@
                         "example": "USD"
                     },
                     {
-                        "name": "app_code_name",
+                        "name": "gateway_name",
                         "in": "query",
-                        "description": "Filter by app code name",
+                        "description": "Filter by gateway name",
                         "schema": {
                             "type": "string"
                         },


### PR DESCRIPTION
## Summary
This PR updates the GET /v3/payment_processing/payment_gateways endpoint by removing the existing `app_code_name` query parameter and adding a new `gateway_name` query parameter.

## Changes Made
- **Removed** `app_code_name` query parameter
- **Added** new `gateway_name` query parameter with description "Filter by gateway name"
- Maintained the same parameter structure and example value ("stripe")

## Files Modified
- `swagger/sales/payment_gateway.json`

## Impact
- API consumers using the `app_code_name` parameter will need to update their code to use `gateway_name` instead
- The functionality is equivalent but uses a more descriptive parameter name
- This is a breaking change for existing API consumers

## Testing
- Swagger definition validates correctly
- New parameter maintains same type and example value
- Parameter serves the same filtering purpose with clearer naming