### PR TITLE
docs(license): document offering `rules` (geo_location)

### DIFF
--- a/entities/license/offering.json
+++ b/entities/license/offering.json
@@ -136,7 +136,7 @@
         "description": "A list of tags to be used for reporting purposes. Tags categorize offerings for analytics and billing reports. Common tags include: **base** for standard base offerings; **free** for free tier offerings; **trial** for trial-period offerings; **ghost** for internal/hidden offerings; **business_management** for business management related offerings; **sandbox** for test environment offerings; **core** for core platform offerings.", 
         "example": ["base", "free"]
       },
-      "rules": {
+      "availability_rules": {
         "type": "object",
         "additionalProperties": false,
         "description": "Availability rules for the offering, keyed by rule type. When present, a business only receives this offering as a bundled item if it satisfies every rule (direct subscription and catalog visibility are not gated). Empty or omitted means available everywhere. The only supported rule is `geo_location` (e.g., { \"geo_location\": { \"allow\": [\"US\"], \"deny\": [] } }).",
@@ -204,7 +204,7 @@
       "trial_type": "no_trial",
       "trial_period": 0,
       "reporting_tags": ["base", "no_payments"],
-      "rules": {
+      "availability_rules": {
         "geo_location": {
           "allow": ["US"],
           "deny": []

--- a/entities/license/offering.json
+++ b/entities/license/offering.json
@@ -135,6 +135,40 @@
         },
         "description": "A list of tags to be used for reporting purposes. Tags categorize offerings for analytics and billing reports. Common tags include: **base** for standard base offerings; **free** for free tier offerings; **trial** for trial-period offerings; **ghost** for internal/hidden offerings; **business_management** for business management related offerings; **sandbox** for test environment offerings; **core** for core platform offerings.", 
         "example": ["base", "free"]
+      },
+      "rules": {
+        "type": "object",
+        "additionalProperties": false,
+        "description": "Availability rules for the offering, keyed by rule type. When present, a business only receives this offering as a bundled item if it satisfies every rule (direct subscription and catalog visibility are not gated). Empty or omitted means available everywhere. The only supported rule is `geo_location` (e.g., { \"geo_location\": { \"allow\": [\"US\"], \"deny\": [] } }).",
+        "properties": {
+          "geo_location": {
+            "type": "object",
+            "additionalProperties": false,
+            "description": "Restricts the offering by the business's country (ISO 3166-1 alpha-2). `deny` always wins over `allow`; empty lists mean available in every country; an unresolved business country is treated as not-allowed when any restriction is set (fail-closed) (e.g., { \"allow\": [\"US\", \"CA\"], \"deny\": [\"IR\"] }).",
+            "required": [
+              "allow",
+              "deny"
+            ],
+            "properties": {
+              "allow": {
+                "type": "array",
+                "description": "Country codes the offering is available in (e.g., [\"US\", \"CA\"]).",
+                "items": {
+                  "type": "string",
+                  "pattern": "^[A-Z]{2}$"
+                }
+              },
+              "deny": {
+                "type": "array",
+                "description": "Country codes the offering is NOT available in; takes precedence over `allow` (e.g., [\"IR\", \"KP\"]).",
+                "items": {
+                  "type": "string",
+                  "pattern": "^[A-Z]{2}$"
+                }
+              }
+            }
+          }
+        }
       }
     },
     "required": [
@@ -169,7 +203,13 @@
       ],
       "trial_type": "no_trial",
       "trial_period": 0,
-      "reporting_tags": ["base", "no_payments"]
+      "reporting_tags": ["base", "no_payments"],
+      "rules": {
+        "geo_location": {
+          "allow": ["US"],
+          "deny": []
+        }
+      }
     }
   ,
     "description": "An Offering represents a commercial agreement in the inTandem platform, describing the various attributes of the commercial terms, including pricing, type, and additional metadata."

--- a/swagger/platform_administration/license.json
+++ b/swagger/platform_administration/license.json
@@ -212,7 +212,7 @@
               "free"
             ]
           },
-          "rules": {
+          "availability_rules": {
             "type": "object",
             "additionalProperties": false,
             "description": "Optional availability rules for the offering, keyed by rule type. When present, a business only receives this offering as a bundled item if it satisfies every rule (direct subscription and catalog visibility are not gated). Omit it or leave the lists empty to make the offering available everywhere. The only supported rule is `geo_location` (e.g., { \"geo_location\": { \"allow\": [\"US\"], \"deny\": [] } }).",
@@ -355,7 +355,7 @@
               "free"
             ]
           },
-          "rules": {
+          "availability_rules": {
             "type": "object",
             "additionalProperties": false,
             "description": "Optional availability rules for the offering, keyed by rule type. When present, a business only receives this offering as a bundled item if it satisfies every rule (direct subscription and catalog visibility are not gated). Omit it or leave the lists empty to make the offering available everywhere. The only supported rule is `geo_location` (e.g., { \"geo_location\": { \"allow\": [\"US\"], \"deny\": [] } }).",

--- a/swagger/platform_administration/license.json
+++ b/swagger/platform_administration/license.json
@@ -211,6 +211,48 @@
               "base",
               "free"
             ]
+          },
+          "rules": {
+            "type": "object",
+            "additionalProperties": false,
+            "description": "Optional availability rules for the offering, keyed by rule type. When present, a business only receives this offering as a bundled item if it satisfies every rule (direct subscription and catalog visibility are not gated). Omit it or leave the lists empty to make the offering available everywhere. The only supported rule is `geo_location` (e.g., { \"geo_location\": { \"allow\": [\"US\"], \"deny\": [] } }).",
+            "properties": {
+              "geo_location": {
+                "type": "object",
+                "additionalProperties": false,
+                "description": "Restricts the offering by the business's country (ISO 3166-1 alpha-2). `deny` always wins over `allow`; empty `allow` and `deny` means available in every country; a business whose country cannot be resolved is treated as not-allowed whenever a restriction is set (fail-closed) (e.g., { \"allow\": [\"US\", \"CA\"], \"deny\": [\"IR\"] }).",
+                "required": [
+                  "allow",
+                  "deny"
+                ],
+                "properties": {
+                  "allow": {
+                    "type": "array",
+                    "description": "Country codes the offering is available in; empty means no allow-restriction (available everywhere except `deny`) (e.g., [\"US\", \"CA\"]).",
+                    "items": {
+                      "type": "string",
+                      "pattern": "^[A-Z]{2}$"
+                    }
+                  },
+                  "deny": {
+                    "type": "array",
+                    "description": "Country codes the offering is NOT available in; takes precedence over `allow` (e.g., [\"IR\", \"KP\"]).",
+                    "items": {
+                      "type": "string",
+                      "pattern": "^[A-Z]{2}$"
+                    }
+                  }
+                }
+              }
+            },
+            "example": {
+              "geo_location": {
+                "allow": [
+                  "US"
+                ],
+                "deny": []
+              }
+            }
           }
         },
         "required": [
@@ -312,6 +354,48 @@
               "base",
               "free"
             ]
+          },
+          "rules": {
+            "type": "object",
+            "additionalProperties": false,
+            "description": "Optional availability rules for the offering, keyed by rule type. When present, a business only receives this offering as a bundled item if it satisfies every rule (direct subscription and catalog visibility are not gated). Omit it or leave the lists empty to make the offering available everywhere. The only supported rule is `geo_location` (e.g., { \"geo_location\": { \"allow\": [\"US\"], \"deny\": [] } }).",
+            "properties": {
+              "geo_location": {
+                "type": "object",
+                "additionalProperties": false,
+                "description": "Restricts the offering by the business's country (ISO 3166-1 alpha-2). `deny` always wins over `allow`; empty `allow` and `deny` means available in every country; a business whose country cannot be resolved is treated as not-allowed whenever a restriction is set (fail-closed) (e.g., { \"allow\": [\"US\", \"CA\"], \"deny\": [\"IR\"] }).",
+                "required": [
+                  "allow",
+                  "deny"
+                ],
+                "properties": {
+                  "allow": {
+                    "type": "array",
+                    "description": "Country codes the offering is available in; empty means no allow-restriction (available everywhere except `deny`) (e.g., [\"US\", \"CA\"]).",
+                    "items": {
+                      "type": "string",
+                      "pattern": "^[A-Z]{2}$"
+                    }
+                  },
+                  "deny": {
+                    "type": "array",
+                    "description": "Country codes the offering is NOT available in; takes precedence over `allow` (e.g., [\"IR\", \"KP\"]).",
+                    "items": {
+                      "type": "string",
+                      "pattern": "^[A-Z]{2}$"
+                    }
+                  }
+                }
+              }
+            },
+            "example": {
+              "geo_location": {
+                "allow": [
+                  "US"
+                ],
+                "deny": []
+              }
+            }
           }
         },
         "required": [


### PR DESCRIPTION
Add the optional `rules` field to CreateOfferingDTO, UpdateOfferingDTO and the offering entity for POST/PUT/GET /v3/license/offerings: a geo_location rule with allow/deny ISO 3166-1 alpha-2 country lists (deny wins; unknown country fails closed).