### PR TITLE
VCITA2-13042: Document operator directory assignments endpoint

### DIFF
--- a/entities/operators/operator_directory_assignment.json
+++ b/entities/operators/operator_directory_assignment.json
@@ -1,0 +1,29 @@
+{
+  "type": "object",
+  "description": "Represents one directory context that an operator can switch to, including the role assigned for that directory.",
+  "properties": {
+    "directory_uid": {
+      "type": "string",
+      "description": "Unique identifier of the directory context assigned to the operator (e.g., \"dir_abc123\")."
+    },
+    "directory_name": {
+      "type": "string",
+      "description": "Display name of the directory context assigned to the operator (e.g., \"Example Directory\")."
+    },
+    "role": {
+      "type": "string",
+      "description": "Operator role assigned for this directory context (e.g., \"admin\", \"sales\")."
+    },
+    "current": {
+      "type": "boolean",
+      "description": "Indicates whether this assignment is the operator's current active directory context (e.g., true)."
+    }
+  },
+  "required": ["directory_uid", "directory_name", "role", "current"],
+  "example": {
+    "directory_uid": "dir_abc123",
+    "directory_name": "Example Directory",
+    "role": "admin",
+    "current": true
+  }
+}

--- a/entities/operators/operator_directory_assignment.json
+++ b/entities/operators/operator_directory_assignment.json
@@ -2,6 +2,10 @@
   "type": "object",
   "description": "Represents one directory context that an operator can switch to, including the role assigned for that directory.",
   "properties": {
+    "operator_uid": {
+      "type": "string",
+      "description": "Unique identifier of the operator that owns this directory assignment (e.g., \"op_abc123\")."
+    },
     "directory_uid": {
       "type": "string",
       "description": "Unique identifier of the directory context assigned to the operator (e.g., \"dir_abc123\")."
@@ -19,8 +23,9 @@
       "description": "Indicates whether this assignment is the operator's current active directory context (e.g., true)."
     }
   },
-  "required": ["directory_uid", "directory_name", "role", "current"],
+  "required": ["operator_uid", "directory_uid", "directory_name", "role", "current"],
   "example": {
+    "operator_uid": "op_abc123",
     "directory_uid": "dir_abc123",
     "directory_name": "Example Directory",
     "role": "admin",

--- a/entities/operators/operator_directory_assignment.json
+++ b/entities/operators/operator_directory_assignment.json
@@ -1,6 +1,6 @@
 {
   "type": "object",
-  "description": "Represents one directory context that an operator can switch to, including the role assigned for that directory.",
+  "description": "Represents one directory or logical directory scope context assigned to an operator, including the role assigned for that context.",
   "properties": {
     "operator_uid": {
       "type": "string",
@@ -8,11 +8,11 @@
     },
     "directory_uid": {
       "type": "string",
-      "description": "Unique identifier of the directory context assigned to the operator (e.g., \"dir_abc123\")."
+      "description": "Unique identifier of the directory context assigned to the operator, or a logical scope value for non-concrete assignments. Supported logical scope values are \"all\", \"duda\", and \"xperts\" (e.g., \"dir_abc123\", \"all\", \"duda\", \"xperts\")."
     },
     "directory_name": {
       "type": "string",
-      "description": "Display name of the directory context assigned to the operator (e.g., \"Example Directory\")."
+      "description": "Display name of the directory or logical scope context assigned to the operator (e.g., \"Example Directory\", \"All\", \"Duda\", \"Xperts\")."
     },
     "role": {
       "type": "string",
@@ -20,15 +20,15 @@
     },
     "current": {
       "type": "boolean",
-      "description": "Indicates whether this assignment is the operator's current active directory context (e.g., true)."
+      "description": "Indicates whether this assignment is the operator's current active concrete directory context. Logical scope assignments return false because they are not concrete directory rows (e.g., true)."
     }
   },
   "required": ["operator_uid", "directory_uid", "directory_name", "role", "current"],
   "example": {
     "operator_uid": "op_abc123",
-    "directory_uid": "dir_abc123",
-    "directory_name": "Example Directory",
+    "directory_uid": "duda",
+    "directory_name": "Duda",
     "role": "admin",
-    "current": true
+    "current": false
   }
 }

--- a/swagger/platform_administration/directory.json
+++ b/swagger/platform_administration/directory.json
@@ -564,6 +564,24 @@
           }
         }
       },
+      "OperatorDirectorySwitcherDirectory": {
+        "type": "object",
+        "description": "A slim directory option available to the authenticated operator for context switching.",
+        "properties": {
+          "uid": {
+            "type": "string",
+            "description": "Unique identifier of the directory option (e.g., \"dir_abc123\")."
+          },
+          "name": {
+            "type": "string",
+            "description": "Display name of the directory option (e.g., \"Example Directory\")."
+          }
+        },
+        "required": [
+          "uid",
+          "name"
+        ]
+      },
       "ErrorResponse": {
         "type": "object",
         "properties": {
@@ -712,7 +730,7 @@
       },
       "get": {
         "summary": "Get a list of Directories",
-        "description": "Returns a filtered, paginated list of directories.\n\nAvailable for **Internal tokens**, **Directory Tokens** and **Staff Tokens**",
+        "description": "Returns a filtered, paginated list of directories. Operator tokens receive only directories available through their operator directory assignments. Use `view_type=operator_switcher` for the slim directory switcher response.\n\nAvailable for **Internal, Directory, Staff, and Operator tokens**",
         "tags": [
           "Directory"
         ],
@@ -746,6 +764,27 @@
               "type": "string"
             },
             "example": "abc"
+          },
+          {
+            "name": "search",
+            "in": "query",
+            "required": false,
+            "description": "Optional case-insensitive search term matched against directory name or uid (e.g., \"example\").",
+            "schema": {
+              "type": "string"
+            },
+            "example": "example"
+          },
+          {
+            "name": "view_type",
+            "in": "query",
+            "required": false,
+            "description": "Optional response view. Use `operator_switcher` to return slim directory options for the Operator Portal directory switcher (e.g., \"operator_switcher\").",
+            "schema": {
+              "type": "string",
+              "enum": ["operator_switcher"]
+            },
+            "example": "operator_switcher"
           },
           {
             "name": "page",
@@ -788,7 +827,14 @@
                         "directories": {
                           "type": "array",
                           "items": {
-                            "$ref": "https://vcita.github.io/developers-hub/entities/business_administration/directory.json"
+                            "oneOf": [
+                              {
+                                "$ref": "https://vcita.github.io/developers-hub/entities/business_administration/directory.json"
+                              },
+                              {
+                                "$ref": "#/components/schemas/OperatorDirectorySwitcherDirectory"
+                              }
+                            ]
                           }
                         }
                       }
@@ -819,6 +865,29 @@
                         "page": 1,
                         "per_page": 50,
                         "total": 1
+                      }
+                    }
+                  },
+                  "Operator Switcher Response": {
+                    "summary": "Slim directory options for Operator Portal switcher",
+                    "value": {
+                      "success": true,
+                      "data": {
+                        "directories": [
+                          {
+                            "uid": "dir_abc123",
+                            "name": "Example Directory"
+                          },
+                          {
+                            "uid": "dir_def456",
+                            "name": "Another Directory"
+                          }
+                        ]
+                      },
+                      "paging": {
+                        "page": 1,
+                        "per_page": 25,
+                        "total": 2
                       }
                     }
                   },
@@ -880,7 +949,7 @@
         ]
       }
     },
-  
+
     "/v3/business_administration/directories/{uid}": {
       "put": {
         "summary": "Update a Directory",

--- a/swagger/platform_administration/operators.json
+++ b/swagger/platform_administration/operators.json
@@ -67,12 +67,14 @@
                   "success": true,
                   "data": [
                     {
+                      "operator_uid": "op_abc123",
                       "directory_uid": "dir_abc123",
                       "directory_name": "Example Directory",
                       "role": "admin",
                       "current": true
                     },
                     {
+                      "operator_uid": "op_abc123",
                       "directory_uid": "dir_def456",
                       "directory_name": "Another Directory",
                       "role": "sales",

--- a/swagger/platform_administration/operators.json
+++ b/swagger/platform_administration/operators.json
@@ -1,0 +1,96 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Operators",
+    "description": "APIs for Operator Portal directory context switching and directory assignment discovery.",
+    "version": "1.0",
+    "contact": {}
+  },
+  "servers": [
+    {
+      "url": "https://api.vcita.biz",
+      "description": "API Gateway server"
+    }
+  ],
+  "components": {
+    "schemas": {
+      "OperatorDirectoryAssignmentsList": {
+        "type": "array",
+        "description": "List of directory assignments available to the authenticated operator.",
+        "items": {
+          "$ref": "https://vcita.github.io/developers-hub/entities/operators/operator_directory_assignment.json"
+        }
+      }
+    },
+    "securitySchemes": {
+      "Bearer": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "JWT",
+        "description": "Provide a valid operator bearer token in the Authorization header. Example: 'Authorization: Bearer {operator_token}'"
+      }
+    }
+  },
+  "paths": {
+    "/v3/operators/operator_directory_assignments": {
+      "get": {
+        "summary": "List operator directory assignments",
+        "description": "Returns the authenticated operator's directory assignments with the role assigned per directory. The operator is taken from the token; there is no path identifier. The Operator Portal can use this response to decide whether to show a directory switcher and which directory is currently active. Available for **Operator tokens**.",
+        "tags": [
+          "Operators"
+        ],
+        "security": [
+          {
+            "Bearer": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Operator directory assignments retrieved successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                    },
+                    {
+                      "properties": {
+                        "data": {
+                          "$ref": "#/components/schemas/OperatorDirectoryAssignmentsList"
+                        }
+                      }
+                    }
+                  ]
+                },
+                "example": {
+                  "success": true,
+                  "data": [
+                    {
+                      "directory_uid": "dir_abc123",
+                      "directory_name": "Example Directory",
+                      "role": "admin",
+                      "current": true
+                    },
+                    {
+                      "directory_uid": "dir_def456",
+                      "directory_name": "Another Directory",
+                      "role": "sales",
+                      "current": false
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - missing or invalid operator token."
+          },
+          "408": {
+            "description": "Request exceeded timeout limit."
+          }
+        }
+      }
+    }
+  }
+}

--- a/swagger/platform_administration/operators.json
+++ b/swagger/platform_administration/operators.json
@@ -35,7 +35,7 @@
     "/v3/operators/operator_directory_assignments": {
       "get": {
         "summary": "List operator directory assignments",
-        "description": "Returns the authenticated operator's directory assignments with the role assigned per directory. The operator is taken from the token; there is no path identifier. The Operator Portal can use this response to decide whether to show a directory switcher and which directory is currently active. Available for **Operator tokens**.",
+        "description": "Returns the authenticated operator's concrete directory assignments and logical directory scope assignments with the role assigned per context. Logical scope assignments use `directory_uid` values such as \"all\", \"duda\", and \"xperts\". The operator is taken from the token; there is no path identifier. The Operator Portal can use this response to decide whether to show a directory switcher and which directory is currently active. Available for **Operator tokens**.",
         "tags": [
           "Operators"
         ],
@@ -75,8 +75,8 @@
                     },
                     {
                       "operator_uid": "op_abc123",
-                      "directory_uid": "dir_def456",
-                      "directory_name": "Another Directory",
+                      "directory_uid": "duda",
+                      "directory_name": "Duda",
                       "role": "sales",
                       "current": false
                     }


### PR DESCRIPTION
Add swagger and entity for the operator-portal directory switcher.

  GET /v3/operators/operator_directory_assignments

  Response shape follows the v3 contract from entities/response.json:
    success path -> { success: true, data: [...] }

The operator is taken from the token; there is no path identifier.

New files:
  - entities/operators/operator_directory_assignment.json Single assignment entry: directory_uid, directory_name, role, current.
  - swagger/platform_administration/operators.json Path, parameters, response schema, and example payload.