### PR TITLE
VCITA2-14233: Extend AIRecommendation entity & API for Pulse Items

### DIFF
--- a/entities/ai/AIRecommendation.json
+++ b/entities/ai/AIRecommendation.json
@@ -7,7 +7,7 @@
       },
       "producer": {
         "type": "string",
-        "description": "Upstream agent or partner system that produced this recommendation (for example: 'client_agent', 'lead_capture_agent')."
+        "description": "Upstream agent or partner system that produced this recommendation (for example: 'client_agent', 'lead_capture_agent', 'partner_x')."
       },
       "business_uid": {
         "type": "string",
@@ -25,15 +25,21 @@
       },
       "category": {
         "type": "string",
-        "enum": ["needs_attention", "opportunity", "fyi"],
+        "enum": ["needs_attention", "opportunity"],
         "default": "needs_attention",
-        "description": "The recommendation category proposed by the producer, used for categorization in the interface: 'needs_attention' (requires the user's attention), 'opportunity' (a potential value opportunity), or 'fyi' (informational only)."
+        "description": "The recommendation category proposed by the producer, used for categorization in the interface: 'needs_attention' (requires the user's attention) or 'opportunity' (a potential value opportunity)."
       },
       "priority": {
         "type": "string",
         "enum": ["high", "standard"],
         "default": "standard",
         "description": "Relative ordering priority within the same category: 'high' (higher priority, surfaced first) or 'standard' (default priority)."
+      },
+      "execution_policy": {
+        "type": "string",
+        "enum": ["auto_execute", "requires_human_approval"],
+        "default": "requires_human_approval",
+        "description": "Defines whether this recommendation is auto-executed by an agent or requires human review before execution: 'auto_execute' (may be executed automatically by the system or an authorized agent) or 'requires_human_approval' (must be reviewed and approved by a human before execution)."
       },
       "tags": {
         "type": "array",
@@ -147,6 +153,7 @@
       "updated_at": "2025-02-04T12:30:00Z",
       "category": "needs_attention",
       "priority": "high",
+      "execution_policy": "requires_human_approval",
       "tags": ["Hot lead"],
       "due_at": "2026-06-08T09:00:00Z",
       "actions": [

--- a/entities/ai/AIRecommendation.json
+++ b/entities/ai/AIRecommendation.json
@@ -27,7 +27,7 @@
         "type": "string",
         "enum": ["needs_attention", "opportunity"],
         "default": "needs_attention",
-        "description": "The recommendation category proposed by the producer, used for categorization in the interface: 'needs_attention' (requires the user's attention) or 'opportunity' (a potential value opportunity)."
+        "description": "Recommendation category set by the producer for interface use: 'needs_attention' (time-sensitive and requires the user's attention) or 'opportunity' (growth-focused value opportunity that does not require immediate action)."
       },
       "priority": {
         "type": "string",
@@ -39,7 +39,7 @@
         "type": "string",
         "enum": ["auto_execute", "requires_human_approval"],
         "default": "requires_human_approval",
-        "description": "Defines whether this recommendation is auto-executed by an agent or requires human review before execution: 'auto_execute' (may be executed automatically by the system or an authorized agent) or 'requires_human_approval' (must be reviewed and approved by a human before execution)."
+        "description": "Indicates whether this recommendation is auto-executed by an agent or requires human review: 'auto_execute' (may be executed automatically by the system or an authorized agent) or 'requires_human_approval' (must be reviewed and approved by a human before execution)."
       },
       "tags": {
         "type": "array",

--- a/entities/ai/AIRecommendation.json
+++ b/entities/ai/AIRecommendation.json
@@ -5,6 +5,14 @@
         "type": "string",
         "description": "A unique identifier for the recommendation."
       },
+      "producer": {
+        "type": "string",
+        "description": "Upstream agent or partner system that produced this recommendation (for example: 'client_agent', 'lead_capture_agent')."
+      },
+      "business_uid": {
+        "type": "string",
+        "description": "The unique identifier (UID) of the business that owns this recommendation. Automatically set based on the authenticated token."
+      },
       "created_at": {
         "type": "string",
         "format": "date-time",
@@ -14,6 +22,36 @@
         "type": "string",
         "format": "date-time",
         "description": "The timestamp when the recommendation was last updated, in ISO 8601 format."
+      },
+      "category": {
+        "type": "string",
+        "enum": ["needs_attention", "opportunity", "fyi"],
+        "default": "needs_attention",
+        "description": "The recommendation category proposed by the producer, used for categorization in the interface: 'needs_attention' (requires the user's attention), 'opportunity' (a potential value opportunity), or 'fyi' (informational only)."
+      },
+      "priority": {
+        "type": "string",
+        "enum": ["high", "standard"],
+        "default": "standard",
+        "description": "Relative ordering priority within the same category: 'high' (higher priority, surfaced first) or 'standard' (default priority)."
+      },
+      "tags": {
+        "type": "array",
+        "maxItems": 10,
+        "description": "Optional user-facing tags that label the item's urgency, value, or context (for example: 'Hot lead', 'New', 'High value', 'Urgent', 'At risk', 'Follow up').",
+        "items": {
+          "type": "string"
+        }
+      },
+      "due_at": {
+        "type": "string",
+        "format": "date-time",
+        "description": "Optional due or target time used for urgency and upcoming behavior, in ISO 8601 format."
+      },
+      "expired_at": {
+        "type": "string",
+        "format": "date-time",
+        "description": "Optional expiry time used for dismissing or clearing the recommendation, in ISO 8601 format."
       },
       "actions": {
         "type": "array",
@@ -44,7 +82,11 @@
             "type": "string",
             "description": "The type of context (e.g., 'matter','client', 'business').",
             "enum": ["matter","client", "business"]
-            }
+            },
+          "context_name": {
+            "type": "string",
+            "description": "The display name of the context object (referenced by 'context_uid') this recommendation is about, according to its 'context_type' - for example, the client's name when 'context_type' is 'client' (e.g., 'John Smith')."
+          }
         }
       },
       "target": {
@@ -64,7 +106,19 @@
       },
       "status": {
         "type": "object",
+        "description": "Current lifecycle status of this recommendation, including the source of the latest status update.",
         "properties":{
+            "state": {
+                "type": "string",
+                "enum": ["active", "completed", "dismissed", "approved", "snoozed"],
+                "default": "active",
+                "description": "Lifecycle state of the recommendation: 'active' (available and not yet completed), 'completed' (executed successfully or otherwise resolved), 'dismissed' (explicitly dismissed without resolving the underlying need), 'approved' (approved by the user but not yet at a terminal outcome), or 'snoozed' (deferred to a later time or trigger condition)."
+            },
+            "state_source_type": {
+                "type": "string",
+                "enum": ["user", "system"],
+                "description": "Source of the current status: 'user' (change via Pulse UI) or 'system' (change by the originating service or agent)."
+            },
             "dismissed": {
                 "type": "boolean",
                 "description": "Indicates whether the recommendation has been dismissed."
@@ -87,8 +141,14 @@
     ],
     "example": {
       "uid": "rec-123",
+      "producer": "client_agent",
+      "business_uid": "biz-1234abcd",
       "created_at": "2025-02-04T12:00:00Z",
       "updated_at": "2025-02-04T12:30:00Z",
+      "category": "needs_attention",
+      "priority": "high",
+      "tags": ["Hot lead"],
+      "due_at": "2026-06-08T09:00:00Z",
       "actions": [
         {
           "uid": "act-456",
@@ -106,13 +166,16 @@
       ],
       "context": {
         "context_uid": "ctx-456",
-        "context_type": "client"
+        "context_type": "client",
+        "context_name": "John Smith"
       },
       "target": {
         "target_actor_uid": "staff-789",
         "target_actor_type": "staff"
       },
-      "status":{ 
+      "status":{
+        "state": "active",
+        "state_source_type": "system",
         "dismissed": false,
         "dismissed_source_type": "user"
   },

--- a/entities/ai/AIRecommendedAction.json
+++ b/entities/ai/AIRecommendedAction.json
@@ -8,8 +8,8 @@
       },
       "action": {
         "type": "string",
-        "enum": ["reply", "estimate", "schedule"],
-        "description": "The type of action recommended. Possible values:\n- 'reply': Suggests responding to a user message.\n- 'estimate': Suggests providing a price estimate.\n- 'schedule': Suggests scheduling an appointment or meeting."
+        "enum": ["reply", "estimate", "schedule", "acknowledge"],
+        "description": "The type of action recommended. Possible values:\n- 'reply': Suggests responding to a user message.\n- 'estimate': Suggests providing a price estimate.\n- 'schedule': Suggests scheduling an appointment or meeting.\n- 'acknowledge': No action or artifact is prepared; the user reviews the item and then completes or dismisses it."
       },
       "display": {
         "type": "object",

--- a/swagger/ai/recommendations.json
+++ b/swagger/ai/recommendations.json
@@ -313,7 +313,7 @@
               "opportunity"
             ],
             "default": "needs_attention",
-            "description": "The recommendation category proposed by the producer, used for categorization in the interface: 'needs_attention' (requires the user's attention) or 'opportunity' (a potential value opportunity)."
+            "description": "Recommendation category set by the producer for interface use: 'needs_attention' (time-sensitive and requires the user's attention) or 'opportunity' (growth-focused value opportunity that does not require immediate action)."
           },
           "priority": {
             "type": "string",
@@ -331,7 +331,7 @@
               "requires_human_approval"
             ],
             "default": "requires_human_approval",
-            "description": "Defines whether this recommendation is auto-executed by an agent or requires human review before execution: 'auto_execute' (may be executed automatically by the system or an authorized agent) or 'requires_human_approval' (must be reviewed and approved by a human before execution)."
+            "description": "Indicates whether this recommendation is auto-executed by an agent or requires human review: 'auto_execute' (may be executed automatically by the system or an authorized agent) or 'requires_human_approval' (must be reviewed and approved by a human before execution)."
           },
           "tags": {
             "type": "array",

--- a/swagger/ai/recommendations.json
+++ b/swagger/ai/recommendations.json
@@ -26,12 +26,47 @@
         ],
         "parameters": [
           {
+            "name": "page",
+            "in": "query",            "description": "Page number of results.",
+            "schema": {
+              "type": "number",
+              "minimum": 1,
+              "maximum": 10000,
+              "default": 1
+            }
+          },
+          {
+            "name": "per_page",
+            "in": "query",            "description": "How many items to return per page. Max: 100",
+            "schema": {
+              "type": "number",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 25
+            }
+          },
+          {
+            "name": "sort",
+            "in": "query",            "description": "Sort by fields. Example: sort=created_at:asc,updated_at:desc",
+            "schema": {
+              "type": "string",
+              "default": "updated_at:desc"
+            }
+          },
+          {
             "name": "status",
             "in": "query",
             "schema": {
-              "type": "string"
+              "type": "string",
+              "enum": [
+                "active",
+                "completed",
+                "dismissed",
+                "approved",
+                "snoozed"
+              ]
             },
-            "description": "Filter by recommendation status."
+            "description": "Filter by recommendation lifecycle state: 'active', 'completed', 'dismissed', 'approved', or 'snoozed'."
           },
           {
             "name": "target",
@@ -48,6 +83,42 @@
               "type": "string"
             },
             "description": "Filter by context UID."
+          },
+          {
+            "name": "category",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "needs_attention",
+                "opportunity",
+                "fyi",
+                "upcoming"
+              ]
+            },
+            "description": "Filter by recommendation category: 'needs_attention', 'opportunity', or 'fyi'. 'upcoming' is a derived filter (not a stored category value): it returns recommendations of any category whose 'due_at' is in the future."
+          },
+          {
+            "name": "producer",
+            "in": "query",            "schema": {
+              "type": "string"
+            },
+            "description": "Filter by the record's 'producer' (creation source). When omitted, only legacy records with an empty 'producer' are returned (default). Pass 'any' to return only records that have a non-empty 'producer', or pass a specific producer value (for example: 'client_agent') to return only records from that producer."
+          },
+          {
+            "name": "include",
+            "in": "query",            "description": "Comma-separated list of optional data sets to include in the response, beyond the recommendations list. Supported values: 'counts' (adds per-category totals under 'meta.counts'). When omitted, no extra data is returned and 'meta' is absent.",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "counts"
+                ]
+              }
+            }
           }
         ],
         "responses": {
@@ -65,6 +136,34 @@
                         "data": {
                           "type": "object",
                           "$ref": "#/components/schemas/AIRecommendationList"
+                        },
+                        "meta": {
+                          "type": "object",
+                          "description": "Additional response metadata not tied to the returned page of recommendations. Present only when requested via the 'include' query parameter.",
+                          "properties": {
+                            "counts": {
+                              "type": "object",
+                              "description": "Returned only when 'include=counts' is requested. Number of recommendations per bucket across the full set matching every query filter except 'category' (that is: 'target', 'context', 'status', and 'producer' are all applied; 'category' is intentionally ignored). This lets the caller show how many items exist in each category regardless of the category currently being requested. The counts are computed scope-wide - they are also independent of pagination, so they reflect totals even for buckets not present in the returned page. Every matching recommendation is counted in exactly one bucket (no overlap): any recommendation whose 'due_at' is in the future is counted under 'upcoming' regardless of its stored category, and the remaining buckets count their category excluding those future-dated items.",
+                              "properties": {
+                                "needs_attention": {
+                                  "type": "integer",
+                                  "description": "Recommendations with category 'needs_attention' whose 'due_at' is in the past, now, or absent."
+                                },
+                                "upcoming": {
+                                  "type": "integer",
+                                  "description": "Recommendations whose 'due_at' is in the future, regardless of stored category. Derived bucket - these are excluded from their category's count."
+                                },
+                                "opportunity": {
+                                  "type": "integer",
+                                  "description": "Recommendations with category 'opportunity' whose 'due_at' is in the past, now, or absent."
+                                },
+                                "fyi": {
+                                  "type": "integer",
+                                  "description": "Recommendations with category 'fyi' whose 'due_at' is in the past, now, or absent."
+                                }
+                              }
+                            }
+                          }
                         }
                       }
                     }
@@ -186,6 +285,10 @@
       "AIRecommendationRequest": {
         "type": "object",
         "properties": {
+          "producer": {
+            "type": "string",
+            "description": "Upstream agent or partner system that produced this recommendation (for example: 'client_agent', 'lead_capture_agent')."
+          },
           "actions": {
             "type": "array",
             "description": "A list of recommended actions related to this entity.",
@@ -203,6 +306,43 @@
               }
             }
           },
+          "category": {
+            "type": "string",
+            "enum": [
+              "needs_attention",
+              "opportunity",
+              "fyi"
+            ],
+            "default": "needs_attention",
+            "description": "The recommendation category proposed by the producer, used for categorization in the interface: 'needs_attention' (requires the user's attention), 'opportunity' (a potential value opportunity), or 'fyi' (informational only)."
+          },
+          "priority": {
+            "type": "string",
+            "enum": [
+              "high",
+              "standard"
+            ],
+            "default": "standard",
+            "description": "Relative ordering priority within the same category: 'high' (higher priority, surfaced first) or 'standard' (default priority)."
+          },
+          "tags": {
+            "type": "array",
+            "maxItems": 10,
+            "description": "Optional user-facing tags that label the item's urgency, value, or context (for example: 'Hot lead', 'New', 'High value', 'Urgent', 'At risk', 'Follow up').",
+            "items": {
+              "type": "string"
+            }
+          },
+          "due_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Optional due or target time used for urgency and upcoming behavior, in ISO 8601 format."
+          },
+          "expired_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Optional expiry time used for dismissing or clearing the recommendation, in ISO 8601 format."
+          },
           "context": {
             "type": "object",
             "description": "The context in which the recommendation was generated.",
@@ -219,6 +359,10 @@
                   "client",
                   "business"
                 ]
+              },
+              "context_name": {
+                "type": "string",
+                "description": "The display name of the context object (referenced by 'context_uid') this recommendation is about, according to its 'context_type' - for example, the client's name when 'context_type' is 'client' (e.g., 'John Smith')."
               }
             }
           },
@@ -243,6 +387,26 @@
           "status": {
             "type": "object",
             "properties": {
+              "state": {
+                "type": "string",
+                "enum": [
+                  "active",
+                  "completed",
+                  "dismissed",
+                  "approved",
+                  "snoozed"
+                ],
+                "default": "active",
+                "description": "Lifecycle state of the recommendation: 'active' (available and not yet completed), 'completed' (executed successfully or otherwise resolved), 'dismissed' (explicitly dismissed without resolving the underlying need), 'approved' (approved by the user but not yet at a terminal outcome), or 'snoozed' (deferred to a later time or trigger condition)."
+              },
+              "state_source_type": {
+                "type": "string",
+                "enum": [
+                  "user",
+                  "system"
+                ],
+                "description": "Source of the current status: 'user' (change via Pulse UI) or 'system' (change by the originating service or agent)."
+              },
               "dismissed": {
                 "type": "boolean",
                 "description": "Indicates whether the recommendation has been dismissed."
@@ -275,6 +439,25 @@
           "status": {
             "type": "object",
             "properties": {
+              "state": {
+                "type": "string",
+                "enum": [
+                  "active",
+                  "completed",
+                  "dismissed",
+                  "approved",
+                  "snoozed"
+                ],
+                "description": "Lifecycle state of the recommendation: 'active' (available and not yet completed), 'completed' (executed successfully or otherwise resolved), 'dismissed' (explicitly dismissed without resolving the underlying need), 'approved' (approved by the user but not yet at a terminal outcome), or 'snoozed' (deferred to a later time or trigger condition)."
+              },
+              "state_source_type": {
+                "type": "string",
+                "enum": [
+                  "user",
+                  "system"
+                ],
+                "description": "Source of the current status: 'user' (change via Pulse UI) or 'system' (change by the originating service or agent)."
+              },
               "dismissed": {
                 "type": "boolean",
                 "description": "Indicates whether the recommendation has been dismissed."
@@ -315,9 +498,10 @@
             "enum": [
               "reply",
               "estimate",
-              "schedule"
+              "schedule",
+              "acknowledge"
             ],
-            "description": "The type of action recommended. Possible values:\n- 'reply': Suggests responding to a user message.\n- 'estimate': Suggests providing a price estimate.\n- 'schedule': Suggests scheduling an appointment or meeting."
+            "description": "The type of action recommended. Possible values:\n- 'reply': Suggests responding to a user message.\n- 'estimate': Suggests providing a price estimate.\n- 'schedule': Suggests scheduling an appointment or meeting.\n- 'acknowledge': No action or artifact is prepared; the user reviews the item and then completes or dismisses it."
           },
           "display": {
             "type": "object",

--- a/swagger/ai/recommendations.json
+++ b/swagger/ai/recommendations.json
@@ -27,7 +27,8 @@
         "parameters": [
           {
             "name": "page",
-            "in": "query",            "description": "Page number of results.",
+            "in": "query",
+            "description": "Page number of results.",
             "schema": {
               "type": "number",
               "minimum": 1,
@@ -37,7 +38,8 @@
           },
           {
             "name": "per_page",
-            "in": "query",            "description": "How many items to return per page. Max: 100",
+            "in": "query",
+            "description": "How many items to return per page. Max: 100",
             "schema": {
               "type": "number",
               "minimum": 1,
@@ -47,7 +49,8 @@
           },
           {
             "name": "sort",
-            "in": "query",            "description": "Sort by fields. Example: sort=created_at:asc,updated_at:desc",
+            "in": "query",
+            "description": "Sort by fields. Example: sort=created_at:asc,updated_at:desc",
             "schema": {
               "type": "string",
               "default": "updated_at:desc"
@@ -96,20 +99,20 @@
                 "upcoming"
               ]
             },
-            "description": "Filter by category bucket. Buckets are mutually exclusive; a record maps to exactly one, evaluated in this order: 'upcoming' - records whose 'due_at' is in the future (derived, regardless of stored category); 'fyi' - non-future records whose 'execution_policy' is 'auto_execute' (derived, regardless of stored category); 'needs_attention' / 'opportunity' - records with that stored category, a non-future 'due_at', and 'execution_policy' = 'requires_human_approval'."
+            "description": "Filter by category bucket. Each record belongs to one bucket only, checked in this order:\nupcoming – due_at is in the future (based on time, even if the stored category is different).\nfyi – due_at is not in the future and execution_policy is auto_execute (again, based on fields, not stored category).\nneeds_attention / opportunity – stored category is one of these, due_at is not in the future, and execution_policy is requires_human_approval."
           },
           {
             "name": "producer",
-            "in": "query",            "schema": {
+            "in": "query",
+            "schema": {
               "type": "string"
             },
             "description": "Filter by the record's 'producer' (creation source). When omitted, only legacy records with an empty 'producer' are returned (default). Pass 'any' to return only records that have a non-empty 'producer', or pass a specific producer value (for example: 'client_agent') to return only records from that producer."
           },
           {
             "name": "include",
-            "in": "query",            "description": "Comma-separated list of optional data sets to include in the response, beyond the recommendations list. Supported values: 'counts' (adds per-category totals under 'meta.counts'). When omitted, no extra data is returned and 'meta' is absent.",
-            "style": "form",
-            "explode": false,
+            "in": "query",
+            "description": "Optional data sets to include in the response, beyond the recommendations list. Supported values: 'counts' (adds per-category totals under 'meta.counts'). Repeat the parameter to request multiple. When omitted, no extra data is returned and 'meta' is absent.",
             "schema": {
               "type": "array",
               "items": {

--- a/swagger/ai/recommendations.json
+++ b/swagger/ai/recommendations.json
@@ -96,7 +96,7 @@
                 "upcoming"
               ]
             },
-            "description": "Filter by recommendation category: 'needs_attention', 'opportunity', or 'fyi'. 'upcoming' is a derived filter (not a stored category value): it returns recommendations of any category whose 'due_at' is in the future."
+            "description": "Filter by category bucket. Buckets are mutually exclusive; a record maps to exactly one, evaluated in this order: 'upcoming' - records whose 'due_at' is in the future (derived, regardless of stored category); 'fyi' - non-future records whose 'execution_policy' is 'auto_execute' (derived, regardless of stored category); 'needs_attention' / 'opportunity' - records with that stored category, a non-future 'due_at', and 'execution_policy' = 'requires_human_approval'."
           },
           {
             "name": "producer",
@@ -143,23 +143,23 @@
                           "properties": {
                             "counts": {
                               "type": "object",
-                              "description": "Returned only when 'include=counts' is requested. Number of recommendations per bucket across the full set matching every query filter except 'category' (that is: 'target', 'context', 'status', and 'producer' are all applied; 'category' is intentionally ignored). This lets the caller show how many items exist in each category regardless of the category currently being requested. The counts are computed scope-wide - they are also independent of pagination, so they reflect totals even for buckets not present in the returned page. Every matching recommendation is counted in exactly one bucket (no overlap): any recommendation whose 'due_at' is in the future is counted under 'upcoming' regardless of its stored category, and the remaining buckets count their category excluding those future-dated items.",
+                              "description": "Returned only when 'include=counts' is requested. Number of recommendations per bucket across the full set matching every query filter except 'category' (that is: 'target', 'context', 'status', and 'producer' are all applied; 'category' is intentionally ignored). This lets the caller show how many items exist in each bucket regardless of the category currently being requested. The counts are computed scope-wide - they are also independent of pagination, so they reflect totals even for buckets not present in the returned page. Every matching recommendation is counted in exactly one bucket (no overlap), evaluated in this order: future 'due_at' -> 'upcoming'; else 'execution_policy' = 'auto_execute' -> 'fyi'; else by stored category -> 'needs_attention' or 'opportunity'.",
                               "properties": {
                                 "needs_attention": {
                                   "type": "integer",
-                                  "description": "Recommendations with category 'needs_attention' whose 'due_at' is in the past, now, or absent."
+                                  "description": "Recommendations with stored category 'needs_attention', a non-future 'due_at', and 'execution_policy' = 'requires_human_approval'."
                                 },
                                 "upcoming": {
                                   "type": "integer",
-                                  "description": "Recommendations whose 'due_at' is in the future, regardless of stored category. Derived bucket - these are excluded from their category's count."
+                                  "description": "Recommendations whose 'due_at' is in the future, regardless of stored category. Derived bucket - these are excluded from every other bucket."
                                 },
                                 "opportunity": {
                                   "type": "integer",
-                                  "description": "Recommendations with category 'opportunity' whose 'due_at' is in the past, now, or absent."
+                                  "description": "Recommendations with stored category 'opportunity', a non-future 'due_at', and 'execution_policy' = 'requires_human_approval'."
                                 },
                                 "fyi": {
                                   "type": "integer",
-                                  "description": "Recommendations with category 'fyi' whose 'due_at' is in the past, now, or absent."
+                                  "description": "Non-future recommendations whose 'execution_policy' is 'auto_execute', regardless of stored category. Derived bucket."
                                 }
                               }
                             }
@@ -287,7 +287,7 @@
         "properties": {
           "producer": {
             "type": "string",
-            "description": "Upstream agent or partner system that produced this recommendation (for example: 'client_agent', 'lead_capture_agent')."
+            "description": "Upstream agent or partner system that produced this recommendation (for example: 'client_agent', 'lead_capture_agent', 'partner_x')."
           },
           "actions": {
             "type": "array",
@@ -310,11 +310,10 @@
             "type": "string",
             "enum": [
               "needs_attention",
-              "opportunity",
-              "fyi"
+              "opportunity"
             ],
             "default": "needs_attention",
-            "description": "The recommendation category proposed by the producer, used for categorization in the interface: 'needs_attention' (requires the user's attention), 'opportunity' (a potential value opportunity), or 'fyi' (informational only)."
+            "description": "The recommendation category proposed by the producer, used for categorization in the interface: 'needs_attention' (requires the user's attention) or 'opportunity' (a potential value opportunity)."
           },
           "priority": {
             "type": "string",
@@ -324,6 +323,15 @@
             ],
             "default": "standard",
             "description": "Relative ordering priority within the same category: 'high' (higher priority, surfaced first) or 'standard' (default priority)."
+          },
+          "execution_policy": {
+            "type": "string",
+            "enum": [
+              "auto_execute",
+              "requires_human_approval"
+            ],
+            "default": "requires_human_approval",
+            "description": "Defines whether this recommendation is auto-executed by an agent or requires human review before execution: 'auto_execute' (may be executed automatically by the system or an authorized agent) or 'requires_human_approval' (must be reviewed and approved by a human before execution)."
           },
           "tags": {
             "type": "array",


### PR DESCRIPTION
## Overview
Extends the `AIRecommendation` entity and its create/update/list APIs to support Pulse Items, per the HLR ([Confluence](https://myvcita.atlassian.net/wiki/spaces/SG/pages/4717740033)).

## Entity (`AIRecommendation`)
- New fields: `producer`, `business_uid`, `category`, `priority`, `execution_policy`, `tags`, `due_at`, `expired_at`, `context.context_name`, `status.state`, `status.state_source_type`.
- `category` stored values: `needs_attention` / `opportunity`.
- `execution_policy`: `auto_execute` / `requires_human_approval` (default `requires_human_approval`).
- `AIRecommendedAction.action` enum gains `acknowledge`.

## Create request (`POST /v3/ai/ai_recommendations`)
Accepts most of the new producer-settable fields: `producer`, `category`, `priority`, `execution_policy`, `tags`, `due_at`, `expired_at`, `context.context_name`, and `status.state` / `status.state_source_type` — plus the existing `actions`, `display`, `context`, `target`. (`business_uid` is auto-set from the token; `uid` is server-assigned, so neither is in the request.)

## Update request (`PUT /v3/ai/ai_recommendations/{uid}`)
Currently limited to `status` — adds `status.state` and `status.state_source_type` (alongside the existing `dismissed` / `dismissed_source_type`).

## List API (`GET /v3/ai/ai_recommendations`)
- Pagination: `page` / `per_page` / `sort`.
- Filters: `status` (enum), `category` (bucketed), `producer` (legacy vs producer-generated).
- Opt-in `meta.counts` via `include=counts` — per-bucket totals (`needs_attention`, `upcoming`, `fyi`, `opportunity`), scope-wide, mutually exclusive, pagination- and `category`-filter-independent.

## Notes
- `mcp_swagger/ai.json` intentionally not included — it regenerates at deployment.
- Skipped all `TBD` fields from the HLR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)