### PR TITLE
docs: fix translation-missing keys on POST /numbers/twilio

### DIFF
--- a/mcp_swagger/communication.json
+++ b/mcp_swagger/communication.json
@@ -658,7 +658,7 @@
     },
     "/platform/v1/numbers/twilio": {
       "post": {
-        "description": "## Overview\ntranslation missing: en.messaging-api.twilio.index.post.descriptionn Available for **Staff, App, and Directory tokens**.",
+        "description": "## Overview\nAdd a Twilio Number Available for **Staff, App, and Directory tokens**.",
         "parameters": [],
         "responses": {
           "201": {
@@ -681,7 +681,7 @@
             }
           }
         },
-        "summary": "translation missing: en.messaging-api.twilio.index.post.titlee",
+        "summary": "Add Twilio Number",
         "tags": [
           "Manage Numbers"
         ],

--- a/swagger/communication/legacy/legacy_v1_communication.json
+++ b/swagger/communication/legacy/legacy_v1_communication.json
@@ -465,7 +465,7 @@
         "consumes": [
           "application/json"
         ],
-        "description": "## Overview\ntranslation missing: en.messaging-api.twilio.index.post.descriptionn Available for **Staff, App, and Directory tokens**.",
+        "description": "## Overview\nAdd a Twilio Number Available for **Staff, App, and Directory tokens**.",
         "parameters": [
           {
             "in": "body",
@@ -524,7 +524,7 @@
             ]
           }
         ],
-        "summary": "translation missing: en.messaging-api.twilio.index.post.titlee",
+        "summary": "Add Twilio Number",
         "tags": [
           "Manage Numbers"
         ],


### PR DESCRIPTION
## Problem

The **POST `/numbers/twilio`** ("Add Twilio Number") endpoint rendered raw i18n keys instead of human-readable text on developers-hub:

- **Title:** `translation missing: en.messaging-api.twilio.index.post.titlee`
- **Description:** `translation missing: en.messaging-api.twilio.index.post.descriptionn`

(Note the doubled trailing letters — `titlee` / `descriptionn` — in the broken keys.)

## Fix

Replaced the broken keys with proper text, consistent with the sibling **DELETE `/numbers/twilio/{sub_account_id}`** ("Remove Twilio Number") endpoint:

- **Summary:** `Add Twilio Number`
- **Description:** `## Overview\nAdd a Twilio Number Available for **Staff, App, and Directory tokens**.`

Applied to both the source legacy swagger and the MCP swagger so docs stay in sync:

- `swagger/communication/legacy/legacy_v1_communication.json`
- `mcp_swagger/communication.json`

Both files validated as well-formed JSON. The `legacy_swagger_do_not_use/` copy was intentionally left untouched (deprecated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)