### PR TITLE
VCITA2-14234 Document Latvian (lv) locale support

### DIFF
--- a/entities/ai/AudioTranscription.json
+++ b/entities/ai/AudioTranscription.json
@@ -10,7 +10,7 @@
     "language": {
       "type": "string",
       "readOnly": true,
-      "description": "The detected or specified language code in ISO-639-1 format (e.g., \"en\" for English, \"es\" for Spanish, \"he\" for Hebrew)."
+      "description": "The detected or specified language code in ISO-639-1 format (e.g., \"en\" for English, \"es\" for Spanish, \"he\" for Hebrew, \"lv\" for Latvian)."
     },
     "duration": {
       "type": "number",

--- a/entities/communication/notificationTemplate.json
+++ b/entities/communication/notificationTemplate.json
@@ -192,7 +192,7 @@
           "locale": {
             "type": "string",
             "enum": [
-              "en", "fr", "de", "it", "pl", "pt", "es", "nl", "he", "sl", "en_gb"
+              "en", "fr", "de", "it", "pl", "pt", "es", "nl", "he", "sl", "en_gb", "lv"
             ]
           },
           "value": { "type": "string" }

--- a/entities/communication/staff_notification.json
+++ b/entities/communication/staff_notification.json
@@ -24,7 +24,7 @@
     "locale": {
       "type": "string",
       "description": "The language locale for the notification content.",
-      "enum": ["en", "fr", "de", "it", "pl", "pt", "es", "nl", "he", "sl", "en_gb"],
+      "enum": ["en", "fr", "de", "it", "pl", "pt", "es", "nl", "he", "sl", "en_gb", "lv"],
       "default": "en"
     },
     "params": {

--- a/mcp_swagger/ai.json
+++ b/mcp_swagger/ai.json
@@ -1851,7 +1851,7 @@
                   },
                   "language": {
                     "type": "string",
-                    "description": "ISO-639-1 language code for the audio content (e.g., \"en\" for English, \"es\" for Spanish, \"he\" for Hebrew). When omitted, the provider will auto-detect the language."
+                    "description": "ISO-639-1 language code for the audio content (e.g., \"en\" for English, \"es\" for Spanish, \"he\" for Hebrew, \"lv\" for Latvian). When omitted, the provider will auto-detect the language."
                   },
                   "prompt": {
                     "type": "string",

--- a/mcp_swagger/apps.json
+++ b/mcp_swagger/apps.json
@@ -5396,6 +5396,9 @@
           },
           "sl": {
             "type": "string"
+          },
+          "lv": {
+            "type": "string"
           }
         },
         "required": [

--- a/mcp_swagger/communication.json
+++ b/mcp_swagger/communication.json
@@ -5662,7 +5662,8 @@
               "nl",
               "he",
               "sl",
-              "en_gb"
+              "en_gb",
+              "lv"
             ],
             "default": "en"
           },

--- a/swagger/ai/generic_ai.json
+++ b/swagger/ai/generic_ai.json
@@ -319,7 +319,7 @@
                   },
                   "language": {
                     "type": "string",
-                    "description": "ISO-639-1 language code for the audio content (e.g., \"en\" for English, \"es\" for Spanish, \"he\" for Hebrew). When omitted, the provider will auto-detect the language."
+                    "description": "ISO-639-1 language code for the audio content (e.g., \"en\" for English, \"es\" for Spanish, \"he\" for Hebrew, \"lv\" for Latvian). When omitted, the provider will auto-detect the language."
                   },
                   "prompt": {
                     "type": "string",

--- a/swagger/apps/widgets_and_boards.json
+++ b/swagger/apps/widgets_and_boards.json
@@ -222,6 +222,9 @@
           },
           "sl": {
             "type": "string"
+          },
+          "lv": {
+            "type": "string"
           }
         },
         "required": [

--- a/swagger/communication/staff_notification.json
+++ b/swagger/communication/staff_notification.json
@@ -42,7 +42,8 @@
               "nl",
               "he",
               "sl",
-              "en_gb"
+              "en_gb",
+              "lv"
             ],
             "default": "en"
           },


### PR DESCRIPTION
## VCITA2-14234 — Add Latvian (`lv`) support (docs)

Adds `lv` (Latvian) to all Tango-owned locale/language definitions. Each entity has parallel `swagger/` and `mcp_swagger/` copies — all kept in sync.

### Changes (9 files)
**Communication `locale` enum → `"lv"`**
- `entities/communication/staff_notification.json`
- `entities/communication/notificationTemplate.json`
- `swagger/communication/staff_notification.json`
- `mcp_swagger/communication.json`

**Widget `DisplayNameDto` → `"lv"`**
- `swagger/apps/widgets_and_boards.json`
- `mcp_swagger/apps.json`

**AudioTranscription `language` description → `lv` example**
- `entities/ai/AudioTranscription.json`
- `swagger/ai/generic_ai.json`
- `mcp_swagger/ai.json`

### Verification
- All 9 JSON files parse-validated

### Note
Sales `payment_gateway` has the same locale enum but is owned by Sales (out of scope). The widget `DisplayNameDto` lists `sl` but not `lv`; this PR adds `lv` only — reconciling `sl` in source is tracked as an open question on the ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)