### PR TITLE
feat(business): add tags filter to GET list businesses endpoint

### DIFF
--- a/swagger/platform_administration/business.json
+++ b/swagger/platform_administration/business.json
@@ -98,6 +98,21 @@
             "example": "partner-biz-98765"
           },
           {
+            "name": "tags",
+            "in": "query",
+            "required": false,
+            "description": "Filter businesses by one or more tags. Returns businesses that match any of the provided tags.",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "style": "form",
+            "explode": true,
+            "example": ["franchise-east", "vip"]
+          },
+          {
             "name": "external_reference_id",
             "in": "query",
             "required": false,


### PR DESCRIPTION
## Summary
- Adds `tags` query filter to `GET /v3/business_administration/businesses`
- Array parameter — returns businesses matching any of the provided tags (e.g. `tags[]=franchise-east&tags[]=vip`)

## Test plan
- [ ] Verify swagger spec is valid JSON
- [ ] Confirm `tags` parameter appears correctly in API docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)