### PR TITLE
VCITA2-14500: Document bulk create subscriptions endpoint

### DIFF
--- a/swagger/platform_administration/license.json
+++ b/swagger/platform_administration/license.json
@@ -498,6 +498,34 @@
             }
           }
         }
+      },
+      "BulkCreateSubscriptionsDTO": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/CreateSubscriptionDTO"
+          },
+          {
+            "type": "object",
+            "description": "Request body for creating multiple identical subscriptions of an add-on offering in a single request.",
+            "properties": {
+              "quantity": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 10,
+                "description": "Number of identical subscription lines to create for the offering (e.g., 3)",
+                "example": 3
+              }
+            },
+            "required": [
+              "quantity"
+            ]
+          }
+        ],
+        "example": {
+          "offering_uid": "bc33f12d-98ee-428f-9f65-18bba589cb95",
+          "purchase_currency": "USD",
+          "quantity": 3
+        }
       }
     },
     "securitySchemes": {
@@ -1625,6 +1653,71 @@
         },
         "summary": "Create a Subscription",
         "description": "## Overview\nCreate a new Subscription for a business. Supports discounted and free plans using coupons.\n\nAvailable for **Staff tokens**.\n\n### Token Permissions\n\n| Token Type | Allowed | Restrictions |\n|------------|---------|-------------|\n| **Staff** | Yes | Cannot set custom pricing. For `external` payment type offerings, must use a Staff token created by a Directory token. |\n| **Directory** | No | Must create a Staff token first via `POST /platform/v1/tokens` |\n| **Internal** | No | Must create a Staff token first |\n| **Billing App** | Yes | Cannot set custom pricing |\n| **Regular App** | No | Not allowed |\n\n### Important: External Payment Type Offerings\n\nOfferings with `payment_type = external` require a **Staff token created by a Directory token**:\n\n1. Use `POST /platform/v1/tokens` with a Directory token to create a Staff token for the target business.\n2. Use that Staff token to call this endpoint.\n\nThe `buyer_uid` in the subscription is automatically derived from the authenticated Staff token's identity.",
+        "security": [
+          {
+            "Bearer": []
+          }
+        ],
+        "tags": [
+          "Subscription"
+        ]
+      }
+    },
+    "/license/subscriptions/bulk": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BulkCreateSubscriptionsDTO"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "The list of created Subscriptions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                    },
+                    {
+                      "properties": {
+                        "data": {
+                          "type": "object",
+                          "$ref": "#/components/schemas/SubscriptionList"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Offering is not an add-on or quantity is out of range",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "success": false,
+                  "error": {
+                    "code": "invalid_request",
+                    "message": "Bulk create is only supported for add-on offerings"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "summary": "Bulk Create Subscriptions",
+        "description": "## Overview\nCreate multiple identical Subscriptions for a business in a single request. Supported for **add-on** offerings only (`type = addon`); each created subscription is a separate line (e.g., an offering of 5 staff seats with `quantity = 3` results in 3 subscription lines, 15 staff seats in total).\n\nSubscriptions are created sequentially; if one creation fails, previously created lines are kept and the error is returned.\n\nAvailable for **Staff tokens**.\n\nToken permissions and external payment type behavior are identical to `POST /license/subscriptions`.",
         "security": [
           {
             "Bearer": []


### PR DESCRIPTION
## VCITA2-14500 — Document bulk create subscriptions endpoint

Adds the OpenAPI spec for `POST /license/subscriptions/bulk` (bulk create add-on subscriptions, quantity 1–10) to `swagger/platform_administration/license.json`.

### Related
- Backend — vcita/subscriptionsmng

🎫 https://myvcita.atlassian.net/browse/VCITA2-14500

🤖 Generated with [Claude Code](https://claude.com/claude-code)
