### PR TITLE
docs: add folder query parameter to platform v1 GET /conversations

### DIFF
--- a/swagger/communication/legacy/legacy_v1_communication.json
+++ b/swagger/communication/legacy/legacy_v1_communication.json
@@ -34,6 +34,14 @@
             "name": "X-On-Behalf-Of",
             "required": false,
             "type": "string"
+          },
+          {
+            "description": "Filter conversations by folder. Only honored for staff (user) tokens; admin/app/directory tokens silently ignore this parameter. Unknown values silently fall through to unfiltered results. (e.g., \"inbox\", \"follow_up\", \"sent\", \"archived\", \"attention\", \"trash\", \"all\")",
+            "in": "query",
+            "name": "folder",
+            "required": false,
+            "type": "string",
+            "enum": ["inbox", "follow_up", "sent", "archived", "attention", "trash", "all"]
           }
         ],
         "produces": [


### PR DESCRIPTION
## Summary

Adds the `folder` query parameter to `swagger/communication/legacy/legacy_v1_communication.json` for `GET /platform/v1/conversations`, in line with the implementation in [vcita/core#28566](https://github.com/vcita/core/pull/28566) (VCITA2-12315), which actually wires `folder` through to the backend.

> Replaces [#255](https://github.com/vcita/developers-hub/pull/255), which was opened before master picked up unrelated rewrites of this file (`X-On-Behalf-Of` header, new description, etc.) and ended up unmergeable. This PR is the same change rebased cleanly onto current master.

Adds a single new parameter entry next to the existing `page` / `per_page` / `X-On-Behalf-Of`:

- `enum`: `inbox`, `follow_up`, `sent`, `archived`, `attention`, `trash`, `all`
  - `inbox / follow_up / sent / archived` — originally documented v1 contract
  - `attention` and `trash` — added during fenv smoke testing after a real caller hit `?folder=attention`
  - `all` — explicit no-op
- `description` documents the silent fall-through behavior (non-staff tokens / unknown values both ignored)

This intentionally does NOT document `sources_*` because the v1 path doesn't go through the `SearchAPI` elasticsearch dispatch that powers it.

Tracks [VCITA2-12315](https://myvcita.atlassian.net/browse/VCITA2-12315). Pairs with [vcita/core#28566](https://github.com/vcita/core/pull/28566) (master) and [vcita/core#28575](https://github.com/vcita/core/pull/28575) (integration).

## Test plan

- [x] JSON parses (validated locally)
- [x] No conflict markers
- [x] Description ends with `(e.g., "value1", ...)` per developers-hub conventions
- [x] Enum values match `Components::ConversationsAPI::PLATFORM_V1_FOLDER_FILTERS` in core exactly
- [ ] Spot-check rendered docs after merge if developers-hub auto-publishes to ReadMe.io

Made with [Cursor](https://cursor.com)

[VCITA2-12315]: https://myvcita.atlassian.net/browse/VCITA2-12315?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ