### PR TITLE
Add package_name filter to GET /v3/business_administration/businesses

### DIFF
--- a/swagger/platform_administration/business.json
+++ b/swagger/platform_administration/business.json
@@ -129,6 +129,16 @@
             "example": "dir_x9y8z7w6v5"
           },
           {
+            "name": "package_name",
+            "in": "query",
+            "required": false,
+            "description": "Filter businesses by their current subscription package name.",
+            "schema": {
+              "type": "string"
+            },
+            "example": "essential"
+          },
+          {
             "name": "is_blocked",
             "in": "query",
             "required": false,


### PR DESCRIPTION
## Summary
- Adds `package_name` query filter to the `GET /v3/business_administration/businesses` endpoint, allowing directories to filter businesses by their current subscription package.

## Test plan
- [ ] Verify swagger spec is valid JSON
- [ ] Confirm `package_name` parameter appears correctly in API docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)