### PR TITLE
VCITA2-13040: document v3 apps API changes (api_uri, directory_uid, oauth fields, extension filter)

### DIFF
--- a/entities/apps/app.json
+++ b/entities/apps/app.json
@@ -41,6 +41,20 @@
         ]
       }
     },
+    "api_uri": {
+      "type": "string",
+      "description": "The URL of the application's API backend. Used to configure the app backend for notifications, communication, payment gateways, etc. Available to all token types."
+    },
+    "access_token_format": {
+      "type": "string",
+      "readOnly": true,
+      "description": "Format of access tokens issued for this app. Determines whether tokens are opaque or JWT."
+    },
+    "client_auth_jwks_uri": {
+      "type": "string",
+      "readOnly": true,
+      "description": "URI returning the JSON Web Key Set used to authenticate the app via Private Key JWT instead of a client secret."
+    },
     "app_types": {
       "type": "array",
       "readOnly": true,
@@ -196,12 +210,8 @@
     },
     "internal": {
       "type": "object",
-      "description": "Internal-only app metadata. Available only for Internal tokens.",
+      "description": "App presentation metadata. Available to all token types.",
       "properties": {
-        "api_uri": {
-          "type": "string",
-          "description": "Link to the application's API."
-        },
         "full_screen": {
           "type": "boolean",
           "description": "Whether the app is opened in a full screen mode.",
@@ -363,6 +373,11 @@
         ]
       }
     },
+    "directory_uid": {
+      "type": "string",
+      "readOnly": true,
+      "description": "UID of the directory that owns the app. Returned only for Directory and Internal tokens. Null for platform-owned apps with no owning directory."
+    },
     "created_at": {
       "type": "string",
       "readOnly": true,
@@ -396,6 +411,9 @@
       "staff_uid",
       "language"
     ],
+    "api_uri": "https://calendar-sync.example.com/api",
+    "access_token_format": "jwt",
+    "client_auth_jwks_uri": "https://calendar-sync.example.com/.well-known/jwks.json",
     "app_types": [
       "communication",
       "menu_items"
@@ -440,7 +458,6 @@
         "personal_connection": true
       },
       "internal": {
-        "api_uri": "https://calendar-sync.example.com/api",
         "full_screen": false,
         "deep_link": {
           "path": "/apps/calendar_sync/settings",
@@ -450,6 +467,7 @@
         }
       },
     "owner": true,
+    "directory_uid": "dir_4f8b1c2d3e4f",
     "extensions": [
       {
         "type": "menu_items",

--- a/swagger/apps/apps.json
+++ b/swagger/apps/apps.json
@@ -166,6 +166,15 @@
               "type": "string"
             },
             "description": "Free-text search across `name`, `app_code_name`, and app market description fields (`app_market.description.short_description`, `app_market.description.text`)."
+          },
+          {
+            "name": "extension",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Filter by extension type. Returns only apps whose `extensions` array includes an entry of the given `type`. Known extension types include: `menu_items`, `additional_params`, `deep_link`, `old_integration_name`, `personal_connection`, `full_screen`. Not restricted to this list — any configured extension type may be used."
           }
         ],
         "responses": {


### PR DESCRIPTION
## VCITA2-13040 — developers-hub docs for the v3 apps API

Documents the changes shipping in core (vcita/core#28895) and consumed by frontage (vcita/frontage#29308). Targets the `v3/apps/apps` API (`Apps_list` / `Apps_get`).

### `entities/apps/app.json`
- **`api_uri`** is now a **root** field (was nested under `internal`). Described as available to all token types — used to configure the app backend for notifications, communication, payment gateways, etc.
- **`access_token_format`** and **`client_auth_jwks_uri`** added as root fields. `api_uri`/`access_token_format`/`client_auth_jwks_uri` are ordered **before `app_types`** to mirror the response.
- **`internal`** object retained, now holding only `full_screen` + `deep_link` (description updated; no longer "internal-only").
- **`directory_uid`** added — returned only for **Directory** and **Internal** tokens.
- Example block updated to match.

### `swagger/apps/apps.json`
- **`Apps_list`**: new optional `extension` query param — filters apps whose `extensions` include the given type. Known types documented; no enum enforced.

`mcp_swagger/` is intentionally not committed (regenerated by CI on publish). Verified `scripts/unify-openapi.js` builds the apps domain cleanly with these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)