### PR TITLE
VCITA2-14180 docs: add can_edit/can_delete to ClientNote entity

### DIFF
--- a/.cursor/rules/v3-guidelines.mdc
+++ b/.cursor/rules/v3-guidelines.mdc
@@ -59,8 +59,6 @@ extensible shape across endpoints and avoids colliding with the Roles & Permissi
 Rules:
 - Name the object `capabilities`; mark it `readOnly` (output-only — never in request schemas).
 - Keys are **action verbs** the client can take (e.g. `update`, `delete`).
-  Prefer positive verbs — do **not** use a `readonly` flag (an action is a capability;
-  "read only" is a derived UI state).
 - Each property is a boolean; document its effect (e.g. "when false, an update is
   rejected with HTTP 403").
 - Expose only the actions the entity actually supports; add more over time without

--- a/.cursor/rules/v3-guidelines.mdc
+++ b/.cursor/rules/v3-guidelines.mdc
@@ -47,3 +47,37 @@ Only allow the following tokens to be documented:
 Internal is our documentation for Admin token
 Staff is sometimes mentioned in the code as Application User
 Directory is sometimes mentioned in the code as Applications
+
+## Capabilities (per-actor abilities)
+
+When an entity needs to tell the client what the **requesting actor** may do with a
+specific resource (so the UI can render read-only state, hide actions, etc.), expose
+a `capabilities` object rather than ad-hoc `can_*` fields. This keeps a single,
+extensible shape across endpoints and avoids colliding with the Roles & Permissions
+("permissions") vocabulary.
+
+Rules:
+- Name the object `capabilities`; mark it `readOnly` (output-only — never in request schemas).
+- Keys are **action verbs** the client can take: `create`, `read`, `update`, `delete`,
+  and domain actions like `share`, `export`. Prefer positive verbs — do **not** use a
+  `readonly` flag (an action is a capability; "read only" is a derived UI state).
+- Each property is a boolean; document its effect (e.g. "when false, an update is
+  rejected with HTTP 403").
+- Expose only the actions the entity actually supports; add more over time without
+  breaking clients.
+
+Example (see `entities/clients/client_note.json`):
+
+```json
+"capabilities": {
+  "type": "object",
+  "readOnly": true,
+  "description": "The requesting staff member's capabilities on this entity, computed server-side. Output-only.",
+  "properties": {
+    "update": { "type": "boolean", "description": "Whether the requester may edit this resource. When false, an update is rejected with HTTP 403." },
+    "delete": { "type": "boolean", "description": "Whether the requester may delete this resource. When false, a delete is rejected with HTTP 403." }
+  }
+}
+```
+
+Runtime payload: `"capabilities": { "update": true, "delete": false }`.

--- a/.cursor/rules/v3-guidelines.mdc
+++ b/.cursor/rules/v3-guidelines.mdc
@@ -58,9 +58,9 @@ extensible shape across endpoints and avoids colliding with the Roles & Permissi
 
 Rules:
 - Name the object `capabilities`; mark it `readOnly` (output-only — never in request schemas).
-- Keys are **action verbs** the client can take: `create`, `read`, `update`, `delete`,
-  and domain actions like `share`, `export`. Prefer positive verbs — do **not** use a
-  `readonly` flag (an action is a capability; "read only" is a derived UI state).
+- Keys are **action verbs** the client can take (e.g. `update`, `delete`, `x`, `y`).
+  Prefer positive verbs — do **not** use a `readonly` flag (an action is a capability;
+  "read only" is a derived UI state).
 - Each property is a boolean; document its effect (e.g. "when false, an update is
   rejected with HTTP 403").
 - Expose only the actions the entity actually supports; add more over time without

--- a/.cursor/rules/v3-guidelines.mdc
+++ b/.cursor/rules/v3-guidelines.mdc
@@ -58,7 +58,7 @@ extensible shape across endpoints and avoids colliding with the Roles & Permissi
 
 Rules:
 - Name the object `capabilities`; mark it `readOnly` (output-only — never in request schemas).
-- Keys are **action verbs** the client can take (e.g. `update`, `delete`, `x`, `y`).
+- Keys are **action verbs** the client can take (e.g. `update`, `delete`).
   Prefer positive verbs — do **not** use a `readonly` flag (an action is a capability;
   "read only" is a derived UI state).
 - Each property is a boolean; document its effect (e.g. "when false, an update is

--- a/entities/clients/client_note.json
+++ b/entities/clients/client_note.json
@@ -59,6 +59,14 @@
       ],
       "description": "Status of the AI summary generation process. Possible values: in_progress (summary is currently being generated, wait before retrying), generated (summary completed successfully and is up-to-date), skipped (summary generation was not performed - user requested skip, content too short, or AI rejected), failed (error during generation). Null indicates a legacy note created before this feature or a note that hasn't been evaluated for summary generation yet."
     },
+    "can_edit": {
+      "type": "boolean",
+      "description": "Whether the staff member making the request is permitted to edit this note. Computed server-side from the same rules that gate the update endpoint (note author, organization-wide activity access, marketing permissions, or staff on the related entity). When false, an update request is rejected with HTTP 403."
+    },
+    "can_delete": {
+      "type": "boolean",
+      "description": "Whether the staff member making the request is permitted to delete this note. Computed server-side using the same rules as can_edit. When false, a delete request is rejected with HTTP 403."
+    },
     "created_at": {
       "type": "string",
       "format": "date-time",
@@ -79,6 +87,8 @@
     "entity_title",
     "summary",
     "summary_status",
+    "can_edit",
+    "can_delete",
     "created_at",
     "updated_at"
   ],
@@ -109,6 +119,8 @@
     "entity_title": "Quick one",
     "summary": "Brief discussion about scheduling matters",
     "summary_status": "generated",
+    "can_edit": true,
+    "can_delete": true,
     "created_at": "2026-04-01T07:00:23Z",
     "updated_at": "2026-04-01T07:00:23Z"
   }

--- a/entities/clients/client_note.json
+++ b/entities/clients/client_note.json
@@ -59,13 +59,19 @@
       ],
       "description": "Status of the AI summary generation process. Possible values: in_progress (summary is currently being generated, wait before retrying), generated (summary completed successfully and is up-to-date), skipped (summary generation was not performed - user requested skip, content too short, or AI rejected), failed (error during generation). Null indicates a legacy note created before this feature or a note that hasn't been evaluated for summary generation yet."
     },
-    "can_edit": {
-      "type": "boolean",
-      "description": "Whether the staff member making the request is permitted to edit this note. Computed server-side from the same rules that gate the update endpoint (note author, organization-wide activity access, marketing permissions, or staff on the related entity). When false, an update request is rejected with HTTP 403."
-    },
-    "can_delete": {
-      "type": "boolean",
-      "description": "Whether the staff member making the request is permitted to delete this note. Computed server-side using the same rules as can_edit. When false, a delete request is rejected with HTTP 403."
+    "capabilities": {
+      "type": "object",
+      "description": "The requesting staff member's capabilities on this note, computed server-side. Output-only; clients should render UI (read-only state, hidden actions) from these flags rather than re-deriving permission rules. Extensible — additional action capabilities may be added over time without breaking existing clients.",
+      "properties": {
+        "update": {
+          "type": "boolean",
+          "description": "Whether the requesting staff member may edit this note. When false, an update request is rejected with HTTP 403. Derived from the note edit rules: note author, organization-wide activity access, marketing permissions, or staff on the related entity."
+        },
+        "delete": {
+          "type": "boolean",
+          "description": "Whether the requesting staff member may delete this note. When false, a delete request is rejected with HTTP 403. Uses the same rules as update."
+        }
+      }
     },
     "created_at": {
       "type": "string",
@@ -87,8 +93,7 @@
     "entity_title",
     "summary",
     "summary_status",
-    "can_edit",
-    "can_delete",
+    "capabilities",
     "created_at",
     "updated_at"
   ],
@@ -119,8 +124,10 @@
     "entity_title": "Quick one",
     "summary": "Brief discussion about scheduling matters",
     "summary_status": "generated",
-    "can_edit": true,
-    "can_delete": true,
+    "capabilities": {
+      "update": true,
+      "delete": true
+    },
     "created_at": "2026-04-01T07:00:23Z",
     "updated_at": "2026-04-01T07:00:23Z"
   }


### PR DESCRIPTION
## What

Part of [VCITA2-14180](https://myvcita.atlassian.net/browse/VCITA2-14180) — documents the `can_edit` / `can_delete` fields now returned on the v3 `ClientNote` entity.

Both are read-only booleans computed server-side from the same permission gate that guards `update` / `destroy`, letting clients render the Edit modal read-only and hide the delete action without re-deriving the rules. A denied write still returns **HTTP 403**.

Kept in sync with the core API change ([vcita/core#28940](https://github.com/vcita/core/pull/28940)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[VCITA2-14180]: https://myvcita.atlassian.net/browse/VCITA2-14180?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ