### PR TITLE
docs: fix dedicated number assign — number_type is an array (SUPPORT-13055)

### DIFF
--- a/swagger/communication/legacy/legacy_v1_communication.json
+++ b/swagger/communication/legacy/legacy_v1_communication.json
@@ -324,8 +324,15 @@
                   "type": "string"
                 },
                 "number_type": {
-                  "description": "[\"promotional\",\"transactional\"]",
-                  "type": "string"
+                  "description": "Array of number types to assign. Must be a JSON array (not a scalar string), e.g. [\"transactional\"] or [\"promotional\",\"transactional\"].",
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": [
+                      "promotional",
+                      "transactional"
+                    ]
+                  }
                 }
               },
               "required": [
@@ -333,7 +340,15 @@
                 "number_type",
                 "api_key"
               ],
-              "type": "object"
+              "type": "object",
+              "example": {
+                "business_uid": "co8yyqp50k0hxzgx",
+                "number": "18335653846",
+                "number_type": [
+                  "transactional"
+                ],
+                "api_key": "<your_api_key>"
+              }
             }
           }
         ],


### PR DESCRIPTION
## Ticket
[SUPPORT-13055](https://myvcita.atlassian.net/browse/SUPPORT-13055) — [Thryv] Unable to assign a number to an account.

## Problem
`POST /platform/v1/numbers/dedicated_numbers/assign` fails with **"Request Missing Mandatory Field."** when a caller sends `number_type` as a scalar string (as the docs implied).

The service (`modules/messaging/app/components/numbers/dedicated_numbers_api.rb`) requires `number_type` to be a **JSON array** — it validates `!number_types.is_a?(Array)` and iterates over each element. The spec documented the field as `type: string`, so the contract never matched the implementation. This is a doc-vs-code mismatch; the code is unchanged since 2023, so docs are being synced to the code.

## Change
File: `swagger/communication/legacy/legacy_v1_communication.json` → `/numbers/dedicated_numbers/assign`

- `number_type`: `type: string` → `type: array` with `items.enum: [promotional, transactional]`
- Description now states a JSON array is required (not a scalar string)
- Added a request-body `example` with `number_type: ["transactional"]` so the "Try it" widget sends the correct shape

## Caller workaround (already valid)
Send a JSON body with the array form:
```json
{ "number": "18335653846", "number_type": ["transactional"], "api_key": "<api_key>" }
```

## Note
After merge, the developers-hub publish pipeline (`scripts/update-readme-swaggers.js`) must run for the change to reach `developers.intandem.tech`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SUPPORT-13055]: https://myvcita.atlassian.net/browse/SUPPORT-13055?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ