### PR TITLE
docs: enumerate folder allowlist for platform v1 GET /conversations

### DIFF
--- a/swagger/communication/legacy/legacy_v1_communication.json
+++ b/swagger/communication/legacy/legacy_v1_communication.json
@@ -29,11 +29,12 @@
             "type": "integer"
           },
           {
-            "description": "Folder - Inbox / Follow-up / Sent / Archived",
+            "description": "Filter conversations by folder. Only honored for staff (user) tokens; admin/app/directory tokens silently ignore this parameter. Unknown values silently fall through to unfiltered results. (e.g., \"inbox\", \"follow_up\", \"sent\", \"archived\", \"attention\", \"trash\", \"all\")",
             "in": "query",
             "name": "folder",
             "required": false,
-            "type": "string"
+            "type": "string",
+            "enum": ["inbox", "follow_up", "sent", "archived", "attention", "trash", "all"]
           }
         ],
         "produces": [


### PR DESCRIPTION
## Summary

Brings `swagger/communication/legacy/legacy_v1_communication.json` in line with the implementation in [vcita/core#28566](https://github.com/vcita/core/pull/28566) (VCITA2-12315), which actually wires `folder` through to the backend on `GET /platform/v1/conversations`.

Changes to the `folder` query parameter:

- Add an explicit `enum` listing every accepted value: `inbox`, `follow_up`, `sent`, `archived`, `attention`, `trash`, `all`.
  - `inbox / follow_up / sent / archived` were the originally documented values.
  - `attention` and `trash` were added during fenv smoke testing — we expanded the v1 allowlist after a real caller hit `?folder=attention`.
  - `all` is the no-op default.
- Replace the previous one-line description with one that explains:
  - Only honored for staff (user) tokens; admin/app/directory tokens silently ignore the parameter.
  - Unknown values silently fall through to unfiltered results.

This intentionally does NOT document `sources_*` because the v1 path doesn't go through the SearchAPI elasticsearch dispatch that powers it.

Tracks [VCITA2-12315](https://myvcita.atlassian.net/browse/VCITA2-12315). Pairs with [vcita/core#28566](https://github.com/vcita/core/pull/28566).

## Test plan

- [x] JSON is valid (file parses)
- [x] Description ends with `(e.g., "value1", ...)` per developers-hub conventions
- [x] Enum values match `Components::ConversationsAPI::PLATFORM_V1_FOLDER_FILTERS` in core
- [ ] Spot-check rendered docs after merge if developers-hub auto-publishes to ReadMe.io

Made with [Cursor](https://cursor.com)

[VCITA2-12315]: https://myvcita.atlassian.net/browse/VCITA2-12315?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ