### PR TITLE
VCITA2-14500: Bulk create subscriptions returns per-item results

### DIFF
--- a/swagger/platform_administration/license.json
+++ b/swagger/platform_administration/license.json
@@ -299,11 +299,11 @@
             },
             "example": [
               {
-                "price": 5.00,
+                "price": 5.0,
                 "currency": "USD"
               },
               {
-                "price": 4.50,
+                "price": 4.5,
                 "currency": "EUR"
               }
             ]
@@ -609,6 +609,48 @@
           "offering_uid": "bc33f12d-98ee-428f-9f65-18bba589cb95",
           "purchase_currency": "USD",
           "quantity": 3
+        }
+      },
+      "BulkCreateSubscriptionsResult": {
+        "type": "object",
+        "properties": {
+          "subscriptions": {
+            "type": "array",
+            "description": "Array of results for each requested subscription line (all items include a success indicator)",
+            "items": {
+              "type": "object",
+              "required": [
+                "success"
+              ],
+              "properties": {
+                "success": {
+                  "type": "boolean",
+                  "description": "Indicates whether this subscription line was created (e.g., true)"
+                },
+                "data": {
+                  "description": "Subscription data (present only when success is true)",
+                  "$ref": "https://vcita.github.io/developers-hub/entities/license/subscription.json"
+                },
+                "errors": {
+                  "type": "array",
+                  "description": "Error details (present only when success is false)",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "code": {
+                        "type": "string",
+                        "example": "creation_failed"
+                      },
+                      "message": {
+                        "type": "string",
+                        "example": "Failed to create subscription"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -1760,8 +1802,8 @@
           "required": true
         },
         "responses": {
-          "201": {
-            "description": "The list of created Subscriptions",
+          "200": {
+            "description": "Bulk create completed (may contain partial failures). Each requested line is reported independently.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1773,11 +1815,36 @@
                       "properties": {
                         "data": {
                           "type": "object",
-                          "$ref": "#/components/schemas/SubscriptionList"
+                          "$ref": "#/components/schemas/BulkCreateSubscriptionsResult"
                         }
                       }
                     }
                   ]
+                },
+                "example": {
+                  "success": true,
+                  "data": {
+                    "subscriptions": [
+                      {
+                        "success": true,
+                        "data": {
+                          "uid": "3b1c8f2a-2d4e-4a1b-9c77-0a1b2c3d4e5f",
+                          "purchasable_uid": "bc33f12d-98ee-428f-9f65-18bba589cb95",
+                          "purchase_currency": "USD",
+                          "status": "active"
+                        }
+                      },
+                      {
+                        "success": false,
+                        "errors": [
+                          {
+                            "code": "creation_failed",
+                            "message": "Failed to create subscription"
+                          }
+                        ]
+                      }
+                    ]
+                  }
                 }
               }
             }

--- a/swagger/platform_administration/license.json
+++ b/swagger/platform_administration/license.json
@@ -1828,10 +1828,29 @@
                       {
                         "success": true,
                         "data": {
-                          "uid": "3b1c8f2a-2d4e-4a1b-9c77-0a1b2c3d4e5f",
-                          "purchasable_uid": "bc33f12d-98ee-428f-9f65-18bba589cb95",
+                          "uid": "368659c8-64b7-4b53-ba13-d6260e61268c",
+                          "display_name": "1 Staff Seat",
+                          "buyer_uid": "oi5dcvf685t1563x",
+                          "business_uid": "4c3ls2gmlq786muz",
                           "purchase_currency": "USD",
-                          "status": "active"
+                          "purchase_price": 10,
+                          "purchase_state": "purchased",
+                          "cancellation_date": null,
+                          "expiration_date": null,
+                          "created_at": "2026-04-29T13:56:58.123Z",
+                          "updated_at": "2026-04-29T13:56:58.123Z",
+                          "payment_type": "monthly",
+                          "bundled_from_subscription_uid": null,
+                          "is_active": true,
+                          "offering_uid": "bc33f12d-98ee-428f-9f65-18bba589cb95",
+                          "trial_type": "no_trial",
+                          "trial_period": 0,
+                          "offering_type": "addon",
+                          "charged_by": "partner",
+                          "quantity": 1,
+                          "sku": "staff_slot",
+                          "original_price": null,
+                          "coupon_code": null
                         }
                       },
                       {


### PR DESCRIPTION
## Summary
Aligns `POST /v3/license/subscriptions/bulk` with the org bulk convention (mirrors `PUT /v3/clients/client_settings/bulk`).

**Before:** `201` returning `SubscriptionList` (a flat list of created subscriptions).

**After:** `200` (partial-failure tolerant) returning per-subscription results:
```jsonc
{ "success": true, "data": { "subscriptions": [
  { "success": true,  "data": { /* subscription */ } },
  { "success": false, "errors": [{ "code": "creation_failed", "message": "…" }] }
] } }
```

Changes in `swagger/platform_administration/license.json`:
- New `BulkCreateSubscriptionsResult` component schema (per-item `{ success, data | errors }`, `data` refs the `license/subscription` entity).
- Bulk `post` response reshaped `201`→`200` with the partial-failure description + example; `400` (offering not add-on / quantity out of range) preserved.

`mcp_swagger/` intentionally not edited — it is regenerated from `swagger/` by CI.

Implements the contract shipped in subscriptionsmng PRs #1171 (master) / #1172 (integration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)