### PR TITLE
docs(app-business-mapping): add object reference

### DIFF
--- a/entities/apps/md/appBusinessMapping.md
+++ b/entities/apps/md/appBusinessMapping.md
@@ -1,0 +1,33 @@
+## AppBusinessMapping
+
+Maps a vcita business to one or more third-party application identifiers for a specific integrated app. Used by partner-facing tooling to associate an SMB with external app identifiers (e.g., a Yext business and user code for app_code_name "yext").
+
+## Properties
+
+| Name | Description | Type | Required |
+| --- | --- | --- | --- |
+| uid | Unique identifier for the app business mapping record (e.g., "abm_7f2e8d9a1b4c"). | string |  |
+| business_uid | Unique identifier of the vcita business being mapped (e.g., "d290f1ee6c544b01"). | string | Yes |
+| directory_uid | Unique identifier of the directory (partner) that owns this mapping (e.g., "dir_partner_xyz"). | string |  |
+| app_code_name | Code name of the third-party integrated app this mapping applies to (e.g., "yext"). | string | Yes |
+| mapped_business_uid | Third-party business identifier for the mapped business in the external app (e.g., "yext-business-id-42"). | string | Yes |
+| mapped_user_uid | Optional third-party user identifier for the mapped business in the external app (e.g., "yext-user-code-42" or null). | string |  |
+| created_at | The date and time when the mapping was created, in ISO 8601 format (e.g., "2026-06-10T10:30:00Z"). | string |  |
+| updated_at | The date and time when the mapping was last updated, in ISO 8601 format (e.g., "2026-06-10T10:30:00Z"). | string |  |
+
+## Example
+
+JSON
+
+```json
+{
+  "uid": "abm_7f2e8d9a1b4c",
+  "business_uid": "d290f1ee6c544b01",
+  "directory_uid": "dir_partner_xyz",
+  "app_code_name": "yext",
+  "mapped_business_uid": "yext-business-id-42",
+  "mapped_user_uid": "yext-user-code-42",
+  "created_at": "2026-06-10T10:30:00Z",
+  "updated_at": "2026-06-10T10:30:00Z"
+}
+```


### PR DESCRIPTION
Generated the AppBusinessMapping object reference from `entities/apps/appBusinessMapping.json` via `npm run gen:entity -- appBusinessMapping`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)