### PR TITLE
feat(business): add is_template, tags, and in_setup to business entity

### DIFF
--- a/entities/business_administration/business.json
+++ b/entities/business_administration/business.json
@@ -15,6 +15,10 @@
       "type": "string",
       "description": "Unique identifier of the directory this business belongs to."
     },
+    "is_template": {
+      "type": "boolean",
+      "description": "Indicates whether this account is used as a template within the directory. Template accounts are not live businesses — they serve as a base configuration for creating new accounts under the directory."
+    },
     "name": {
       "type": "string",
       "description": "The business name."
@@ -30,6 +34,14 @@
       },
       "uniqueItems": true,
       "description": "List of occupational vertical UIDs associated with the business."
+    },
+    "tags": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "uniqueItems": true,
+      "description": "Free-form tags assigned to the business by the directory. Used to differentiate and group accounts (e.g. by franchise, tier, region, or account type). Tags are directory-defined and have no enforced schema."
     },
     "external_reference_id": {
       "type": "string",
@@ -97,6 +109,10 @@
       "readOnly": true,
       "description": "The business's current subscription package or plan identifier."
     },
+    "in_setup": {
+      "type": "boolean",
+      "description": "Indicates whether the business account is still in setup (onboarding) mode. When `true`, the account has not yet completed onboarding and is not live — sales operators can impersonate the account. When `false`, setup is complete, the account is live, and operator impersonation is no longer permitted."
+    },
     "account_blocked_at": {
       "type": "string",
       "format": "date-time",
@@ -119,9 +135,11 @@
   "example": {
     "uid": "b_a1b2c3d4e5f6",
     "directory_uid": "dir_x9y8z7w6v5",
+    "is_template": false,
     "name": "Green Leaf Wellness",
     "business_category": "health_wellness",
     "identities": ["vert_yoga", "vert_nutrition"],
+    "tags": ["franchise-east", "vip"],
     "external_reference_id": "partner-biz-98765",
     "reference_id": "crm-ref-00123",
     "business_maturity_in_years": "2+",
@@ -137,6 +155,7 @@
     "locale": "en",
     "time_format": "12h",
     "current_package": "essential",
+    "in_setup": false,
     "account_blocked_at": null,
     "created_at": "2023-03-15T10:00:00Z",
     "updated_at": "2024-11-20T14:35:22Z"


### PR DESCRIPTION
## Summary
- `is_template` (boolean) — flags accounts used as directory templates
- `tags` (array of strings) — free-form directory-defined labels for grouping/differentiating accounts (e.g. franchise, tier, region)
- `in_setup` (boolean) — indicates onboarding state; when `true` the account is not yet live and sales operators can impersonate it

## Test plan
- [ ] Verify entity JSON is valid
- [ ] Confirm new fields appear in API docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)