### PR TITLE
docs: businesses list contract (VCITA2-14107)

### DIFF
--- a/entities/business_administration/business.json
+++ b/entities/business_administration/business.json
@@ -111,7 +111,8 @@
     },
     "in_setup": {
       "type": "boolean",
-      "description": "Indicates whether the business account is still in setup (onboarding) mode. When `true`, the account has not yet completed onboarding and is not live — sales operators can impersonate the account. When `false`, setup is complete, the account is live, and operator impersonation is no longer permitted."
+      "nullable": true,
+      "description": "Indicates whether the business account is still in setup (onboarding) mode. When `true`, the account has not yet completed onboarding and is not live — sales operators can impersonate the account. When `false`, setup is complete, the account is live, and operator impersonation is no longer permitted. `null` when the business has no directory membership."
     },
     "account_blocked_at": {
       "type": "string",

--- a/swagger/platform_administration/business.json
+++ b/swagger/platform_administration/business.json
@@ -101,7 +101,7 @@
             "name": "tags",
             "in": "query",
             "required": false,
-            "description": "Filter businesses by one or more tags. Returns businesses that match any of the provided tags.",
+            "description": "Filter businesses by one or more tags (comma-separated). Returns businesses that match any of the provided tags.",
             "schema": {
               "type": "array",
               "items": {
@@ -109,7 +109,7 @@
               }
             },
             "style": "form",
-            "explode": true,
+            "explode": false,
             "example": ["franchise-east", "vip"]
           },
           {
@@ -137,7 +137,7 @@
             "name": "directory_uid",
             "in": "query",
             "required": false,
-            "description": "Filter businesses by directory UID. Available for **Internal tokens** only.",
+            "description": "Filter businesses by directory UID. Available for **Internal tokens** only, where it is **required**. Ignored for Directory tokens (which are scoped to their own directory).",
             "schema": {
               "type": "string"
             },
@@ -147,11 +147,16 @@
             "name": "package_name",
             "in": "query",
             "required": false,
-            "description": "Filter businesses by their current subscription package name.",
+            "description": "Filter businesses by their current subscription package name. Accepts a comma-separated list to match any of several packages (e.g. \"essential,business\").",
             "schema": {
-              "type": "string"
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             },
-            "example": "essential"
+            "style": "form",
+            "explode": false,
+            "example": ["essential", "business"]
           },
           {
             "name": "is_blocked",
@@ -201,9 +206,11 @@
                       {
                         "uid": "b_a1b2c3d4e5f6",
                         "directory_uid": "dir_x9y8z7w6v5",
+                        "is_template": false,
                         "name": "Green Leaf Wellness",
                         "business_category": "health_wellness",
                         "identities": ["vert_yoga", "vert_nutrition"],
+                        "tags": ["franchise-east", "vip"],
                         "external_reference_id": "partner-biz-98765",
                         "reference_id": "crm-ref-00123",
                         "business_maturity_in_years": "2+",
@@ -219,6 +226,7 @@
                         "locale": "en",
                         "time_format": "12h",
                         "current_package": "essential",
+                        "in_setup": false,
                         "account_blocked_at": null,
                         "created_at": "2023-03-15T10:00:00Z",
                         "updated_at": "2024-11-20T14:35:22Z"
@@ -262,9 +270,9 @@
                   "success": false,
                   "errors": [
                     {
-                      "field": "per_page",
+                      "field": "is_blocked",
                       "code": "invalid",
-                      "message": "per_page must not exceed 200"
+                      "message": "is_blocked must be a boolean (true or false)"
                     }
                   ]
                 }


### PR DESCRIPTION
Aligns the `GET /v3/business_administration/businesses` contract with the implementation.

Ticket: https://myvcita.atlassian.net/browse/VCITA2-14107
Core PR: https://github.com/vcita/core/pull/28886

## Changes
- **Entity** (`entities/business_administration/business.json`): `in_setup` is now `nullable: true` (null when the business has no directory membership).
- **Swagger** (`swagger/platform_administration/business.json`):
  - `package_name` filter → array (comma-separated list), `style: form`, `explode: false` — matches the implemented list support.
  - `tags` filter → `explode: false` (comma-separated), matching how the endpoint parses it.
  - `directory_uid` documented as **required** for internal tokens.
  - 200 example now includes `is_template`, `tags`, `in_setup`; 400 example uses `is_blocked`.

The new fields (`is_template`, `tags`, `reference_id`, `in_setup`), the `tags` filter, the Staff token, and the `external_id` description were already on master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)