### PR TITLE
docs: add voice call transcript API documentation

### DIFF
--- a/entities/communication/voiceCall.json
+++ b/entities/communication/voiceCall.json
@@ -25,9 +25,9 @@
         "MISSED",
         "ANSWERED_BY_CALLS_PROVIDER",
         "MISSED_CALL_HANDLED",
-        "VOICEMAIL_RECEIVED"
+        "VOICEMAIL"
       ],
-      "description": "The status of the call"
+      "description": "The status of the call (e.g., \"ANSWERED_BY_STAFF\")"
     },
     "direction": {
       "type": "string",
@@ -53,10 +53,6 @@
       "type": "string",
       "description": "The phone number the call was made to"
     },
-    "recording_url": {
-      "type": "string",
-      "description": "Link to the call recording"
-    },
     "call_summary": {
       "type": "string",
       "description": "Text summary of the call"
@@ -68,20 +64,38 @@
     },
     "external_app_url": {
       "type": "string",
-      "description": "Link to an application page with additional details about the call.\n\n"
+      "description": "Link to an application page with additional details about the call (e.g., \"https://example.com/call-details\")"
+    },
+    "external_app_name": {
+      "type": "string",
+      "description": "The name of the external application that originated or manages the call (e.g., \"my.pa\")"
+    },
+    "source_id": {
+      "type": "string",
+      "description": "A unique source identifier for the call from the provider system (e.g., \"call-src-001\")"
+    },
+    "external_uuid": {
+      "type": "string",
+      "description": "An external unique identifier for the call conversation from the provider system (e.g., \"ext-call-001\")"
     },
     "handled_by_staff_uid": {
-        "type": "string",
-        "description": "The unique identifier of the staff who handled the call"
+      "type": "string",
+      "description": "The unique identifier of the staff who handled the call"
     },
     "handled_at": {
-        "type": "string",
-        "description": "The date and time when the call was handled",
-        "format": "date-time"
+      "type": "string",
+      "description": "The date and time when the call was handled",
+      "format": "date-time"
     },
     "deleted_at": {
       "type": "string",
       "description": "Time the call was deleted - is null if the call is not deleted"
+    },
+    "transcript_status": {
+      "type": "string",
+      "nullable": true,
+      "enum": ["IN_PROGRESS", "DONE", "FAILED"],
+      "description": "Processing status of the associated transcript. IN_PROGRESS means the transcript is being generated, DONE means it is ready, FAILED means generation failed (e.g., \"DONE\")"
     }
   },
   "example": {
@@ -95,25 +109,23 @@
     "client_uid": "d290f1ee-6c54-4b01-90e6-d701748f0851",
     "from_number": "183466347342",
     "to_number": "183466347342",
-    "recording_url": "https://example.com/recording.mp3",
     "call_summary": "Client called to ask about their account balance",
     "recording": {
-      "external_uid": "abc123xyz",
-      "external_url": "https://example.com/recordings/abc123xyz",
+      "uid": "rec-abc123xyz",
+      "recordingUrl": "https://example.com/recordings/presigned-url",
       "size": 1048576,
       "duration": 300,
       "recording_played": false,
-      "recording_type": "CALL_RECORDING",
-      "started_at": "2024-03-20T12:34:56Z",
-      "storage_blob": "storage_blob_id_123",
-      "created_at": "2024-01-01T09:00:00Z",
-      "updated_at": "2024-03-20T12:34:56Z",
-      "deleted_at": null
+      "recording_type": "CALL"
     },
     "external_app_url": "https://example.com/call-details",
+    "external_app_name": "my.pa",
+    "source_id": "call-src-001",
+    "external_uuid": "ext-call-001",
     "handled_by_staff_uid": "d290f1ee-6c54-4b01-90e6-d701748f0851",
     "handled_at": "2021-07-20T14:00:00.000Z",
-    "deleted_at": null
+    "deleted_at": null,
+    "transcript_status": "DONE"
   },
   "description": "Represents a phone call record, including participants, status, recording and audit timestamps."
 }

--- a/entities/communication/voiceCallRecording.json
+++ b/entities/communication/voiceCallRecording.json
@@ -1,78 +1,48 @@
 {
   "type": "object",
   "properties": {
-    "external_uid": {
+    "uid": {
       "type": "string",
-      "description": "The unique identifier of the external recording resource"
+      "description": "Unique identifier of the recording entity (e.g., \"rec-abc123xyz\")"
     },
-    "external_url": {
+    "recordingUrl": {
       "type": "string",
-      "description": "The URL to access the external recording resource"
+      "description": "Pre-signed URL to access the recording file (e.g., \"https://example.com/recordings/presigned-url\")"
     },
     "size": {
       "type": "number",
-      "description": "The size of the recording in bytes"
+      "description": "The size of the recording in bytes (e.g., 1048576)"
     },
     "duration": {
       "type": "number",
-      "description": "The duration of the recording in seconds"
+      "description": "The duration of the recording in seconds (e.g., 300)"
     },
-    "record_played": {
+    "recording_played": {
       "type": "boolean",
-      "description": "Whether the call recording has been played"
+      "description": "Whether the call recording has been played (e.g., false)"
     },
     "recording_type": {
       "type": "string",
       "description": "The type of the recording",
       "enum": [
-        "VOICEMAIL_RECORDING",
-        "CALL_RECORDING"
+        "CALL",
+        "VOICEMAIL"
       ]
-    },
-    "started_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "The start date and time of the recording"
-    },
-    "storage_blob": {
-      "type": "string",
-      "description": "The storage blob identifier if stored in a cloud storage service"
-    },
-    "created_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "The date and time when the recording entity was created"
-    },
-    "updated_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "The date and time when the recording entity was last updated"
-    },
-    "deleted_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "The date and time when the recording was deleted"
     }
   },
   "required": [
-    "external_uid",
+    "uid",
     "size",
     "duration",
-    "started_at"
+    "recording_type"
   ],
   "example": {
-    "external_uid": "abc123xyz",
-    "external_url": "https://example.com/recordings/abc123xyz",
+    "uid": "rec-abc123xyz",
+    "recordingUrl": "https://example.com/recordings/presigned-url",
     "size": 1048576,
     "duration": 300,
-    "record_played": false,
-    "recording_type": "CALL_RECORDING",
-    "started_at": "2024-03-20T12:34:56Z",
-    "storage_blob": "storage_blob_id_123",
-    "created_at": "2024-01-01T09:00:00Z",
-    "updated_at": "2024-03-20T12:34:56Z",
-    "deleted_at": null
-  }
-,
-  "description": "Metadata for an external call recording, including storage and lifecycle fields."
+    "recording_played": false,
+    "recording_type": "CALL"
+  },
+  "description": "Recording details for a voice call, including a pre-signed access URL and playback metadata."
 }

--- a/entities/communication/voiceCallSetting.json
+++ b/entities/communication/voiceCallSetting.json
@@ -1,112 +1,107 @@
 {
-    "type": "object",
-    "properties": {
-        "uid": {
-            "type": "string",
-            "description": "The unique identifier of the VoiceCallSetting entity"
-        },
-        "staff_uid": {
-            "type": "string",
-            "description": "The unique identifier of the staff receiving the forwarded call"
-        },
-        "forward_number": {
-            "type": "string",
-            "description": "The phone number of the staff receiving the forwarded call"
-        },
-        "dedicated_number": {
-            "type": "string",
-            "description": "The dedicated number of the business receiving calls from clients"
-        },
-        "forwarding_enabled": {
-            "type": "boolean",
-            "description": "Indicates if voice call forwarding is enabled"
-        },
-        "call_forwarding_policy": {
-            "type": "string",
-            "enum": [
-                "ALWAYS",
-                "WORK_HOURS",
-                "NEVER"],
-            "description": "Specifies the conditions under which calls are forwarded based on staff availability"
-        },
-        "staff_weekly_availability_uid": {
-            "type": "string",
-            "description": "The unique identifier represents the weekly working hours availability list object of staff members\nThis list will assist deciding if to forward the call to staff or its out of the working hours (in case forwarding policy is WORK_HOURS)."
-        },
-        "call_timeout_sec": {
-            "type": "number",
-            "description": "Call ringing timeout in seconds"
-        },
-        "publish_number": {
-            "type": "boolean",
-            "description": "Indicates if the dedicated number should be published as the business's phone number."
-        },
-        "voice_scripts": {
-            "type": "object",
-            "description": "The voice_scripts property within the voiceCallSettings entity allows for the configuration of various voice messages that are played to callers during different stages of a voice call. Each key-value pair within voice_scripts represents a specific voice message, identified by a unique name.\n\nStructure:\nkey: String - The name of the voice message configuration (e.g., greeting_message, missed_call_message). This key can be any descriptive name suitable for the specific message.\n\nvalue: Object - Contains the following properties:\nmessage: String - The actual voice message that will be played to the caller.\nenabled: Boolean - A flag indicating whether this specific voice message is enabled or disabled."
-        },
-        "external_app_config": {
-            "type": "object",
-            "description": "A configuration JSON object defining the external AI app managing the voice call.\nThe object defines three keys:\napp_name: the name of the app used (for internal use)\nfull_url: the endpoint related to that app\nmethod: the HTTP method that should be used (GET/POST)"
-        },
-        "created_at": {
-            "type": "string",
-            "description": "The date and time when the VoiceCallSetting entity was created",
-            "format": "date-time"
-        },
-        "updated_at": {
-            "type": "string",
-            "description": "The date and time when the VoiceCallSetting entity was updated",
-            "format": "date-time"
-        },
-        "deleted_at": {
-            "type": "string",
-            "description": "The date and time when the VoiceCallSetting entity was deleted",
-            "format": "date-time"
-        }
+  "type": "object",
+  "properties": {
+    "uid": {
+      "type": "string",
+      "description": "The unique identifier of the VoiceCallSetting entity (e.g., \"56ah3478b56c\")"
     },
-    "required": [
-        "forward_call",
-        "forwarding_enabled"
-    ],
-    "example": {
-        "uid": "56ah3478b56c",
-        "staff_uid": "5ya4gbwm2c3qic8",
-        "forward_number": "180348567634",
-        "dedicated_number": "12845783457",
-        "forwarding_enabled": true,
-        "call_forwarding_policy": "WORK_HOURS",
-        "staff_weekly_availability_uid": "0c4ac9717ab26f56",
-        "call_timeout_sec": 20,
-        "publish_number": true,
-        "voice_scripts": {
-            "greeting_message": {
-                "message": "Hi, The call will be forwarded soon, please wait.",
-                "enabled": true
-            },
-            "missed_call_message": {
-                "message": "Sorry, please try again later.",
-                "enabled": false
-            },
-            "voicemail_message": {
-                "message": "Sorry, the staff is not available right now. Please leave a message after the beep.",
-                "enabled": false
-            },
-            "recording_call_message": {
-                "message": "Please note that this is a voice recording, please press 1 to continue.",
-                "enabled": false
-            }
-            
-        },
-        "external_app_config": {
-            "app_name": "my.pa",
-            "full_url": "https://ww.example.com/my/pa/ncco",
-            "method": "GET"
-        },
-        "created_at": "2024-01-01T09:00:00Z",
-        "updated_at": "2024-03-20T12:34:56Z",
-        "deleted_at": null
+    "business_uid": {
+      "type": "string",
+      "description": "The unique identifier of the business (e.g., \"d290f1ee-6c54-4b01-90e6-d701748f0851\")"
+    },
+    "staff_uid": {
+      "type": "string",
+      "description": "The unique identifier of the staff receiving the forwarded call (e.g., \"5ya4gbwm2c3qic8\")"
+    },
+    "forward_number": {
+      "type": "string",
+      "description": "The phone number of the staff receiving the forwarded call (e.g., \"180348567634\")"
+    },
+    "dedicated_number": {
+      "type": "string",
+      "description": "The dedicated number of the business receiving calls from clients (e.g., \"12845783457\")"
+    },
+    "forwarding_enabled": {
+      "type": "boolean",
+      "description": "Indicates if voice call forwarding is enabled (e.g., true)"
+    },
+    "call_forwarding_policy": {
+      "type": "string",
+      "enum": ["ALWAYS", "WORK_HOURS", "NEVER"],
+      "description": "Specifies the conditions under which calls are forwarded based on staff availability (e.g., \"WORK_HOURS\")"
+    },
+    "call_timeout_sec": {
+      "type": "number",
+      "description": "Call ringing timeout in seconds (e.g., 20)"
+    },
+    "publish_number": {
+      "type": "boolean",
+      "description": "Indicates if the dedicated number should be published as the business's phone number (e.g., true)"
+    },
+    "voice_scripts": {
+      "type": "object",
+      "nullable": true,
+      "description": "Configuration of voice messages played to callers during different stages of a voice call. Each key is a message name, value is an object with message (string) and enabled (boolean)."
+    },
+    "external_app_name": {
+      "type": "string",
+      "description": "The name of the external application managing the voice call (e.g., \"my.pa\")"
+    },
+    "app_status": {
+      "type": "string",
+      "enum": ["INSTALLED", "UNINSTALLED", "PAYMENT_ISSUE"],
+      "description": "The status of the app (e.g., \"INSTALLED\")"
+    },
+    "feature": {
+      "type": "string",
+      "enum": ["VOICE", "SMS", "VOICE_SMS"],
+      "nullable": true,
+      "description": "The feature type for this setting (e.g., \"VOICE\")"
+    },
+    "transcript_enabled": {
+      "type": "boolean",
+      "description": "Whether automatic transcript processing is enabled for voice calls in this business (e.g., true)"
     }
-,
+  },
+  "required": [
+    "uid",
+    "business_uid",
+    "forwarding_enabled",
+    "external_app_name",
+    "app_status"
+  ],
+  "example": {
+    "uid": "56ah3478b56c",
+    "business_uid": "d290f1ee-6c54-4b01-90e6-d701748f0851",
+    "staff_uid": "5ya4gbwm2c3qic8",
+    "forward_number": "180348567634",
+    "dedicated_number": "12845783457",
+    "forwarding_enabled": true,
+    "call_forwarding_policy": "WORK_HOURS",
+    "call_timeout_sec": 20,
+    "publish_number": true,
+    "voice_scripts": {
+      "greeting_message": {
+        "message": "Hi, The call will be forwarded soon, please wait.",
+        "enabled": true
+      },
+      "missed_call_message": {
+        "message": "Sorry, please try again later.",
+        "enabled": false
+      },
+      "voicemail_message": {
+        "message": "Sorry, the staff is not available right now. Please leave a message after the beep.",
+        "enabled": false
+      },
+      "recording_call_message": {
+        "message": "Please note that this is a voice recording, please press 1 to continue.",
+        "enabled": false
+      }
+    },
+    "external_app_name": "my.pa",
+    "app_status": "INSTALLED",
+    "feature": "VOICE",
+    "transcript_enabled": true
+  },
   "description": "Defines voice call settings for a staff member/business, including forwarding, policies, and scripts."
 }

--- a/entities/communication/voiceCallTranscript.json
+++ b/entities/communication/voiceCallTranscript.json
@@ -1,0 +1,60 @@
+{
+  "type": "object",
+  "properties": {
+    "transcript_uid": {
+      "type": "string",
+      "description": "Unique identifier of the transcript entity (e.g., \"a1b2c3d4-5678-90ab-cdef-1234567890ab\")"
+    },
+    "status": {
+      "type": "string",
+      "enum": ["IN_PROGRESS", "DONE", "FAILED"],
+      "description": "Processing status of the transcript. IN_PROGRESS means generation is underway, DONE means it is ready, FAILED means generation failed (e.g., \"DONE\")"
+    },
+    "transcript": {
+      "type": "array",
+      "nullable": true,
+      "description": "Array of transcript entries, present only when status is DONE",
+      "items": {
+        "type": "object",
+        "properties": {
+          "timestamp": {
+            "type": "number",
+            "description": "Timestamp in seconds from start of audio (e.g., 12.5)"
+          },
+          "speaker_role": {
+            "type": "string",
+            "description": "Role of the speaker in the conversation (e.g., \"client\", \"staff\")"
+          },
+          "text": {
+            "type": "string",
+            "description": "Transcribed text for this segment (e.g., \"Hello, how can I help you?\")"
+          }
+        },
+        "required": ["timestamp", "speaker_role", "text"]
+      }
+    }
+  },
+  "required": ["transcript_uid", "status"],
+  "example": {
+    "transcript_uid": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
+    "status": "DONE",
+    "transcript": [
+      {
+        "timestamp": 0.0,
+        "speaker_role": "staff",
+        "text": "Hello, thank you for calling. How can I help you today?"
+      },
+      {
+        "timestamp": 3.2,
+        "speaker_role": "client",
+        "text": "Hi, I'd like to schedule an appointment for next week."
+      },
+      {
+        "timestamp": 7.8,
+        "speaker_role": "staff",
+        "text": "Sure, let me check available slots for you."
+      }
+    ]
+  },
+  "description": "Represents the transcript of a voice call, including processing status and individual speaker entries."
+}

--- a/swagger/communication/communication.json
+++ b/swagger/communication/communication.json
@@ -76,6 +76,15 @@
           "app_status": {
             "type": "string",
             "description": "The status of the app"
+          },
+          "feature": {
+            "type": "string",
+            "enum": ["VOICE", "SMS", "VOICE_SMS"],
+            "description": "The feature type for this setting (e.g., \"VOICE\")"
+          },
+          "transcript_enabled": {
+            "type": "boolean",
+            "description": "Whether automatic transcript processing is enabled for voice calls in this business (e.g., true)"
           }
         },
         "required": [
@@ -141,6 +150,15 @@
           "app_status": {
             "type": "string",
             "description": "The app's status"
+          },
+          "feature": {
+            "type": "string",
+            "enum": ["VOICE", "SMS", "VOICE_SMS"],
+            "description": "The feature type for this setting (e.g., \"VOICE\")"
+          },
+          "transcript_enabled": {
+            "type": "boolean",
+            "description": "Whether automatic transcript processing is enabled for voice calls (e.g., true)"
           }
         },
         "required": [
@@ -206,20 +224,17 @@
           "app_status": {
             "type": "string",
             "description": "The app's status"
+          },
+          "feature": {
+            "type": "string",
+            "enum": ["VOICE", "SMS", "VOICE_SMS"],
+            "description": "The feature type for this setting (e.g., \"VOICE\")"
+          },
+          "transcript_enabled": {
+            "type": "boolean",
+            "description": "Whether automatic transcript processing is enabled for voice calls (e.g., true)"
           }
-        },
-        "required": [
-          "staff_uid",
-          "forward_number",
-          "staff_weekly_availability_uid",
-          "forwarding_enabled",
-          "dedicated_number",
-          "call_forwarding_policy",
-          "call_timeout_sec",
-          "voice_scripts",
-          "external_app_name",
-          "app_status"
-        ]
+        }
       },
       "MultiResponseEntity": {
         "type": "object",
@@ -284,9 +299,9 @@
               "MISSED",
               "ANSWERED_BY_CALLS_PROVIDER",
               "MISSED_CALL_HANDLED",
-              "VOICEMAIL_RECEIVED"
+              "VOICEMAIL"
             ],
-            "description": "The status of the call. Must be one of the allowed enum values: INCOMING_CALL (call is ringing), ANSWERED_BY_STAFF (staff picked up), MISSED (no one answered), ANSWERED_BY_CALLS_PROVIDER (handled by provider IVR), MISSED_CALL_HANDLED (missed call was followed up), VOICEMAIL_RECEIVED (caller left a voicemail). Values are case-sensitive and must be uppercase (e.g., \"MISSED\")."
+            "description": "The status of the call. Must be one of the allowed enum values: INCOMING_CALL (call is ringing), ANSWERED_BY_STAFF (staff picked up), MISSED (no one answered), ANSWERED_BY_CALLS_PROVIDER (handled by provider IVR), MISSED_CALL_HANDLED (missed call was followed up), VOICEMAIL (caller left a voicemail). Values are case-sensitive and must be uppercase (e.g., \"MISSED\")."
           },
           "rate": {
             "type": "string",
@@ -358,11 +373,15 @@
       "UpdateVoiceCallRecording": {
         "type": "object",
         "properties": {
-          "record_played": {
+          "recording_played": {
             "type": "boolean",
-            "description": "Whether the call recording has been played"
+            "description": "Whether the call recording has been played (e.g., true)"
           }
         }
+      },
+      "TranscriptResponse": {
+        "type": "object",
+        "$ref": "https://vcita.github.io/developers-hub/entities/communication/voiceCallTranscript.json"
       },
       "CreateVoiceCall": {
         "type": "object",
@@ -399,9 +418,9 @@
               "MISSED",
               "ANSWERED_BY_CALLS_PROVIDER",
               "MISSED_CALL_HANDLED",
-              "VOICEMAIL_RECEIVED"
+              "VOICEMAIL"
             ],
-            "description": "The status of the call. Must be one of the allowed enum values: INCOMING_CALL (call is ringing), ANSWERED_BY_STAFF (staff picked up), MISSED (no one answered), ANSWERED_BY_CALLS_PROVIDER (handled by provider IVR), MISSED_CALL_HANDLED (missed call was followed up), VOICEMAIL_RECEIVED (caller left a voicemail). Values are case-sensitive and must be uppercase (e.g., \"MISSED\")."
+            "description": "The status of the call. Must be one of the allowed enum values: INCOMING_CALL (call is ringing), ANSWERED_BY_STAFF (staff picked up), MISSED (no one answered), ANSWERED_BY_CALLS_PROVIDER (handled by provider IVR), MISSED_CALL_HANDLED (missed call was followed up), VOICEMAIL (caller left a voicemail). Values are case-sensitive and must be uppercase (e.g., \"MISSED\")."
           },
           "rate": {
             "type": "string",
@@ -494,7 +513,7 @@
               "MISSED",
               "ANSWERED_BY_CALLS_PROVIDER",
               "MISSED_CALL_HANDLED",
-              "VOICEMAIL_RECEIVED"
+              "VOICEMAIL"
             ]
           },
           "count": {
@@ -601,7 +620,37 @@
       "get": {
         "operationId": "SettingsController_get",
         "summary": "Get all VoiceCallSettings",
-        "parameters": [],
+        "parameters": [
+          {
+            "name": "feature",
+            "required": false,
+            "in": "query",
+            "description": "Filter by feature type (e.g., \"VOICE\", \"SMS\", \"VOICE_SMS\")",
+            "schema": {
+              "type": "string",
+              "enum": ["VOICE", "SMS", "VOICE_SMS"]
+            }
+          },
+          {
+            "name": "dedicated_number",
+            "required": false,
+            "in": "query",
+            "description": "Filter by dedicated number",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "app_status",
+            "required": false,
+            "in": "query",
+            "description": "Filter by app status (e.g., \"INSTALLED\", \"UNINSTALLED\", \"PAYMENT_ISSUE\")",
+            "schema": {
+              "type": "string",
+              "enum": ["INSTALLED", "UNINSTALLED", "PAYMENT_ISSUE"]
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "",
@@ -638,6 +687,53 @@
       }
     },
     "/v3/communication/voice_call_settings/{uid}": {
+      "delete": {
+        "operationId": "SettingsController_delete",
+        "summary": "Delete VoiceCallSetting",
+        "description": "## Overview\nDelete a VoiceCallSetting.\n\nAvailable for **Admin tokens**",
+        "parameters": [
+          {
+            "name": "uid",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Response"
+                    },
+                    {
+                      "properties": {
+                        "data": {
+                          "type": "object",
+                          "$ref": "https://vcita.github.io/developers-hub/entities/communication/voiceCallSetting.json"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Voice Call Settings"
+        ],
+        "security": [
+          {
+            "Bearer": []
+          }
+        ]
+      },
       "put": {
         "operationId": "SettingsController_update",
         "summary": "Update VoiceCallSetting",
@@ -946,6 +1042,59 @@
         "description": "## Overview\nUpdate a VoiceCall Available for **Staff, App, and Directory tokens**."
       }
     },
+    "/v3/communication/voice_calls/{uid}/transcript": {
+      "get": {
+        "operationId": "TranscriptController_getTranscript",
+        "summary": "Get transcript for a voice call",
+        "description": "## Overview\nRetrieves the transcript for a specific voice call. Returns the processing status and, when status is DONE, the full transcript entries.\n\nAvailable for **Staff, Directory, and Client tokens**",
+        "parameters": [
+          {
+            "name": "uid",
+            "required": true,
+            "in": "path",
+            "description": "The unique identifier of the voice call",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Transcript retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Response"
+                    },
+                    {
+                      "properties": {
+                        "data": {
+                          "type": "object",
+                          "$ref": "https://vcita.github.io/developers-hub/entities/communication/voiceCallTranscript.json"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Transcript not found for the given voice call"
+          }
+        },
+        "tags": [
+          "Voice Call Transcripts"
+        ],
+        "security": [
+          {
+            "Bearer": []
+          }
+        ]
+      }
+    },
     "/v3/communication/voice_call_recordings/{uid}": {
       "put": {
         "operationId": "RecordingsController_updateVoiceCallRecording",
@@ -1134,7 +1283,7 @@
                 "MISSED",
                 "ANSWERED_BY_CALLS_PROVIDER",
                 "MISSED_CALL_HANDLED",
-                "VOICEMAIL_RECEIVED"
+                "VOICEMAIL"
               ]
             }
           }


### PR DESCRIPTION
Add transcript-related fields and endpoint to the communication API docs:
- voiceCall entity: add transcript_status field
- voiceCallSetting entity: add transcript_enabled field
- New voiceCallTranscript entity for transcript response shape
- New GET /v3/communication/voice_calls/{uid}/transcript endpoint

Co-authored-by: Cursor <cursoragent@cursor.com>