### PR TITLE
VCITA2-14233: Add Latvian (lv) to payment_gateway locale enums

### DIFF
--- a/entities/payment_processing/payment_gateway.json
+++ b/entities/payment_processing/payment_gateway.json
@@ -20,7 +20,7 @@
     "default_locale": {
       "type": "string",
       "enum": [
-        "en", "fr", "de", "it", "pl", "pt", "es", "nl", "he", "en_gb"
+        "en", "fr", "de", "it", "pl", "pt", "es", "nl", "he", "en_gb", "lv"
       ],
       "description": "Specifies the fallback locale for the gateway's textual content. If a translation or string is missing, this locale will be used by default."
     },
@@ -54,7 +54,7 @@
           "locale": {
             "type": "string",
             "enum": [
-              "en", "fr", "de", "it", "pl", "pt", "es", "nl", "he", "en_gb"
+              "en", "fr", "de", "it", "pl", "pt", "es", "nl", "he", "en_gb", "lv"
             ]
           },
           "benefits": {
@@ -78,7 +78,7 @@
           "locale": {
             "type": "string",
             "enum": [
-              "en", "fr", "de", "it", "pl", "pt", "es", "nl", "he", "en_gb"
+              "en", "fr", "de", "it", "pl", "pt", "es", "nl", "he", "en_gb", "lv"
             ]
           },
           "highlights": {

--- a/swagger/sales/payment_gateway.json
+++ b/swagger/sales/payment_gateway.json
@@ -331,7 +331,8 @@
                             "es",
                             "nl",
                             "he",
-                            "en_gb"
+                            "en_gb",
+                            "lv"
                           ],
                           "description": "The locale code (e.g., en, fr, es)."
                         },
@@ -369,7 +370,8 @@
                             "es",
                             "nl",
                             "he",
-                            "en_gb"
+                            "en_gb",
+                            "lv"
                           ],
                           "description": "The locale code (e.g., en, fr, es)."
                         },
@@ -656,7 +658,8 @@
                             "es",
                             "nl",
                             "he",
-                            "en_gb"
+                            "en_gb",
+                            "lv"
                           ],
                           "description": "The locale code (e.g., en, fr, es)."
                         },
@@ -694,7 +697,8 @@
                             "es",
                             "nl",
                             "he",
-                            "en_gb"
+                            "en_gb",
+                            "lv"
                           ],
                           "description": "The locale code (e.g., en, fr, es)."
                         },


### PR DESCRIPTION
## What
Adds `"lv"` to the payment_gateway locale enums in the API docs.

- `swagger/sales/payment_gateway.json` (source of truth) — 4 `locale` enums: `main_gateway_benefits` & `brief_benefit_highlights` for POST and PUT.
- `entities/payment_processing/payment_gateway.json` — `main_gateway_benefits`, `brief_benefit_highlights`, **and** `default_locale` enums.

## Notes
- `mcp_swagger/sales.json` is auto-generated from the source swagger via `unify-openapi.js` and is intentionally **not** hand-edited in this PR.
- `default_locale` in the entity was included (beyond the ticket's literal list) because it shares the same `Locale` enum in code — omitting it would make the entity inconsistent with generated output.
- Code change in companion PR: vcita/payments#46.

## Ticket
https://myvcita.atlassian.net/browse/VCITA2-14233

🤖 Generated with [Claude Code](https://claude.com/claude-code)