### PR TITLE
Flatten external $ref URLs in mcp_swagger into inline JSON

### DIFF
--- a/mcp_swagger/ai.json
+++ b/mcp_swagger/ai.json
@@ -162,7 +162,50 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
@@ -235,12 +278,366 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/ai/AIRecommendation.json"
+                          "type": "object",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "description": "A unique identifier for the recommendation."
+                            },
+                            "producer": {
+                              "type": "string",
+                              "description": "Upstream agent or partner system that produced this recommendation (for example: 'client_agent', 'lead_capture_agent', 'partner_x')."
+                            },
+                            "business_uid": {
+                              "type": "string",
+                              "description": "The unique identifier (UID) of the business that owns this recommendation. Automatically set based on the authenticated token."
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "description": "The timestamp when the recommendation was created, in ISO 8601 format."
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "description": "The timestamp when the recommendation was last updated, in ISO 8601 format."
+                            },
+                            "category": {
+                              "type": "string",
+                              "enum": [
+                                "needs_attention",
+                                "opportunity"
+                              ],
+                              "default": "needs_attention",
+                              "description": "Recommendation category set by the producer for interface use: 'needs_attention' (time-sensitive and requires the user's attention) or 'opportunity' (growth-focused value opportunity that does not require immediate action)."
+                            },
+                            "priority": {
+                              "type": "string",
+                              "enum": [
+                                "high",
+                                "standard"
+                              ],
+                              "default": "standard",
+                              "description": "Relative ordering priority within the same category: 'high' (higher priority, surfaced first) or 'standard' (default priority)."
+                            },
+                            "execution_policy": {
+                              "type": "string",
+                              "enum": [
+                                "auto_execute",
+                                "requires_human_approval"
+                              ],
+                              "default": "requires_human_approval",
+                              "description": "Indicates whether this recommendation is auto-executed by an agent or requires human review: 'auto_execute' (may be executed automatically by the system or an authorized agent) or 'requires_human_approval' (must be reviewed and approved by a human before execution)."
+                            },
+                            "tags": {
+                              "type": "array",
+                              "maxItems": 10,
+                              "description": "Optional user-facing tags that label the item's urgency, value, or context (for example: 'Hot lead', 'New', 'High value', 'Urgent', 'At risk', 'Follow up').",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "due_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "description": "Optional due or target time used for urgency and upcoming behavior, in ISO 8601 format."
+                            },
+                            "expired_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "description": "Optional expiry time used for dismissing or clearing the recommendation, in ISO 8601 format."
+                            },
+                            "actions": {
+                              "type": "array",
+                              "description": "A list of recommended actions related to this entity.",
+                              "items": {
+                                "type": "object",
+                                "description": "Represents a recommended action based on AI analysis.",
+                                "properties": {
+                                  "uid": {
+                                    "type": "string",
+                                    "description": "A unique identifier for the recommended action."
+                                  },
+                                  "action": {
+                                    "type": "string",
+                                    "enum": [
+                                      "reply",
+                                      "estimate",
+                                      "schedule",
+                                      "acknowledge"
+                                    ],
+                                    "description": "The type of action recommended. Possible values:\n- 'reply': Suggests responding to a user message.\n- 'estimate': Suggests providing a price estimate.\n- 'schedule': Suggests scheduling an appointment or meeting.\n- 'acknowledge': No action or artifact is prepared; the user reviews the item and then completes or dismisses it."
+                                  },
+                                  "display": {
+                                    "type": "object",
+                                    "description": "Contains display-related information for the recommendation.",
+                                    "properties": {
+                                      "btn_text": {
+                                        "type": "string",
+                                        "description": "A human-readable title describing the recommendation."
+                                      }
+                                    }
+                                  },
+                                  "reason": {
+                                    "type": "string",
+                                    "description": "The reason why this action is recommended, providing context for decision-making."
+                                  },
+                                  "payload": {
+                                    "type": "object",
+                                    "description": "Additional data related to the recommended action. The structure depends on the action type."
+                                  },
+                                  "evidence": {
+                                    "type": "array",
+                                    "description": "A list of supporting statements or facts justifying the recommendation.",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "context": {
+                                    "type": "object",
+                                    "description": "The context in which the recommendation was generated.",
+                                    "properties": {
+                                      "context_uid": {
+                                        "type": "string",
+                                        "description": "A unique identifier for the context associated with this recommendation."
+                                      },
+                                      "context_type": {
+                                        "type": "string",
+                                        "description": "The type of context (e.g., 'matter','client', 'business').",
+                                        "enum": [
+                                          "matter",
+                                          "client",
+                                          "business"
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  "confidence": {
+                                    "type": "number",
+                                    "description": "A confidence score (0-1) indicating how confident the AI is in this recommendation."
+                                  }
+                                },
+                                "required": [
+                                  "uid",
+                                  "action"
+                                ],
+                                "example": {
+                                  "uid": "act-456",
+                                  "action": "reply",
+                                  "display": {
+                                    "btn_text": "Generate Reply"
+                                  },
+                                  "reason": "User needs clarification on pricing",
+                                  "evidence": [
+                                    "User asked for price estimate"
+                                  ],
+                                  "payload": {
+                                    "message": "Hi please send some more details"
+                                  },
+                                  "context": {
+                                    "context_uid": "ctx-456",
+                                    "context_type": "client"
+                                  }
+                                }
+                              }
+                            },
+                            "display": {
+                              "type": "object",
+                              "description": "Contains display-related information for the recommendation.",
+                              "properties": {
+                                "title": {
+                                  "type": "string",
+                                  "description": "A human-readable title describing the recommendation."
+                                }
+                              }
+                            },
+                            "context": {
+                              "type": "object",
+                              "description": "The context in which the recommendation was generated.",
+                              "properties": {
+                                "context_uid": {
+                                  "type": "string",
+                                  "description": "A unique identifier for the context associated with this recommendation."
+                                },
+                                "context_type": {
+                                  "type": "string",
+                                  "description": "The type of context (e.g., 'matter','client', 'business').",
+                                  "enum": [
+                                    "matter",
+                                    "client",
+                                    "business"
+                                  ]
+                                },
+                                "context_name": {
+                                  "type": "string",
+                                  "description": "The display name of the context object (referenced by 'context_uid') this recommendation is about, according to its 'context_type' - for example, the client's name when 'context_type' is 'client' (e.g., 'John Smith')."
+                                }
+                              }
+                            },
+                            "target": {
+                              "type": "object",
+                              "description": "The target entity for this recommendation, typically representing the user or business involved.",
+                              "properties": {
+                                "target_actor_uid": {
+                                  "type": "string",
+                                  "description": "A unique identifier for the target actor (e.g., a user or business)."
+                                },
+                                "target_actor_type": {
+                                  "type": "string",
+                                  "description": "The type of target actor (e.g., 'staff','directory').",
+                                  "enum": [
+                                    "staff",
+                                    "directory"
+                                  ]
+                                }
+                              }
+                            },
+                            "status": {
+                              "type": "object",
+                              "description": "Current lifecycle status of this recommendation, including the source of the latest status update.",
+                              "properties": {
+                                "state": {
+                                  "type": "string",
+                                  "enum": [
+                                    "active",
+                                    "completed",
+                                    "dismissed",
+                                    "approved",
+                                    "snoozed"
+                                  ],
+                                  "default": "active",
+                                  "description": "Lifecycle state of the recommendation: 'active' (available and not yet completed), 'completed' (executed successfully or otherwise resolved), 'dismissed' (explicitly dismissed without resolving the underlying need), 'approved' (approved by the user but not yet at a terminal outcome), or 'snoozed' (deferred to a later time or trigger condition)."
+                                },
+                                "state_source_type": {
+                                  "type": "string",
+                                  "enum": [
+                                    "user",
+                                    "system"
+                                  ],
+                                  "description": "Source of the current status: 'user' (change via Pulse UI) or 'system' (change by the originating service or agent)."
+                                },
+                                "dismissed": {
+                                  "type": "boolean",
+                                  "description": "Indicates whether the recommendation has been dismissed."
+                                },
+                                "dismissed_source_type": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ],
+                                  "enum": [
+                                    "user",
+                                    "system",
+                                    null
+                                  ],
+                                  "description": "The source that dismissed the recommendation. Null when the recommendation has not been dismissed."
+                                }
+                              }
+                            }
+                          },
+                          "required": [
+                            "uid",
+                            "actions",
+                            "display",
+                            "context",
+                            "target",
+                            "status"
+                          ],
+                          "example": {
+                            "uid": "rec-123",
+                            "producer": "client_agent",
+                            "business_uid": "biz-1234abcd",
+                            "created_at": "2025-02-04T12:00:00Z",
+                            "updated_at": "2025-02-04T12:30:00Z",
+                            "category": "needs_attention",
+                            "priority": "high",
+                            "execution_policy": "requires_human_approval",
+                            "tags": [
+                              "Hot lead"
+                            ],
+                            "due_at": "2026-06-08T09:00:00Z",
+                            "actions": [
+                              {
+                                "uid": "act-456",
+                                "action": "reply",
+                                "reason": "Clarification needed",
+                                "display": {
+                                  "btn_text": "Generate Reply"
+                                },
+                                "evidence": [
+                                  "User asked for price estimate"
+                                ],
+                                "payload": {
+                                  "message": "Hi, I can provide you with a roofing estimate. Please provide me with the address and any other relevant details."
+                                },
+                                "confidence": 0.85
+                              }
+                            ],
+                            "context": {
+                              "context_uid": "ctx-456",
+                              "context_type": "client",
+                              "context_name": "John Smith"
+                            },
+                            "target": {
+                              "target_actor_uid": "staff-789",
+                              "target_actor_type": "staff"
+                            },
+                            "status": {
+                              "state": "active",
+                              "state_source_type": "system",
+                              "dismissed": false,
+                              "dismissed_source_type": "user"
+                            },
+                            "description": "An AI-generated recommendation with context, target, actions, and status metadata."
+                          }
                         }
                       }
                     }
@@ -292,12 +689,366 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/ai/AIRecommendation.json"
+                          "type": "object",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "description": "A unique identifier for the recommendation."
+                            },
+                            "producer": {
+                              "type": "string",
+                              "description": "Upstream agent or partner system that produced this recommendation (for example: 'client_agent', 'lead_capture_agent', 'partner_x')."
+                            },
+                            "business_uid": {
+                              "type": "string",
+                              "description": "The unique identifier (UID) of the business that owns this recommendation. Automatically set based on the authenticated token."
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "description": "The timestamp when the recommendation was created, in ISO 8601 format."
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "description": "The timestamp when the recommendation was last updated, in ISO 8601 format."
+                            },
+                            "category": {
+                              "type": "string",
+                              "enum": [
+                                "needs_attention",
+                                "opportunity"
+                              ],
+                              "default": "needs_attention",
+                              "description": "Recommendation category set by the producer for interface use: 'needs_attention' (time-sensitive and requires the user's attention) or 'opportunity' (growth-focused value opportunity that does not require immediate action)."
+                            },
+                            "priority": {
+                              "type": "string",
+                              "enum": [
+                                "high",
+                                "standard"
+                              ],
+                              "default": "standard",
+                              "description": "Relative ordering priority within the same category: 'high' (higher priority, surfaced first) or 'standard' (default priority)."
+                            },
+                            "execution_policy": {
+                              "type": "string",
+                              "enum": [
+                                "auto_execute",
+                                "requires_human_approval"
+                              ],
+                              "default": "requires_human_approval",
+                              "description": "Indicates whether this recommendation is auto-executed by an agent or requires human review: 'auto_execute' (may be executed automatically by the system or an authorized agent) or 'requires_human_approval' (must be reviewed and approved by a human before execution)."
+                            },
+                            "tags": {
+                              "type": "array",
+                              "maxItems": 10,
+                              "description": "Optional user-facing tags that label the item's urgency, value, or context (for example: 'Hot lead', 'New', 'High value', 'Urgent', 'At risk', 'Follow up').",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "due_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "description": "Optional due or target time used for urgency and upcoming behavior, in ISO 8601 format."
+                            },
+                            "expired_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "description": "Optional expiry time used for dismissing or clearing the recommendation, in ISO 8601 format."
+                            },
+                            "actions": {
+                              "type": "array",
+                              "description": "A list of recommended actions related to this entity.",
+                              "items": {
+                                "type": "object",
+                                "description": "Represents a recommended action based on AI analysis.",
+                                "properties": {
+                                  "uid": {
+                                    "type": "string",
+                                    "description": "A unique identifier for the recommended action."
+                                  },
+                                  "action": {
+                                    "type": "string",
+                                    "enum": [
+                                      "reply",
+                                      "estimate",
+                                      "schedule",
+                                      "acknowledge"
+                                    ],
+                                    "description": "The type of action recommended. Possible values:\n- 'reply': Suggests responding to a user message.\n- 'estimate': Suggests providing a price estimate.\n- 'schedule': Suggests scheduling an appointment or meeting.\n- 'acknowledge': No action or artifact is prepared; the user reviews the item and then completes or dismisses it."
+                                  },
+                                  "display": {
+                                    "type": "object",
+                                    "description": "Contains display-related information for the recommendation.",
+                                    "properties": {
+                                      "btn_text": {
+                                        "type": "string",
+                                        "description": "A human-readable title describing the recommendation."
+                                      }
+                                    }
+                                  },
+                                  "reason": {
+                                    "type": "string",
+                                    "description": "The reason why this action is recommended, providing context for decision-making."
+                                  },
+                                  "payload": {
+                                    "type": "object",
+                                    "description": "Additional data related to the recommended action. The structure depends on the action type."
+                                  },
+                                  "evidence": {
+                                    "type": "array",
+                                    "description": "A list of supporting statements or facts justifying the recommendation.",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "context": {
+                                    "type": "object",
+                                    "description": "The context in which the recommendation was generated.",
+                                    "properties": {
+                                      "context_uid": {
+                                        "type": "string",
+                                        "description": "A unique identifier for the context associated with this recommendation."
+                                      },
+                                      "context_type": {
+                                        "type": "string",
+                                        "description": "The type of context (e.g., 'matter','client', 'business').",
+                                        "enum": [
+                                          "matter",
+                                          "client",
+                                          "business"
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  "confidence": {
+                                    "type": "number",
+                                    "description": "A confidence score (0-1) indicating how confident the AI is in this recommendation."
+                                  }
+                                },
+                                "required": [
+                                  "uid",
+                                  "action"
+                                ],
+                                "example": {
+                                  "uid": "act-456",
+                                  "action": "reply",
+                                  "display": {
+                                    "btn_text": "Generate Reply"
+                                  },
+                                  "reason": "User needs clarification on pricing",
+                                  "evidence": [
+                                    "User asked for price estimate"
+                                  ],
+                                  "payload": {
+                                    "message": "Hi please send some more details"
+                                  },
+                                  "context": {
+                                    "context_uid": "ctx-456",
+                                    "context_type": "client"
+                                  }
+                                }
+                              }
+                            },
+                            "display": {
+                              "type": "object",
+                              "description": "Contains display-related information for the recommendation.",
+                              "properties": {
+                                "title": {
+                                  "type": "string",
+                                  "description": "A human-readable title describing the recommendation."
+                                }
+                              }
+                            },
+                            "context": {
+                              "type": "object",
+                              "description": "The context in which the recommendation was generated.",
+                              "properties": {
+                                "context_uid": {
+                                  "type": "string",
+                                  "description": "A unique identifier for the context associated with this recommendation."
+                                },
+                                "context_type": {
+                                  "type": "string",
+                                  "description": "The type of context (e.g., 'matter','client', 'business').",
+                                  "enum": [
+                                    "matter",
+                                    "client",
+                                    "business"
+                                  ]
+                                },
+                                "context_name": {
+                                  "type": "string",
+                                  "description": "The display name of the context object (referenced by 'context_uid') this recommendation is about, according to its 'context_type' - for example, the client's name when 'context_type' is 'client' (e.g., 'John Smith')."
+                                }
+                              }
+                            },
+                            "target": {
+                              "type": "object",
+                              "description": "The target entity for this recommendation, typically representing the user or business involved.",
+                              "properties": {
+                                "target_actor_uid": {
+                                  "type": "string",
+                                  "description": "A unique identifier for the target actor (e.g., a user or business)."
+                                },
+                                "target_actor_type": {
+                                  "type": "string",
+                                  "description": "The type of target actor (e.g., 'staff','directory').",
+                                  "enum": [
+                                    "staff",
+                                    "directory"
+                                  ]
+                                }
+                              }
+                            },
+                            "status": {
+                              "type": "object",
+                              "description": "Current lifecycle status of this recommendation, including the source of the latest status update.",
+                              "properties": {
+                                "state": {
+                                  "type": "string",
+                                  "enum": [
+                                    "active",
+                                    "completed",
+                                    "dismissed",
+                                    "approved",
+                                    "snoozed"
+                                  ],
+                                  "default": "active",
+                                  "description": "Lifecycle state of the recommendation: 'active' (available and not yet completed), 'completed' (executed successfully or otherwise resolved), 'dismissed' (explicitly dismissed without resolving the underlying need), 'approved' (approved by the user but not yet at a terminal outcome), or 'snoozed' (deferred to a later time or trigger condition)."
+                                },
+                                "state_source_type": {
+                                  "type": "string",
+                                  "enum": [
+                                    "user",
+                                    "system"
+                                  ],
+                                  "description": "Source of the current status: 'user' (change via Pulse UI) or 'system' (change by the originating service or agent)."
+                                },
+                                "dismissed": {
+                                  "type": "boolean",
+                                  "description": "Indicates whether the recommendation has been dismissed."
+                                },
+                                "dismissed_source_type": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ],
+                                  "enum": [
+                                    "user",
+                                    "system",
+                                    null
+                                  ],
+                                  "description": "The source that dismissed the recommendation. Null when the recommendation has not been dismissed."
+                                }
+                              }
+                            }
+                          },
+                          "required": [
+                            "uid",
+                            "actions",
+                            "display",
+                            "context",
+                            "target",
+                            "status"
+                          ],
+                          "example": {
+                            "uid": "rec-123",
+                            "producer": "client_agent",
+                            "business_uid": "biz-1234abcd",
+                            "created_at": "2025-02-04T12:00:00Z",
+                            "updated_at": "2025-02-04T12:30:00Z",
+                            "category": "needs_attention",
+                            "priority": "high",
+                            "execution_policy": "requires_human_approval",
+                            "tags": [
+                              "Hot lead"
+                            ],
+                            "due_at": "2026-06-08T09:00:00Z",
+                            "actions": [
+                              {
+                                "uid": "act-456",
+                                "action": "reply",
+                                "reason": "Clarification needed",
+                                "display": {
+                                  "btn_text": "Generate Reply"
+                                },
+                                "evidence": [
+                                  "User asked for price estimate"
+                                ],
+                                "payload": {
+                                  "message": "Hi, I can provide you with a roofing estimate. Please provide me with the address and any other relevant details."
+                                },
+                                "confidence": 0.85
+                              }
+                            ],
+                            "context": {
+                              "context_uid": "ctx-456",
+                              "context_type": "client",
+                              "context_name": "John Smith"
+                            },
+                            "target": {
+                              "target_actor_uid": "staff-789",
+                              "target_actor_type": "staff"
+                            },
+                            "status": {
+                              "state": "active",
+                              "state_source_type": "system",
+                              "dismissed": false,
+                              "dismissed_source_type": "user"
+                            },
+                            "description": "An AI-generated recommendation with context, target, actions, and status metadata."
+                          }
                         }
                       }
                     }
@@ -377,7 +1128,50 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
@@ -514,7 +1308,50 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
@@ -616,12 +1453,209 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/ai/BusinessRule.json"
+                          "type": "object",
+                          "description": "Represents a business rule that guides AI behavior for a specific business. Rules are organized by category (tone of voice, business policies, things to avoid, FAQ) and can be AI-generated (system) or user-created. For FAQ category rules, the metadata contains structured question and answer fields extracted from the content. Rules can be activated, deactivated, or held in a pending approval state.",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "readOnly": true,
+                              "description": "The unique identifier (UID) of the business rule (e.g., \"br-a1b2c3d4-5678-90ef-ghij-klmnopqrstuv\"). Assigned automatically by the system upon creation."
+                            },
+                            "business_uid": {
+                              "type": "string",
+                              "readOnly": true,
+                              "description": "The unique identifier (UID) of the business that owns this rule (e.g., \"biz-1234abcd-5678-90ef-ghij-klmnopqrstuv\"). Automatically set based on the authenticated token."
+                            },
+                            "content": {
+                              "type": "string",
+                              "description": "The content or text of the business rule (e.g., \"Always use a friendly and professional tone when communicating with clients\"). For FAQ rules, this typically contains both the question and answer in a combined format."
+                            },
+                            "status": {
+                              "type": "string",
+                              "description": "The current status of the business rule, controlling whether the AI agent actively uses it.\n\n* `active` - The rule is currently in effect and will be used by the AI agent.\n* `pending_approval` - The rule has been suggested (typically by the system) and is awaiting staff review before becoming active.\n* `inactive` - The rule has been deactivated and will not be used by the AI agent.",
+                              "enum": [
+                                "active",
+                                "pending_approval",
+                                "inactive"
+                              ]
+                            },
+                            "source": {
+                              "type": "string",
+                              "readOnly": true,
+                              "description": "Indicates whether the rule was created by the AI system or by a user (staff member).\n\n* `system` - The rule was generated automatically by the AI based on analysis of business conversations.\n* `user` - The rule was manually created or edited by a staff member.",
+                              "enum": [
+                                "system",
+                                "user"
+                              ]
+                            },
+                            "created_by_staff_uid": {
+                              "type": "string",
+                              "readOnly": true,
+                              "description": "The UID of the staff member who created the rule (e.g., \"stf-9876wxyz-5432-10ab-cdef-ghijklmnopqr\"). Will be null for system-generated rules that have not been manually edited.",
+                              "nullable": true
+                            },
+                            "updated_by_staff_uid": {
+                              "type": "string",
+                              "readOnly": true,
+                              "description": "The UID of the staff member who last updated the rule (e.g., \"stf-9876wxyz-5432-10ab-cdef-ghijklmnopqr\"). Will be null if the rule has never been updated by a staff member.",
+                              "nullable": true
+                            },
+                            "sort_order": {
+                              "type": "integer",
+                              "description": "Sort order for displaying rules within a category (e.g., 0). Lower values appear first. Rules within the same category are ordered by this field in ascending order."
+                            },
+                            "metadata": {
+                              "type": "object",
+                              "description": "Additional metadata associated with the rule. For FAQ rules, includes structured `question` and `answer` fields. For system-generated rules, may include `confidence`, `reasoning`, and `evidence` from the AI analysis.",
+                              "nullable": true,
+                              "properties": {
+                                "question": {
+                                  "type": "string",
+                                  "description": "The question part of an FAQ rule (e.g., \"What are your business hours?\"). Only present for rules with category `faq`."
+                                },
+                                "answer": {
+                                  "type": "string",
+                                  "description": "The answer part of an FAQ rule (e.g., \"We are open Monday to Friday, 9 AM to 5 PM.\"). Only present for rules with category `faq`."
+                                },
+                                "confidence": {
+                                  "type": "number",
+                                  "description": "AI confidence score ranging from 0.0 to 1.0 indicating how confident the system is about this rule (e.g., 0.92). Only present for system-generated rules."
+                                },
+                                "reasoning": {
+                                  "type": "string",
+                                  "description": "AI-generated reasoning explaining why this rule was created or suggested (e.g., \"Consistent friendly tone observed across 15 client conversations\"). Only present for system-generated rules."
+                                },
+                                "evidence": {
+                                  "type": "array",
+                                  "description": "Evidence from conversations that supports this rule. Contains quotes and references from actual client-staff interactions.",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "client_uid": {
+                                        "type": "string",
+                                        "description": "The UID of the client involved in the conversation."
+                                      },
+                                      "message_uid": {
+                                        "type": "string",
+                                        "description": "The UID of the specific message used as evidence."
+                                      },
+                                      "quote": {
+                                        "type": "string",
+                                        "description": "A direct quote from the conversation used as evidence."
+                                      },
+                                      "speaker": {
+                                        "type": "string",
+                                        "enum": [
+                                          "staff",
+                                          "client"
+                                        ],
+                                        "description": "Identifies whether the quote is from a staff member or a client.\n\n* `staff` - The quote is from a staff member.\n* `client` - The quote is from a client."
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "readOnly": true,
+                              "description": "The date and time when the business rule was created, in ISO 8601 format (e.g., \"2024-12-15T10:30:00.000Z\")."
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "readOnly": true,
+                              "description": "The date and time when the business rule was last updated, in ISO 8601 format (e.g., \"2024-12-16T14:00:00.000Z\")."
+                            },
+                            "category_code": {
+                              "type": "string",
+                              "description": "The category of the business rule. Determines how the AI agent uses this rule.\n\n* `tone_of_voice` - Rules about communication style, language, and tone the AI should adopt when interacting with clients.\n* `policies_and_info` - Rules about business operations, pricing, scheduling policies, and other operational guidelines.\n* `things_to_avoid` - Rules about topics, phrases, or actions the AI should not mention or perform.\n* `faq` - Frequently asked questions and their answers. When this category is used, the metadata field should contain structured `question` and `answer` fields.\n* `client_facing_bot_policies` - Rules specifically for client-facing bot interactions, defining bot behavior, limitations, and escalation policies.",
+                              "enum": [
+                                "tone_of_voice",
+                                "policies_and_info",
+                                "things_to_avoid",
+                                "faq",
+                                "client_facing_bot_policies"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "uid",
+                            "business_uid",
+                            "category_code",
+                            "content",
+                            "status",
+                            "source",
+                            "sort_order",
+                            "created_at",
+                            "updated_at"
+                          ],
+                          "example": {
+                            "uid": "br-a1b2c3d4-5678-90ef-ghij-klmnopqrstuv",
+                            "business_uid": "biz-1234abcd-5678-90ef-ghij-klmnopqrstuv",
+                            "content": "Always use a friendly and professional tone when communicating with clients",
+                            "status": "active",
+                            "source": "system",
+                            "created_by_staff_uid": "stf-9876wxyz-5432-10ab-cdef-ghijklmnopqr",
+                            "updated_by_staff_uid": null,
+                            "sort_order": 0,
+                            "metadata": {
+                              "confidence": 0.92,
+                              "reasoning": "Consistent friendly tone observed across 15 client conversations"
+                            },
+                            "created_at": "2024-12-15T10:30:00.000Z",
+                            "updated_at": "2024-12-15T10:30:00.000Z",
+                            "category_code": "tone_of_voice"
+                          }
                         }
                       }
                     }
@@ -768,7 +1802,50 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
@@ -849,12 +1926,151 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/ai/BusinessRuleHistory.json"
+                          "type": "object",
+                          "description": "Represents a historical record of a change made to a business rule. Each time a rule is created, updated, or deleted, a history entry is recorded capturing the state of the rule at that point in time, who made the change, and what type of change it was. This provides a full audit trail for business rule management.",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "readOnly": true,
+                              "description": "The unique identifier (UID) of the history record (e.g., \"hist-a1b2c3d4-e5f6-7890-abcd-ef1234567890\"). Assigned automatically by the system."
+                            },
+                            "rule_uid": {
+                              "type": "string",
+                              "readOnly": true,
+                              "description": "The UID of the business rule this history entry belongs to (e.g., \"br-a1b2c3d4-5678-90ef-ghij-klmnopqrstuv\"). Links back to the original business rule."
+                            },
+                            "business_uid": {
+                              "type": "string",
+                              "readOnly": true,
+                              "description": "The unique identifier (UID) of the business that owns the rule (e.g., \"biz-1234abcd-5678-90ef-ghij-klmnopqrstuv\")."
+                            },
+                            "content": {
+                              "type": "string",
+                              "description": "The content of the rule at the time of the change (e.g., \"Always use a friendly and professional tone when communicating with clients\"). This captures the exact state of the rule content when the history entry was recorded."
+                            },
+                            "source": {
+                              "type": "string",
+                              "description": "Indicates whether the change was made by the AI system or by a user (staff member).\n\n* `system` - The change was made automatically by the AI system.\n* `user` - The change was made manually by a staff member.",
+                              "enum": [
+                                "system",
+                                "user"
+                              ]
+                            },
+                            "action": {
+                              "type": "string",
+                              "description": "The type of change that was made to the business rule.\n\n* `created` - The rule was newly created.\n* `updated` - The rule's content, category, status, or other fields were modified.\n* `deleted` - The rule was removed.",
+                              "enum": [
+                                "created",
+                                "updated",
+                                "deleted"
+                              ]
+                            },
+                            "changed_by_staff_uid": {
+                              "type": "string",
+                              "description": "The UID of the staff member who made the change (e.g., \"stf-9876wxyz-5432-10ab-cdef-ghijklmnopqr\"). Will be null if the change was made by the system automatically.",
+                              "nullable": true
+                            },
+                            "changed_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "description": "The date and time when the change was made, in ISO 8601 format (e.g., \"2024-12-16T14:30:00.000Z\")."
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "readOnly": true,
+                              "description": "The date and time when the history record was created, in ISO 8601 format (e.g., \"2024-12-16T14:30:00.000Z\")."
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "readOnly": true,
+                              "description": "The date and time when the history record was last updated, in ISO 8601 format (e.g., \"2024-12-16T14:30:00.000Z\")."
+                            },
+                            "category_code": {
+                              "type": "string",
+                              "description": "The category of the business rule at the time of the change.\n\n* `tone_of_voice` - Rules about communication style, language, and tone the AI should adopt.\n* `policies_and_info` - Rules about business operations, pricing, and scheduling policies.\n* `things_to_avoid` - Rules about topics, phrases, or actions the AI should not mention or perform.\n* `faq` - Frequently asked questions and their answers.",
+                              "enum": [
+                                "tone_of_voice",
+                                "policies_and_info",
+                                "things_to_avoid",
+                                "faq"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "uid",
+                            "rule_uid",
+                            "business_uid",
+                            "category_code",
+                            "content",
+                            "source",
+                            "action",
+                            "changed_at",
+                            "created_at",
+                            "updated_at"
+                          ],
+                          "example": {
+                            "uid": "hist-a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                            "rule_uid": "br-a1b2c3d4-5678-90ef-ghij-klmnopqrstuv",
+                            "business_uid": "biz-1234abcd-5678-90ef-ghij-klmnopqrstuv",
+                            "content": "Always use a friendly and professional tone when communicating with clients",
+                            "source": "user",
+                            "action": "updated",
+                            "changed_by_staff_uid": "stf-9876wxyz-5432-10ab-cdef-ghijklmnopqr",
+                            "changed_at": "2024-12-16T14:30:00.000Z",
+                            "created_at": "2024-12-16T14:30:00.000Z",
+                            "updated_at": "2024-12-16T14:30:00.000Z",
+                            "category_code": "tone_of_voice"
+                          }
                         }
                       }
                     }
@@ -949,12 +2165,209 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/ai/BusinessRule.json"
+                          "type": "object",
+                          "description": "Represents a business rule that guides AI behavior for a specific business. Rules are organized by category (tone of voice, business policies, things to avoid, FAQ) and can be AI-generated (system) or user-created. For FAQ category rules, the metadata contains structured question and answer fields extracted from the content. Rules can be activated, deactivated, or held in a pending approval state.",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "readOnly": true,
+                              "description": "The unique identifier (UID) of the business rule (e.g., \"br-a1b2c3d4-5678-90ef-ghij-klmnopqrstuv\"). Assigned automatically by the system upon creation."
+                            },
+                            "business_uid": {
+                              "type": "string",
+                              "readOnly": true,
+                              "description": "The unique identifier (UID) of the business that owns this rule (e.g., \"biz-1234abcd-5678-90ef-ghij-klmnopqrstuv\"). Automatically set based on the authenticated token."
+                            },
+                            "content": {
+                              "type": "string",
+                              "description": "The content or text of the business rule (e.g., \"Always use a friendly and professional tone when communicating with clients\"). For FAQ rules, this typically contains both the question and answer in a combined format."
+                            },
+                            "status": {
+                              "type": "string",
+                              "description": "The current status of the business rule, controlling whether the AI agent actively uses it.\n\n* `active` - The rule is currently in effect and will be used by the AI agent.\n* `pending_approval` - The rule has been suggested (typically by the system) and is awaiting staff review before becoming active.\n* `inactive` - The rule has been deactivated and will not be used by the AI agent.",
+                              "enum": [
+                                "active",
+                                "pending_approval",
+                                "inactive"
+                              ]
+                            },
+                            "source": {
+                              "type": "string",
+                              "readOnly": true,
+                              "description": "Indicates whether the rule was created by the AI system or by a user (staff member).\n\n* `system` - The rule was generated automatically by the AI based on analysis of business conversations.\n* `user` - The rule was manually created or edited by a staff member.",
+                              "enum": [
+                                "system",
+                                "user"
+                              ]
+                            },
+                            "created_by_staff_uid": {
+                              "type": "string",
+                              "readOnly": true,
+                              "description": "The UID of the staff member who created the rule (e.g., \"stf-9876wxyz-5432-10ab-cdef-ghijklmnopqr\"). Will be null for system-generated rules that have not been manually edited.",
+                              "nullable": true
+                            },
+                            "updated_by_staff_uid": {
+                              "type": "string",
+                              "readOnly": true,
+                              "description": "The UID of the staff member who last updated the rule (e.g., \"stf-9876wxyz-5432-10ab-cdef-ghijklmnopqr\"). Will be null if the rule has never been updated by a staff member.",
+                              "nullable": true
+                            },
+                            "sort_order": {
+                              "type": "integer",
+                              "description": "Sort order for displaying rules within a category (e.g., 0). Lower values appear first. Rules within the same category are ordered by this field in ascending order."
+                            },
+                            "metadata": {
+                              "type": "object",
+                              "description": "Additional metadata associated with the rule. For FAQ rules, includes structured `question` and `answer` fields. For system-generated rules, may include `confidence`, `reasoning`, and `evidence` from the AI analysis.",
+                              "nullable": true,
+                              "properties": {
+                                "question": {
+                                  "type": "string",
+                                  "description": "The question part of an FAQ rule (e.g., \"What are your business hours?\"). Only present for rules with category `faq`."
+                                },
+                                "answer": {
+                                  "type": "string",
+                                  "description": "The answer part of an FAQ rule (e.g., \"We are open Monday to Friday, 9 AM to 5 PM.\"). Only present for rules with category `faq`."
+                                },
+                                "confidence": {
+                                  "type": "number",
+                                  "description": "AI confidence score ranging from 0.0 to 1.0 indicating how confident the system is about this rule (e.g., 0.92). Only present for system-generated rules."
+                                },
+                                "reasoning": {
+                                  "type": "string",
+                                  "description": "AI-generated reasoning explaining why this rule was created or suggested (e.g., \"Consistent friendly tone observed across 15 client conversations\"). Only present for system-generated rules."
+                                },
+                                "evidence": {
+                                  "type": "array",
+                                  "description": "Evidence from conversations that supports this rule. Contains quotes and references from actual client-staff interactions.",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "client_uid": {
+                                        "type": "string",
+                                        "description": "The UID of the client involved in the conversation."
+                                      },
+                                      "message_uid": {
+                                        "type": "string",
+                                        "description": "The UID of the specific message used as evidence."
+                                      },
+                                      "quote": {
+                                        "type": "string",
+                                        "description": "A direct quote from the conversation used as evidence."
+                                      },
+                                      "speaker": {
+                                        "type": "string",
+                                        "enum": [
+                                          "staff",
+                                          "client"
+                                        ],
+                                        "description": "Identifies whether the quote is from a staff member or a client.\n\n* `staff` - The quote is from a staff member.\n* `client` - The quote is from a client."
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "readOnly": true,
+                              "description": "The date and time when the business rule was created, in ISO 8601 format (e.g., \"2024-12-15T10:30:00.000Z\")."
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "readOnly": true,
+                              "description": "The date and time when the business rule was last updated, in ISO 8601 format (e.g., \"2024-12-16T14:00:00.000Z\")."
+                            },
+                            "category_code": {
+                              "type": "string",
+                              "description": "The category of the business rule. Determines how the AI agent uses this rule.\n\n* `tone_of_voice` - Rules about communication style, language, and tone the AI should adopt when interacting with clients.\n* `policies_and_info` - Rules about business operations, pricing, scheduling policies, and other operational guidelines.\n* `things_to_avoid` - Rules about topics, phrases, or actions the AI should not mention or perform.\n* `faq` - Frequently asked questions and their answers. When this category is used, the metadata field should contain structured `question` and `answer` fields.\n* `client_facing_bot_policies` - Rules specifically for client-facing bot interactions, defining bot behavior, limitations, and escalation policies.",
+                              "enum": [
+                                "tone_of_voice",
+                                "policies_and_info",
+                                "things_to_avoid",
+                                "faq",
+                                "client_facing_bot_policies"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "uid",
+                            "business_uid",
+                            "category_code",
+                            "content",
+                            "status",
+                            "source",
+                            "sort_order",
+                            "created_at",
+                            "updated_at"
+                          ],
+                          "example": {
+                            "uid": "br-a1b2c3d4-5678-90ef-ghij-klmnopqrstuv",
+                            "business_uid": "biz-1234abcd-5678-90ef-ghij-klmnopqrstuv",
+                            "content": "Always use a friendly and professional tone when communicating with clients",
+                            "status": "active",
+                            "source": "system",
+                            "created_by_staff_uid": "stf-9876wxyz-5432-10ab-cdef-ghijklmnopqr",
+                            "updated_by_staff_uid": null,
+                            "sort_order": 0,
+                            "metadata": {
+                              "confidence": 0.92,
+                              "reasoning": "Consistent friendly tone observed across 15 client conversations"
+                            },
+                            "created_at": "2024-12-15T10:30:00.000Z",
+                            "updated_at": "2024-12-15T10:30:00.000Z",
+                            "category_code": "tone_of_voice"
+                          }
                         }
                       }
                     }
@@ -1060,12 +2473,209 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/ai/BusinessRule.json"
+                          "type": "object",
+                          "description": "Represents a business rule that guides AI behavior for a specific business. Rules are organized by category (tone of voice, business policies, things to avoid, FAQ) and can be AI-generated (system) or user-created. For FAQ category rules, the metadata contains structured question and answer fields extracted from the content. Rules can be activated, deactivated, or held in a pending approval state.",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "readOnly": true,
+                              "description": "The unique identifier (UID) of the business rule (e.g., \"br-a1b2c3d4-5678-90ef-ghij-klmnopqrstuv\"). Assigned automatically by the system upon creation."
+                            },
+                            "business_uid": {
+                              "type": "string",
+                              "readOnly": true,
+                              "description": "The unique identifier (UID) of the business that owns this rule (e.g., \"biz-1234abcd-5678-90ef-ghij-klmnopqrstuv\"). Automatically set based on the authenticated token."
+                            },
+                            "content": {
+                              "type": "string",
+                              "description": "The content or text of the business rule (e.g., \"Always use a friendly and professional tone when communicating with clients\"). For FAQ rules, this typically contains both the question and answer in a combined format."
+                            },
+                            "status": {
+                              "type": "string",
+                              "description": "The current status of the business rule, controlling whether the AI agent actively uses it.\n\n* `active` - The rule is currently in effect and will be used by the AI agent.\n* `pending_approval` - The rule has been suggested (typically by the system) and is awaiting staff review before becoming active.\n* `inactive` - The rule has been deactivated and will not be used by the AI agent.",
+                              "enum": [
+                                "active",
+                                "pending_approval",
+                                "inactive"
+                              ]
+                            },
+                            "source": {
+                              "type": "string",
+                              "readOnly": true,
+                              "description": "Indicates whether the rule was created by the AI system or by a user (staff member).\n\n* `system` - The rule was generated automatically by the AI based on analysis of business conversations.\n* `user` - The rule was manually created or edited by a staff member.",
+                              "enum": [
+                                "system",
+                                "user"
+                              ]
+                            },
+                            "created_by_staff_uid": {
+                              "type": "string",
+                              "readOnly": true,
+                              "description": "The UID of the staff member who created the rule (e.g., \"stf-9876wxyz-5432-10ab-cdef-ghijklmnopqr\"). Will be null for system-generated rules that have not been manually edited.",
+                              "nullable": true
+                            },
+                            "updated_by_staff_uid": {
+                              "type": "string",
+                              "readOnly": true,
+                              "description": "The UID of the staff member who last updated the rule (e.g., \"stf-9876wxyz-5432-10ab-cdef-ghijklmnopqr\"). Will be null if the rule has never been updated by a staff member.",
+                              "nullable": true
+                            },
+                            "sort_order": {
+                              "type": "integer",
+                              "description": "Sort order for displaying rules within a category (e.g., 0). Lower values appear first. Rules within the same category are ordered by this field in ascending order."
+                            },
+                            "metadata": {
+                              "type": "object",
+                              "description": "Additional metadata associated with the rule. For FAQ rules, includes structured `question` and `answer` fields. For system-generated rules, may include `confidence`, `reasoning`, and `evidence` from the AI analysis.",
+                              "nullable": true,
+                              "properties": {
+                                "question": {
+                                  "type": "string",
+                                  "description": "The question part of an FAQ rule (e.g., \"What are your business hours?\"). Only present for rules with category `faq`."
+                                },
+                                "answer": {
+                                  "type": "string",
+                                  "description": "The answer part of an FAQ rule (e.g., \"We are open Monday to Friday, 9 AM to 5 PM.\"). Only present for rules with category `faq`."
+                                },
+                                "confidence": {
+                                  "type": "number",
+                                  "description": "AI confidence score ranging from 0.0 to 1.0 indicating how confident the system is about this rule (e.g., 0.92). Only present for system-generated rules."
+                                },
+                                "reasoning": {
+                                  "type": "string",
+                                  "description": "AI-generated reasoning explaining why this rule was created or suggested (e.g., \"Consistent friendly tone observed across 15 client conversations\"). Only present for system-generated rules."
+                                },
+                                "evidence": {
+                                  "type": "array",
+                                  "description": "Evidence from conversations that supports this rule. Contains quotes and references from actual client-staff interactions.",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "client_uid": {
+                                        "type": "string",
+                                        "description": "The UID of the client involved in the conversation."
+                                      },
+                                      "message_uid": {
+                                        "type": "string",
+                                        "description": "The UID of the specific message used as evidence."
+                                      },
+                                      "quote": {
+                                        "type": "string",
+                                        "description": "A direct quote from the conversation used as evidence."
+                                      },
+                                      "speaker": {
+                                        "type": "string",
+                                        "enum": [
+                                          "staff",
+                                          "client"
+                                        ],
+                                        "description": "Identifies whether the quote is from a staff member or a client.\n\n* `staff` - The quote is from a staff member.\n* `client` - The quote is from a client."
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "readOnly": true,
+                              "description": "The date and time when the business rule was created, in ISO 8601 format (e.g., \"2024-12-15T10:30:00.000Z\")."
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "readOnly": true,
+                              "description": "The date and time when the business rule was last updated, in ISO 8601 format (e.g., \"2024-12-16T14:00:00.000Z\")."
+                            },
+                            "category_code": {
+                              "type": "string",
+                              "description": "The category of the business rule. Determines how the AI agent uses this rule.\n\n* `tone_of_voice` - Rules about communication style, language, and tone the AI should adopt when interacting with clients.\n* `policies_and_info` - Rules about business operations, pricing, scheduling policies, and other operational guidelines.\n* `things_to_avoid` - Rules about topics, phrases, or actions the AI should not mention or perform.\n* `faq` - Frequently asked questions and their answers. When this category is used, the metadata field should contain structured `question` and `answer` fields.\n* `client_facing_bot_policies` - Rules specifically for client-facing bot interactions, defining bot behavior, limitations, and escalation policies.",
+                              "enum": [
+                                "tone_of_voice",
+                                "policies_and_info",
+                                "things_to_avoid",
+                                "faq",
+                                "client_facing_bot_policies"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "uid",
+                            "business_uid",
+                            "category_code",
+                            "content",
+                            "status",
+                            "source",
+                            "sort_order",
+                            "created_at",
+                            "updated_at"
+                          ],
+                          "example": {
+                            "uid": "br-a1b2c3d4-5678-90ef-ghij-klmnopqrstuv",
+                            "business_uid": "biz-1234abcd-5678-90ef-ghij-klmnopqrstuv",
+                            "content": "Always use a friendly and professional tone when communicating with clients",
+                            "status": "active",
+                            "source": "system",
+                            "created_by_staff_uid": "stf-9876wxyz-5432-10ab-cdef-ghijklmnopqr",
+                            "updated_by_staff_uid": null,
+                            "sort_order": 0,
+                            "metadata": {
+                              "confidence": 0.92,
+                              "reasoning": "Consistent friendly tone observed across 15 client conversations"
+                            },
+                            "created_at": "2024-12-15T10:30:00.000Z",
+                            "updated_at": "2024-12-15T10:30:00.000Z",
+                            "category_code": "tone_of_voice"
+                          }
                         }
                       }
                     }
@@ -1187,7 +2797,50 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     }
                   ]
                 },
@@ -1287,7 +2940,50 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
@@ -1334,12 +3030,128 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/ai/BizAIChat.json"
+                          "type": "object",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "description": "The unique identifier (UID) of the chat"
+                            },
+                            "actor_uid": {
+                              "type": "string",
+                              "description": "The unique identifier (UID) of the actor that created the chat"
+                            },
+                            "agent": {
+                              "type": "string",
+                              "description": "Agent associated with the chat"
+                            },
+                            "metadata": {
+                              "type": "object",
+                              "description": "A JSON string used to pass additional information to the chat agent in run time"
+                            },
+                            "config": {
+                              "type": "object",
+                              "description": "The agent configuration settings for this chat session",
+                              "properties": {
+                                "instruction": {
+                                  "oneOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "object"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ],
+                                  "description": "The instructions for the agent. Can be a simple string prompt, a structured object with template variables, or null if not configured."
+                                },
+                                "model_name": {
+                                  "type": "string",
+                                  "description": "The AI model name used for the agent"
+                                }
+                              }
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "description": "Date the chat was created"
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "description": "Date the chat was last updated"
+                            }
+                          },
+                          "required": [
+                            "uid",
+                            "actor_uid",
+                            "agent",
+                            "created_at",
+                            "updated_at"
+                          ],
+                          "example": {
+                            "uid": "d290f1ee-6c54-4b01-90e6-d701748f0851",
+                            "actor_uid": "ghp0f1ee-6c54-4b01-90e6-d701748f0851",
+                            "agent": "vanilla",
+                            "metadata": {
+                              "directory_uid": "k98axtpqg7h1whh6",
+                              "instruction": "You are a helpful assistant. Answer all questions to the best of your ability."
+                            },
+                            "config": {
+                              "instruction": "You are an experienced business consultant with a friendly voice.",
+                              "model_name": "gpt-4"
+                            },
+                            "created_at": "2021-07-20T14:00:00.000Z",
+                            "updated_at": "2021-07-20T14:00:00.000Z"
+                          },
+                          "description": "Represents a business AI chat session, including agent, metadata, and audit timestamps."
                         }
                       }
                     }
@@ -1384,12 +3196,128 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/ai/BizAIChat.json"
+                          "type": "object",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "description": "The unique identifier (UID) of the chat"
+                            },
+                            "actor_uid": {
+                              "type": "string",
+                              "description": "The unique identifier (UID) of the actor that created the chat"
+                            },
+                            "agent": {
+                              "type": "string",
+                              "description": "Agent associated with the chat"
+                            },
+                            "metadata": {
+                              "type": "object",
+                              "description": "A JSON string used to pass additional information to the chat agent in run time"
+                            },
+                            "config": {
+                              "type": "object",
+                              "description": "The agent configuration settings for this chat session",
+                              "properties": {
+                                "instruction": {
+                                  "oneOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "object"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ],
+                                  "description": "The instructions for the agent. Can be a simple string prompt, a structured object with template variables, or null if not configured."
+                                },
+                                "model_name": {
+                                  "type": "string",
+                                  "description": "The AI model name used for the agent"
+                                }
+                              }
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "description": "Date the chat was created"
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "description": "Date the chat was last updated"
+                            }
+                          },
+                          "required": [
+                            "uid",
+                            "actor_uid",
+                            "agent",
+                            "created_at",
+                            "updated_at"
+                          ],
+                          "example": {
+                            "uid": "d290f1ee-6c54-4b01-90e6-d701748f0851",
+                            "actor_uid": "ghp0f1ee-6c54-4b01-90e6-d701748f0851",
+                            "agent": "vanilla",
+                            "metadata": {
+                              "directory_uid": "k98axtpqg7h1whh6",
+                              "instruction": "You are a helpful assistant. Answer all questions to the best of your ability."
+                            },
+                            "config": {
+                              "instruction": "You are an experienced business consultant with a friendly voice.",
+                              "model_name": "gpt-4"
+                            },
+                            "created_at": "2021-07-20T14:00:00.000Z",
+                            "updated_at": "2021-07-20T14:00:00.000Z"
+                          },
+                          "description": "Represents a business AI chat session, including agent, metadata, and audit timestamps."
                         }
                       }
                     }
@@ -1467,7 +3395,50 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
@@ -1522,7 +3493,32 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "https://vcita.github.io/developers-hub/entities/ai/BizAIChatStreamMessage.json"
+                  "type": "object",
+                  "properties": {
+                    "uid": {
+                      "type": "string",
+                      "description": "The unique identifier (UID) of the message"
+                    },
+                    "delta": {
+                      "type": "string",
+                      "description": "Token that is part of the content of the message"
+                    },
+                    "finish_reason": {
+                      "type": "string",
+                      "description": "The reason the stream has finished. If null, the stream is did not finish yet"
+                    }
+                  },
+                  "required": [
+                    "uid",
+                    "delta",
+                    "finish_reason"
+                  ],
+                  "example": {
+                    "uid": "d290f1ee-6c54-4b01-90e6-d701748f0851",
+                    "delta": "Hello",
+                    "finish_reason": null
+                  },
+                  "description": "Represents a streamed token chunk for a BizAI chat message, with finish state."
                 }
               }
             }
@@ -1567,7 +3563,111 @@
                       "type": "boolean"
                     },
                     "data": {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/ai/AISmartReply.json"
+                      "type": "object",
+                      "description": "Represents a smart reply generated by AI with different message formats for various communication channels.",
+                      "properties": {
+                        "uid": {
+                          "type": "string",
+                          "description": "The unique identifier (UID) of the smart reply"
+                        },
+                        "created_at": {
+                          "type": "string",
+                          "format": "date-time",
+                          "description": "The timestamp when the smart reply was created, in ISO 8601 format"
+                        },
+                        "updated_at": {
+                          "type": "string",
+                          "format": "date-time",
+                          "description": "The timestamp when the smart reply was last updated, in ISO 8601 format"
+                        },
+                        "display": {
+                          "type": "object",
+                          "description": "Contains display-related information for the smart reply.",
+                          "properties": {
+                            "btn_text": {
+                              "type": "string",
+                              "description": "A human-readable title for the smart reply button."
+                            }
+                          }
+                        },
+                        "reason": {
+                          "type": "string",
+                          "description": "The reason why this smart reply was generated, providing context for decision-making."
+                        },
+                        "payload": {
+                          "type": "object",
+                          "description": "Contains the generated reply messages for different communication channels.",
+                          "properties": {
+                            "email_message": {
+                              "type": "string",
+                              "description": "The generated reply formatted for email communication"
+                            },
+                            "sms_message": {
+                              "type": "string",
+                              "description": "The generated reply formatted for SMS communication"
+                            },
+                            "FB_message": {
+                              "type": "string",
+                              "description": "The generated reply formatted for Facebook messaging"
+                            },
+                            "other_message": {
+                              "type": "string",
+                              "description": "The generated reply formatted for other communication channels"
+                            }
+                          },
+                          "required": [
+                            "email_message",
+                            "sms_message",
+                            "FB_message",
+                            "other_message"
+                          ]
+                        },
+                        "evidence": {
+                          "oneOf": [
+                            {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "description": "Supporting statements or facts that led to the generation of this smart reply. Can be an array of strings or a single string."
+                        },
+                        "matter_uid": {
+                          "type": "string",
+                          "description": "The unique identifier of the associated matter"
+                        }
+                      },
+                      "required": [
+                        "uid",
+                        "created_at",
+                        "updated_at",
+                        "reason",
+                        "payload",
+                        "matter_uid"
+                      ],
+                      "example": {
+                        "uid": "d290f1ee-6c54-4b01-90e6-d701748f0851",
+                        "created_at": "2025-02-04T14:00:00.000Z",
+                        "updated_at": "2025-02-04T14:00:00.000Z",
+                        "display": {
+                          "btn_text": "Generate Reply"
+                        },
+                        "reason": "User needs clarification on pricing",
+                        "payload": {
+                          "email_message": "I need more details to send you a quote<br/>best regards,<br/>ramster",
+                          "sms_message": "I need more details to send you a quote",
+                          "FB_message": "I need more details to send you a quote",
+                          "other_message": "I need more details to send you a quote"
+                        },
+                        "evidence": [
+                          "User asked for price estimate"
+                        ],
+                        "matter_uid": "7f8a9b32d4e"
+                      }
                     }
                   }
                 }
@@ -1673,7 +3773,304 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "https://vcita.github.io/developers-hub/entities/ai/ChatCompletionRequest.json"
+                "type": "object",
+                "description": "Request body for creating a chat completion. Specify the model, messages, and optional parameters to control the completion behavior.",
+                "properties": {
+                  "model": {
+                    "type": "string",
+                    "description": "Model identifier in provider/model format. Supported providers: openai, anthropic, google (e.g., \"openai/gpt-4o\", \"anthropic/claude-sonnet-4-5-20250929\", \"google/gemini-2.5-pro\").",
+                    "example": "openai/gpt-4o"
+                  },
+                  "messages": {
+                    "type": "array",
+                    "description": "Array of messages representing the conversation history. Must include at least one message with role 'user'.",
+                    "items": {
+                      "type": "object",
+                      "description": "A single message in the chat conversation. Messages represent the dialogue between the user, system, assistant, and tools.",
+                      "properties": {
+                        "role": {
+                          "type": "string",
+                          "enum": [
+                            "system",
+                            "user",
+                            "assistant",
+                            "tool"
+                          ],
+                          "description": "The role of the message author. 'system' sets the assistant's behavior, 'user' is the human input, 'assistant' is the model's response, 'tool' is the response to a tool call."
+                        },
+                        "content": {
+                          "description": "Message content. A string for plain text input, or an array of content parts for multimodal input (images, audio, video, files).",
+                          "oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "description": "A content part for multimodal messages. Supports text, images, audio, video, and file inputs. Used within the 'content' array of a ChatMessage when providing multimodal input.",
+                                "properties": {
+                                  "type": {
+                                    "type": "string",
+                                    "enum": [
+                                      "text",
+                                      "image_url",
+                                      "image",
+                                      "audio_url",
+                                      "video_url",
+                                      "input_audio",
+                                      "file"
+                                    ],
+                                    "description": "The type of content part. 'text' for plain text, 'image_url' for an image via URL, 'image' for inline image data, 'audio_url' for audio via URL, 'video_url' for video via URL, 'input_audio' for inline audio data, 'file' for file attachments."
+                                  }
+                                },
+                                "example": {
+                                  "type": "text"
+                                }
+                              }
+                            }
+                          ]
+                        },
+                        "name": {
+                          "type": "string",
+                          "description": "Optional name for the participant. Useful for distinguishing between multiple users in a multi-turn conversation."
+                        },
+                        "tool_calls": {
+                          "type": "array",
+                          "description": "Tool calls made by the assistant. Only present on messages with role 'assistant' when the model decides to invoke a function.",
+                          "items": {
+                            "type": "object",
+                            "description": "A tool call requested by the assistant during a chat completion. Contains the function name and arguments the model wants to invoke.",
+                            "properties": {
+                              "id": {
+                                "type": "string",
+                                "description": "Unique identifier for this tool call, used to match tool responses back to the request (e.g., \"call_abc123\")."
+                              },
+                              "type": {
+                                "type": "string",
+                                "enum": [
+                                  "function"
+                                ],
+                                "description": "The type of tool call. Currently only 'function' is supported."
+                              },
+                              "function": {
+                                "type": "object",
+                                "description": "The function to be called, including its name and arguments.",
+                                "properties": {
+                                  "name": {
+                                    "type": "string",
+                                    "description": "The name of the function to call (e.g., \"get_weather\")."
+                                  },
+                                  "arguments": {
+                                    "type": "string",
+                                    "description": "A JSON-encoded string of the arguments to pass to the function (e.g., \"{\\\"location\\\": \\\"Paris\\\"}\")."
+                                  }
+                                }
+                              }
+                            },
+                            "example": {
+                              "id": "call_abc123",
+                              "type": "function",
+                              "function": {
+                                "name": "get_weather",
+                                "arguments": "{\"location\": \"Paris\"}"
+                              }
+                            }
+                          }
+                        },
+                        "tool_call_id": {
+                          "type": "string",
+                          "description": "The unique identifier of the tool call this message responds to. Required on messages with role 'tool'."
+                        }
+                      },
+                      "required": [
+                        "role"
+                      ],
+                      "example": {
+                        "role": "user",
+                        "content": "What is the weather in Paris?"
+                      }
+                    }
+                  },
+                  "stream": {
+                    "type": "boolean",
+                    "description": "Whether to stream the response as Server-Sent Events (SSE). When true, the response is delivered incrementally as text/event-stream. Defaults to true.",
+                    "default": true
+                  },
+                  "async": {
+                    "type": "boolean",
+                    "description": "Process the request asynchronously. Returns a run UID immediately that can be polled via GET /v3/ai/chat_completion_runs/{uid}. Recommended for thinking models (e.g., openai/o1, openai/o3-mini) that may take longer to respond.",
+                    "default": false
+                  },
+                  "temperature": {
+                    "type": "number",
+                    "description": "Sampling temperature between 0 and 2. Higher values (e.g., 0.8) make the output more random, while lower values (e.g., 0.2) make it more focused and deterministic.",
+                    "minimum": 0,
+                    "maximum": 2,
+                    "example": 0.7
+                  },
+                  "max_tokens": {
+                    "type": "integer",
+                    "description": "Maximum number of tokens to generate in the completion. The total length of input tokens and generated tokens is limited by the model's context length.",
+                    "minimum": 1,
+                    "example": 1024
+                  },
+                  "top_p": {
+                    "type": "number",
+                    "description": "Top-p (nucleus) sampling parameter between 0 and 1. The model considers the results of the tokens with top_p probability mass. For example, 0.1 means only tokens comprising the top 10% probability mass are considered.",
+                    "minimum": 0,
+                    "maximum": 1,
+                    "example": 1
+                  },
+                  "tools": {
+                    "type": "array",
+                    "description": "Array of tool definitions available for the model to call during the completion. The model may choose to call zero or more of these tools based on the conversation context.",
+                    "items": {
+                      "type": "object",
+                      "description": "Defines a tool (function) available to the model during chat completion. The model may choose to call one or more tools based on the conversation context.",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "function"
+                          ],
+                          "description": "The type of tool. Currently only 'function' is supported."
+                        },
+                        "function": {
+                          "type": "object",
+                          "description": "The function definition including its name, description, and parameter schema.",
+                          "properties": {
+                            "name": {
+                              "type": "string",
+                              "description": "The name of the function to be called. Must be a-z, A-Z, 0-9, underscores, or dashes, with a maximum length of 64 (e.g., \"get_weather\")."
+                            },
+                            "description": {
+                              "type": "string",
+                              "description": "A clear description of what the function does. The model uses this to decide when and how to call the function (e.g., \"Get current weather for a location\")."
+                            },
+                            "parameters": {
+                              "type": "object",
+                              "description": "A JSON Schema object describing the function's parameters. The model will generate arguments that conform to this schema."
+                            },
+                            "strict": {
+                              "type": "boolean",
+                              "description": "Whether to enforce strict schema validation on the generated arguments. When true, the model output is guaranteed to match the schema exactly."
+                            }
+                          },
+                          "required": [
+                            "name",
+                            "parameters"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "function"
+                      ],
+                      "example": {
+                        "type": "function",
+                        "function": {
+                          "name": "get_weather",
+                          "description": "Get current weather for a location",
+                          "parameters": {
+                            "type": "object",
+                            "properties": {
+                              "location": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "location"
+                            ]
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "response_format": {
+                    "type": "object",
+                    "description": "Response format specification for structured output. Use this to constrain the model's output to a specific format such as JSON. When not specified, the model returns free-form text.",
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "text",
+                          "json_object",
+                          "json_schema"
+                        ],
+                        "description": "The format type. 'text' for free-form text (default), 'json_object' for any valid JSON, 'json_schema' for JSON constrained to a specific schema."
+                      },
+                      "json_schema": {
+                        "type": "object",
+                        "description": "JSON Schema definition. Required when type is 'json_schema'. Defines the exact structure the model must follow.",
+                        "properties": {
+                          "name": {
+                            "type": "string",
+                            "description": "A name for the schema, used for identification (e.g., \"person\")."
+                          },
+                          "schema": {
+                            "type": "object",
+                            "description": "The JSON Schema that the model's output must conform to."
+                          },
+                          "strict": {
+                            "type": "boolean",
+                            "description": "Whether to enforce strict schema validation on the model's output."
+                          }
+                        }
+                      }
+                    },
+                    "example": {
+                      "type": "json_schema",
+                      "json_schema": {
+                        "name": "person",
+                        "schema": {
+                          "type": "object",
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "age": {
+                              "type": "integer"
+                            }
+                          },
+                          "required": [
+                            "name",
+                            "age"
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  "stop": {
+                    "description": "Up to 4 sequences where the model will stop generating further tokens. The returned text will not contain the stop sequence.",
+                    "oneOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "model",
+                  "messages"
+                ],
+                "example": {
+                  "model": "openai/gpt-4o-mini",
+                  "messages": [
+                    {
+                      "role": "user",
+                      "content": "Say hello"
+                    }
+                  ],
+                  "stream": false,
+                  "max_tokens": 100
+                }
               },
               "examples": {
                 "simple": {
@@ -1782,12 +4179,213 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/ai/ChatCompletion.json"
+                          "type": "object",
+                          "description": "Represents a chat completion response from an LLM provider. Contains the generated text, tool calls, and token usage statistics.",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "readOnly": true,
+                              "description": "Unique identifier for this completion (e.g., \"chatcmpl-1677652288-a1b2c3\")."
+                            },
+                            "object": {
+                              "type": "string",
+                              "readOnly": true,
+                              "description": "Object type identifier. Always 'chat.completion' for non-streaming responses.",
+                              "enum": [
+                                "chat.completion"
+                              ]
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "readOnly": true,
+                              "description": "The date and time when the completion was created, in ISO 8601 format (e.g., \"2026-02-09T09:31:30.000Z\")."
+                            },
+                            "model": {
+                              "type": "string",
+                              "readOnly": true,
+                              "description": "The model used for the completion in provider/model format (e.g., \"openai/gpt-4o-mini\", \"anthropic/claude-sonnet-4-5-20250929\")."
+                            },
+                            "choices": {
+                              "type": "array",
+                              "readOnly": true,
+                              "description": "Array of completion choices generated by the model. Typically contains a single choice.",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "index": {
+                                    "type": "integer",
+                                    "description": "Zero-based index of this choice in the choices array."
+                                  },
+                                  "message": {
+                                    "type": "object",
+                                    "properties": {
+                                      "role": {
+                                        "type": "string",
+                                        "enum": [
+                                          "assistant"
+                                        ],
+                                        "description": "The role of the message author. Always 'assistant' for completion responses."
+                                      },
+                                      "content": {
+                                        "type": "string",
+                                        "nullable": true,
+                                        "description": "The text content of the assistant's response. May be null when the model makes tool calls instead of generating text."
+                                      },
+                                      "tool_calls": {
+                                        "type": "array",
+                                        "description": "Tool calls requested by the assistant. Present when the model decides to call one or more functions defined in the request's 'tools' parameter.",
+                                        "items": {
+                                          "type": "object",
+                                          "description": "A tool call requested by the assistant during a chat completion. Contains the function name and arguments the model wants to invoke.",
+                                          "properties": {
+                                            "id": {
+                                              "type": "string",
+                                              "description": "Unique identifier for this tool call, used to match tool responses back to the request (e.g., \"call_abc123\")."
+                                            },
+                                            "type": {
+                                              "type": "string",
+                                              "enum": [
+                                                "function"
+                                              ],
+                                              "description": "The type of tool call. Currently only 'function' is supported."
+                                            },
+                                            "function": {
+                                              "type": "object",
+                                              "description": "The function to be called, including its name and arguments.",
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string",
+                                                  "description": "The name of the function to call (e.g., \"get_weather\")."
+                                                },
+                                                "arguments": {
+                                                  "type": "string",
+                                                  "description": "A JSON-encoded string of the arguments to pass to the function (e.g., \"{\\\"location\\\": \\\"Paris\\\"}\")."
+                                                }
+                                              }
+                                            }
+                                          },
+                                          "example": {
+                                            "id": "call_abc123",
+                                            "type": "function",
+                                            "function": {
+                                              "name": "get_weather",
+                                              "arguments": "{\"location\": \"Paris\"}"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "finish_reason": {
+                                    "type": "string",
+                                    "enum": [
+                                      "stop",
+                                      "length",
+                                      "tool_calls",
+                                      "content_filter"
+                                    ],
+                                    "description": "The reason the model stopped generating. 'stop' means the model naturally finished, 'length' means max_tokens was reached, 'tool_calls' means the model wants to call a function, 'content_filter' means content was filtered by safety systems."
+                                  }
+                                }
+                              }
+                            },
+                            "usage": {
+                              "type": "object",
+                              "readOnly": true,
+                              "description": "Token usage statistics for the completion request. Useful for tracking costs and monitoring token consumption.",
+                              "properties": {
+                                "prompt_tokens": {
+                                  "type": "integer",
+                                  "description": "Number of tokens in the input prompt (e.g., 9)."
+                                },
+                                "completion_tokens": {
+                                  "type": "integer",
+                                  "description": "Number of tokens generated in the completion response (e.g., 9)."
+                                },
+                                "total_tokens": {
+                                  "type": "integer",
+                                  "description": "Total number of tokens used (prompt_tokens + completion_tokens) (e.g., 18)."
+                                }
+                              }
+                            }
+                          },
+                          "required": [
+                            "uid",
+                            "object",
+                            "created_at",
+                            "model",
+                            "choices"
+                          ],
+                          "example": {
+                            "uid": "chatcmpl-1677652288-a1b2c3",
+                            "object": "chat.completion",
+                            "created_at": "2026-02-09T09:31:30.000Z",
+                            "model": "openai/gpt-4o-mini",
+                            "choices": [
+                              {
+                                "index": 0,
+                                "message": {
+                                  "role": "assistant",
+                                  "content": "Hello! How can I help you today?"
+                                },
+                                "finish_reason": "stop"
+                              }
+                            ],
+                            "usage": {
+                              "prompt_tokens": 9,
+                              "completion_tokens": 9,
+                              "total_tokens": 18
+                            }
+                          }
                         }
                       }
                     }
@@ -1809,12 +4407,285 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/ai/ChatCompletionRun.json"
+                          "type": "object",
+                          "description": "Represents an async chat completion run. Poll this resource until status is COMPLETED or FAILED.",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "readOnly": true,
+                              "description": "Unique identifier of the chat completion run."
+                            },
+                            "status": {
+                              "type": "string",
+                              "readOnly": true,
+                              "enum": [
+                                "QUEUED",
+                                "IN_PROGRESS",
+                                "COMPLETED",
+                                "FAILED"
+                              ],
+                              "description": "Current status of the run. Possible values: 'QUEUED' (job is waiting to be processed), 'IN_PROGRESS' (job is actively being processed by the LLM provider), 'COMPLETED' (job finished successfully and result is available), 'FAILED' (job encountered an error and error_message is available)."
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "readOnly": true,
+                              "description": "The date and time when the run was created, in ISO 8601 format (e.g., \"2026-02-09T09:31:30.934Z\")."
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "readOnly": true,
+                              "description": "The date and time when the run was last updated, in ISO 8601 format (e.g., \"2026-02-09T09:31:31.000Z\")."
+                            },
+                            "result": {
+                              "type": "object",
+                              "description": "The completion result. Only present when status is 'COMPLETED'.",
+                              "properties": {
+                                "uid": {
+                                  "type": "string",
+                                  "readOnly": true,
+                                  "description": "Unique identifier for this completion (e.g., \"chatcmpl-1677652288-a1b2c3\")."
+                                },
+                                "object": {
+                                  "type": "string",
+                                  "readOnly": true,
+                                  "description": "Object type identifier. Always 'chat.completion' for non-streaming responses.",
+                                  "enum": [
+                                    "chat.completion"
+                                  ]
+                                },
+                                "created_at": {
+                                  "type": "string",
+                                  "format": "date-time",
+                                  "readOnly": true,
+                                  "description": "The date and time when the completion was created, in ISO 8601 format (e.g., \"2026-02-09T09:31:30.000Z\")."
+                                },
+                                "model": {
+                                  "type": "string",
+                                  "readOnly": true,
+                                  "description": "The model used for the completion in provider/model format (e.g., \"openai/gpt-4o-mini\", \"anthropic/claude-sonnet-4-5-20250929\")."
+                                },
+                                "choices": {
+                                  "type": "array",
+                                  "readOnly": true,
+                                  "description": "Array of completion choices generated by the model. Typically contains a single choice.",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "index": {
+                                        "type": "integer",
+                                        "description": "Zero-based index of this choice in the choices array."
+                                      },
+                                      "message": {
+                                        "type": "object",
+                                        "properties": {
+                                          "role": {
+                                            "type": "string",
+                                            "enum": [
+                                              "assistant"
+                                            ],
+                                            "description": "The role of the message author. Always 'assistant' for completion responses."
+                                          },
+                                          "content": {
+                                            "type": "string",
+                                            "nullable": true,
+                                            "description": "The text content of the assistant's response. May be null when the model makes tool calls instead of generating text."
+                                          },
+                                          "tool_calls": {
+                                            "type": "array",
+                                            "description": "Tool calls requested by the assistant. Present when the model decides to call one or more functions defined in the request's 'tools' parameter.",
+                                            "items": {
+                                              "type": "object",
+                                              "description": "A tool call requested by the assistant during a chat completion. Contains the function name and arguments the model wants to invoke.",
+                                              "properties": {
+                                                "id": {
+                                                  "type": "string",
+                                                  "description": "Unique identifier for this tool call, used to match tool responses back to the request (e.g., \"call_abc123\")."
+                                                },
+                                                "type": {
+                                                  "type": "string",
+                                                  "enum": [
+                                                    "function"
+                                                  ],
+                                                  "description": "The type of tool call. Currently only 'function' is supported."
+                                                },
+                                                "function": {
+                                                  "type": "object",
+                                                  "description": "The function to be called, including its name and arguments.",
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string",
+                                                      "description": "The name of the function to call (e.g., \"get_weather\")."
+                                                    },
+                                                    "arguments": {
+                                                      "type": "string",
+                                                      "description": "A JSON-encoded string of the arguments to pass to the function (e.g., \"{\\\"location\\\": \\\"Paris\\\"}\")."
+                                                    }
+                                                  }
+                                                }
+                                              },
+                                              "example": {
+                                                "id": "call_abc123",
+                                                "type": "function",
+                                                "function": {
+                                                  "name": "get_weather",
+                                                  "arguments": "{\"location\": \"Paris\"}"
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "finish_reason": {
+                                        "type": "string",
+                                        "enum": [
+                                          "stop",
+                                          "length",
+                                          "tool_calls",
+                                          "content_filter"
+                                        ],
+                                        "description": "The reason the model stopped generating. 'stop' means the model naturally finished, 'length' means max_tokens was reached, 'tool_calls' means the model wants to call a function, 'content_filter' means content was filtered by safety systems."
+                                      }
+                                    }
+                                  }
+                                },
+                                "usage": {
+                                  "type": "object",
+                                  "readOnly": true,
+                                  "description": "Token usage statistics for the completion request. Useful for tracking costs and monitoring token consumption.",
+                                  "properties": {
+                                    "prompt_tokens": {
+                                      "type": "integer",
+                                      "description": "Number of tokens in the input prompt (e.g., 9)."
+                                    },
+                                    "completion_tokens": {
+                                      "type": "integer",
+                                      "description": "Number of tokens generated in the completion response (e.g., 9)."
+                                    },
+                                    "total_tokens": {
+                                      "type": "integer",
+                                      "description": "Total number of tokens used (prompt_tokens + completion_tokens) (e.g., 18)."
+                                    }
+                                  }
+                                }
+                              },
+                              "required": [
+                                "uid",
+                                "object",
+                                "created_at",
+                                "model",
+                                "choices"
+                              ],
+                              "example": {
+                                "uid": "chatcmpl-1677652288-a1b2c3",
+                                "object": "chat.completion",
+                                "created_at": "2026-02-09T09:31:30.000Z",
+                                "model": "openai/gpt-4o-mini",
+                                "choices": [
+                                  {
+                                    "index": 0,
+                                    "message": {
+                                      "role": "assistant",
+                                      "content": "Hello! How can I help you today?"
+                                    },
+                                    "finish_reason": "stop"
+                                  }
+                                ],
+                                "usage": {
+                                  "prompt_tokens": 9,
+                                  "completion_tokens": 9,
+                                  "total_tokens": 18
+                                }
+                              },
+                              "readOnly": true
+                            },
+                            "error_message": {
+                              "type": "string",
+                              "readOnly": true,
+                              "description": "Error message describing the failure reason. Only present when status is 'FAILED'."
+                            }
+                          },
+                          "required": [
+                            "uid",
+                            "status",
+                            "created_at"
+                          ],
+                          "example": {
+                            "uid": "0ce1af9d-3337-419b-933c-02ea21d4d9ca",
+                            "status": "COMPLETED",
+                            "created_at": "2026-02-09T09:31:30.934Z",
+                            "updated_at": "2026-02-09T09:31:31.000Z",
+                            "result": {
+                              "uid": "chatcmpl-1677652288-a1b2c3",
+                              "object": "chat.completion",
+                              "created_at": "2026-02-09T09:31:30.000Z",
+                              "model": "openai/gpt-4o-mini",
+                              "choices": [
+                                {
+                                  "index": 0,
+                                  "message": {
+                                    "role": "assistant",
+                                    "content": "2 + 2 equals 4."
+                                  },
+                                  "finish_reason": "stop"
+                                }
+                              ],
+                              "usage": {
+                                "prompt_tokens": 14,
+                                "completion_tokens": 8,
+                                "total_tokens": 22
+                              }
+                            }
+                          }
                         }
                       }
                     }
@@ -1828,7 +4699,50 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "description": "Indicates whether the API request was successful (true) or failed (false)."
+                    },
+                    "data": {
+                      "type": "object",
+                      "description": "The response payload. Present on successful responses (success: true)."
+                    },
+                    "error": {
+                      "type": "string",
+                      "description": "Error message for simple error responses. Used in some legacy endpoints."
+                    },
+                    "errors": {
+                      "type": "array",
+                      "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string",
+                            "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                          },
+                          "message": {
+                            "type": "string",
+                            "description": "Human-readable error message."
+                          },
+                          "field": {
+                            "type": "string",
+                            "description": "The field that caused the error (for validation errors)."
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "success"
+                  ],
+                  "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                 },
                 "example": {
                   "success": false,
@@ -1847,7 +4761,50 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "description": "Indicates whether the API request was successful (true) or failed (false)."
+                    },
+                    "data": {
+                      "type": "object",
+                      "description": "The response payload. Present on successful responses (success: true)."
+                    },
+                    "error": {
+                      "type": "string",
+                      "description": "Error message for simple error responses. Used in some legacy endpoints."
+                    },
+                    "errors": {
+                      "type": "array",
+                      "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string",
+                            "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                          },
+                          "message": {
+                            "type": "string",
+                            "description": "Human-readable error message."
+                          },
+                          "field": {
+                            "type": "string",
+                            "description": "The field that caused the error (for validation errors)."
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "success"
+                  ],
+                  "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                 },
                 "example": {
                   "success": false,
@@ -1866,7 +4823,50 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "description": "Indicates whether the API request was successful (true) or failed (false)."
+                    },
+                    "data": {
+                      "type": "object",
+                      "description": "The response payload. Present on successful responses (success: true)."
+                    },
+                    "error": {
+                      "type": "string",
+                      "description": "Error message for simple error responses. Used in some legacy endpoints."
+                    },
+                    "errors": {
+                      "type": "array",
+                      "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string",
+                            "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                          },
+                          "message": {
+                            "type": "string",
+                            "description": "Human-readable error message."
+                          },
+                          "field": {
+                            "type": "string",
+                            "description": "The field that caused the error (for validation errors)."
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "success"
+                  ],
+                  "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                 },
                 "example": {
                   "success": false,
@@ -1886,7 +4886,50 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "description": "Indicates whether the API request was successful (true) or failed (false)."
+                    },
+                    "data": {
+                      "type": "object",
+                      "description": "The response payload. Present on successful responses (success: true)."
+                    },
+                    "error": {
+                      "type": "string",
+                      "description": "Error message for simple error responses. Used in some legacy endpoints."
+                    },
+                    "errors": {
+                      "type": "array",
+                      "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string",
+                            "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                          },
+                          "message": {
+                            "type": "string",
+                            "description": "Human-readable error message."
+                          },
+                          "field": {
+                            "type": "string",
+                            "description": "The field that caused the error (for validation errors)."
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "success"
+                  ],
+                  "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                 },
                 "example": {
                   "success": false,
@@ -1905,7 +4948,50 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "description": "Indicates whether the API request was successful (true) or failed (false)."
+                    },
+                    "data": {
+                      "type": "object",
+                      "description": "The response payload. Present on successful responses (success: true)."
+                    },
+                    "error": {
+                      "type": "string",
+                      "description": "Error message for simple error responses. Used in some legacy endpoints."
+                    },
+                    "errors": {
+                      "type": "array",
+                      "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string",
+                            "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                          },
+                          "message": {
+                            "type": "string",
+                            "description": "Human-readable error message."
+                          },
+                          "field": {
+                            "type": "string",
+                            "description": "The field that caused the error (for validation errors)."
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "success"
+                  ],
+                  "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                 },
                 "example": {
                   "success": false,
@@ -1998,12 +5084,169 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/ai/AudioTranscription.json"
+                          "type": "object",
+                          "description": "Represents an audio transcription result, following the OpenAI Whisper API response format. Contains the transcribed text along with optional metadata such as detected language, audio duration, word-level timestamps, and segment-level data.",
+                          "properties": {
+                            "text": {
+                              "type": "string",
+                              "readOnly": true,
+                              "description": "The full transcribed text output from the audio file."
+                            },
+                            "language": {
+                              "type": "string",
+                              "readOnly": true,
+                              "description": "The detected or specified language code in ISO-639-1 format (e.g., \"en\" for English, \"es\" for Spanish, \"he\" for Hebrew)."
+                            },
+                            "duration": {
+                              "type": "number",
+                              "readOnly": true,
+                              "description": "Total duration of the audio file in seconds (e.g., 3.5)."
+                            },
+                            "words": {
+                              "type": "array",
+                              "readOnly": true,
+                              "description": "Word-level timestamps for each transcribed word. Only present when using the 'verbose_json' response format.",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "word": {
+                                    "type": "string",
+                                    "description": "The transcribed word."
+                                  },
+                                  "start": {
+                                    "type": "number",
+                                    "description": "Start time of the word in seconds from the beginning of the audio."
+                                  },
+                                  "end": {
+                                    "type": "number",
+                                    "description": "End time of the word in seconds from the beginning of the audio."
+                                  }
+                                }
+                              }
+                            },
+                            "segments": {
+                              "type": "array",
+                              "readOnly": true,
+                              "description": "Segment-level data with timing and optional speaker information. Each segment represents a contiguous block of transcribed speech, useful for diarization and long audio files.",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "id": {
+                                    "type": "integer",
+                                    "description": "Sequential identifier for the segment (e.g., 0, 1, 2)."
+                                  },
+                                  "start": {
+                                    "type": "number",
+                                    "description": "Start time of the segment in seconds from the beginning of the audio."
+                                  },
+                                  "end": {
+                                    "type": "number",
+                                    "description": "End time of the segment in seconds from the beginning of the audio."
+                                  },
+                                  "text": {
+                                    "type": "string",
+                                    "description": "The transcribed text for this segment."
+                                  },
+                                  "speaker": {
+                                    "type": "string",
+                                    "description": "Speaker identifier when diarization is enabled (e.g., \"SPEAKER_00\", \"SPEAKER_01\")."
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "required": [
+                            "text"
+                          ],
+                          "example": {
+                            "text": "For more information visit www.FEMA.gov",
+                            "language": "en",
+                            "duration": 3.5,
+                            "words": [
+                              {
+                                "word": "For",
+                                "start": 0,
+                                "end": 0.18
+                              },
+                              {
+                                "word": "more",
+                                "start": 0.18,
+                                "end": 0.38
+                              },
+                              {
+                                "word": "information",
+                                "start": 0.38,
+                                "end": 0.92
+                              },
+                              {
+                                "word": "visit",
+                                "start": 0.92,
+                                "end": 1.24
+                              },
+                              {
+                                "word": "www.FEMA.gov",
+                                "start": 1.24,
+                                "end": 3.5
+                              }
+                            ],
+                            "segments": [
+                              {
+                                "id": 0,
+                                "start": 0,
+                                "end": 3.5,
+                                "text": "For more information visit www.FEMA.gov",
+                                "speaker": "SPEAKER_00"
+                              }
+                            ]
+                          }
                         }
                       }
                     }
@@ -2019,12 +5262,225 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/ai/TranscriptionRun.json"
+                          "type": "object",
+                          "description": "Represents an async transcription run. Poll this resource until status is COMPLETED or FAILED.",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "readOnly": true,
+                              "description": "Unique identifier of the transcription run."
+                            },
+                            "status": {
+                              "type": "string",
+                              "readOnly": true,
+                              "enum": [
+                                "QUEUED",
+                                "IN_PROGRESS",
+                                "COMPLETED",
+                                "FAILED"
+                              ],
+                              "description": "Current status of the run. Possible values: 'QUEUED' (job is waiting to be processed), 'IN_PROGRESS' (job is actively being processed by the transcription provider), 'COMPLETED' (job finished successfully and result is available), 'FAILED' (job encountered an error and error_message is available)."
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "readOnly": true,
+                              "description": "The date and time when the run was created, in ISO 8601 format (e.g., \"2026-02-08T13:18:39.698Z\")."
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "readOnly": true,
+                              "description": "The date and time when the run was last updated, in ISO 8601 format (e.g., \"2026-02-08T13:18:41.000Z\")."
+                            },
+                            "result": {
+                              "type": "object",
+                              "description": "The transcription result. Only present when status is 'COMPLETED'.",
+                              "properties": {
+                                "text": {
+                                  "type": "string",
+                                  "readOnly": true,
+                                  "description": "The full transcribed text output from the audio file."
+                                },
+                                "language": {
+                                  "type": "string",
+                                  "readOnly": true,
+                                  "description": "The detected or specified language code in ISO-639-1 format (e.g., \"en\" for English, \"es\" for Spanish, \"he\" for Hebrew)."
+                                },
+                                "duration": {
+                                  "type": "number",
+                                  "readOnly": true,
+                                  "description": "Total duration of the audio file in seconds (e.g., 3.5)."
+                                },
+                                "words": {
+                                  "type": "array",
+                                  "readOnly": true,
+                                  "description": "Word-level timestamps for each transcribed word. Only present when using the 'verbose_json' response format.",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "word": {
+                                        "type": "string",
+                                        "description": "The transcribed word."
+                                      },
+                                      "start": {
+                                        "type": "number",
+                                        "description": "Start time of the word in seconds from the beginning of the audio."
+                                      },
+                                      "end": {
+                                        "type": "number",
+                                        "description": "End time of the word in seconds from the beginning of the audio."
+                                      }
+                                    }
+                                  }
+                                },
+                                "segments": {
+                                  "type": "array",
+                                  "readOnly": true,
+                                  "description": "Segment-level data with timing and optional speaker information. Each segment represents a contiguous block of transcribed speech, useful for diarization and long audio files.",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "id": {
+                                        "type": "integer",
+                                        "description": "Sequential identifier for the segment (e.g., 0, 1, 2)."
+                                      },
+                                      "start": {
+                                        "type": "number",
+                                        "description": "Start time of the segment in seconds from the beginning of the audio."
+                                      },
+                                      "end": {
+                                        "type": "number",
+                                        "description": "End time of the segment in seconds from the beginning of the audio."
+                                      },
+                                      "text": {
+                                        "type": "string",
+                                        "description": "The transcribed text for this segment."
+                                      },
+                                      "speaker": {
+                                        "type": "string",
+                                        "description": "Speaker identifier when diarization is enabled (e.g., \"SPEAKER_00\", \"SPEAKER_01\")."
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              "required": [
+                                "text"
+                              ],
+                              "example": {
+                                "text": "For more information visit www.FEMA.gov",
+                                "language": "en",
+                                "duration": 3.5,
+                                "words": [
+                                  {
+                                    "word": "For",
+                                    "start": 0,
+                                    "end": 0.18
+                                  },
+                                  {
+                                    "word": "more",
+                                    "start": 0.18,
+                                    "end": 0.38
+                                  },
+                                  {
+                                    "word": "information",
+                                    "start": 0.38,
+                                    "end": 0.92
+                                  },
+                                  {
+                                    "word": "visit",
+                                    "start": 0.92,
+                                    "end": 1.24
+                                  },
+                                  {
+                                    "word": "www.FEMA.gov",
+                                    "start": 1.24,
+                                    "end": 3.5
+                                  }
+                                ],
+                                "segments": [
+                                  {
+                                    "id": 0,
+                                    "start": 0,
+                                    "end": 3.5,
+                                    "text": "For more information visit www.FEMA.gov",
+                                    "speaker": "SPEAKER_00"
+                                  }
+                                ]
+                              },
+                              "readOnly": true
+                            },
+                            "error_message": {
+                              "type": "string",
+                              "readOnly": true,
+                              "description": "Error message describing the failure reason. Only present when status is 'FAILED'."
+                            }
+                          },
+                          "required": [
+                            "uid",
+                            "status",
+                            "created_at"
+                          ],
+                          "example": {
+                            "uid": "85ade9f5-2690-48e8-ae5b-b07d6b57b457",
+                            "status": "COMPLETED",
+                            "created_at": "2026-02-08T13:18:39.698Z",
+                            "updated_at": "2026-02-08T13:18:41.000Z",
+                            "result": {
+                              "text": "For more information visit www.FEMA.gov",
+                              "language": "en",
+                              "duration": 3.5
+                            }
+                          }
                         }
                       }
                     }
@@ -2038,7 +5494,50 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "description": "Indicates whether the API request was successful (true) or failed (false)."
+                    },
+                    "data": {
+                      "type": "object",
+                      "description": "The response payload. Present on successful responses (success: true)."
+                    },
+                    "error": {
+                      "type": "string",
+                      "description": "Error message for simple error responses. Used in some legacy endpoints."
+                    },
+                    "errors": {
+                      "type": "array",
+                      "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string",
+                            "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                          },
+                          "message": {
+                            "type": "string",
+                            "description": "Human-readable error message."
+                          },
+                          "field": {
+                            "type": "string",
+                            "description": "The field that caused the error (for validation errors)."
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "success"
+                  ],
+                  "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                 },
                 "example": {
                   "success": false,
@@ -2057,7 +5556,50 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "description": "Indicates whether the API request was successful (true) or failed (false)."
+                    },
+                    "data": {
+                      "type": "object",
+                      "description": "The response payload. Present on successful responses (success: true)."
+                    },
+                    "error": {
+                      "type": "string",
+                      "description": "Error message for simple error responses. Used in some legacy endpoints."
+                    },
+                    "errors": {
+                      "type": "array",
+                      "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string",
+                            "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                          },
+                          "message": {
+                            "type": "string",
+                            "description": "Human-readable error message."
+                          },
+                          "field": {
+                            "type": "string",
+                            "description": "The field that caused the error (for validation errors)."
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "success"
+                  ],
+                  "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                 },
                 "example": {
                   "success": false,
@@ -2076,7 +5618,50 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "description": "Indicates whether the API request was successful (true) or failed (false)."
+                    },
+                    "data": {
+                      "type": "object",
+                      "description": "The response payload. Present on successful responses (success: true)."
+                    },
+                    "error": {
+                      "type": "string",
+                      "description": "Error message for simple error responses. Used in some legacy endpoints."
+                    },
+                    "errors": {
+                      "type": "array",
+                      "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string",
+                            "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                          },
+                          "message": {
+                            "type": "string",
+                            "description": "Human-readable error message."
+                          },
+                          "field": {
+                            "type": "string",
+                            "description": "The field that caused the error (for validation errors)."
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "success"
+                  ],
+                  "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                 },
                 "example": {
                   "success": false,
@@ -2096,7 +5681,50 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "description": "Indicates whether the API request was successful (true) or failed (false)."
+                    },
+                    "data": {
+                      "type": "object",
+                      "description": "The response payload. Present on successful responses (success: true)."
+                    },
+                    "error": {
+                      "type": "string",
+                      "description": "Error message for simple error responses. Used in some legacy endpoints."
+                    },
+                    "errors": {
+                      "type": "array",
+                      "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string",
+                            "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                          },
+                          "message": {
+                            "type": "string",
+                            "description": "Human-readable error message."
+                          },
+                          "field": {
+                            "type": "string",
+                            "description": "The field that caused the error (for validation errors)."
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "success"
+                  ],
+                  "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                 },
                 "example": {
                   "success": false,
@@ -2116,7 +5744,50 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "description": "Indicates whether the API request was successful (true) or failed (false)."
+                    },
+                    "data": {
+                      "type": "object",
+                      "description": "The response payload. Present on successful responses (success: true)."
+                    },
+                    "error": {
+                      "type": "string",
+                      "description": "Error message for simple error responses. Used in some legacy endpoints."
+                    },
+                    "errors": {
+                      "type": "array",
+                      "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string",
+                            "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                          },
+                          "message": {
+                            "type": "string",
+                            "description": "Human-readable error message."
+                          },
+                          "field": {
+                            "type": "string",
+                            "description": "The field that caused the error (for validation errors)."
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "success"
+                  ],
+                  "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                 },
                 "example": {
                   "success": false,
@@ -2164,12 +5835,285 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/ai/ChatCompletionRun.json"
+                          "type": "object",
+                          "description": "Represents an async chat completion run. Poll this resource until status is COMPLETED or FAILED.",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "readOnly": true,
+                              "description": "Unique identifier of the chat completion run."
+                            },
+                            "status": {
+                              "type": "string",
+                              "readOnly": true,
+                              "enum": [
+                                "QUEUED",
+                                "IN_PROGRESS",
+                                "COMPLETED",
+                                "FAILED"
+                              ],
+                              "description": "Current status of the run. Possible values: 'QUEUED' (job is waiting to be processed), 'IN_PROGRESS' (job is actively being processed by the LLM provider), 'COMPLETED' (job finished successfully and result is available), 'FAILED' (job encountered an error and error_message is available)."
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "readOnly": true,
+                              "description": "The date and time when the run was created, in ISO 8601 format (e.g., \"2026-02-09T09:31:30.934Z\")."
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "readOnly": true,
+                              "description": "The date and time when the run was last updated, in ISO 8601 format (e.g., \"2026-02-09T09:31:31.000Z\")."
+                            },
+                            "result": {
+                              "type": "object",
+                              "description": "The completion result. Only present when status is 'COMPLETED'.",
+                              "properties": {
+                                "uid": {
+                                  "type": "string",
+                                  "readOnly": true,
+                                  "description": "Unique identifier for this completion (e.g., \"chatcmpl-1677652288-a1b2c3\")."
+                                },
+                                "object": {
+                                  "type": "string",
+                                  "readOnly": true,
+                                  "description": "Object type identifier. Always 'chat.completion' for non-streaming responses.",
+                                  "enum": [
+                                    "chat.completion"
+                                  ]
+                                },
+                                "created_at": {
+                                  "type": "string",
+                                  "format": "date-time",
+                                  "readOnly": true,
+                                  "description": "The date and time when the completion was created, in ISO 8601 format (e.g., \"2026-02-09T09:31:30.000Z\")."
+                                },
+                                "model": {
+                                  "type": "string",
+                                  "readOnly": true,
+                                  "description": "The model used for the completion in provider/model format (e.g., \"openai/gpt-4o-mini\", \"anthropic/claude-sonnet-4-5-20250929\")."
+                                },
+                                "choices": {
+                                  "type": "array",
+                                  "readOnly": true,
+                                  "description": "Array of completion choices generated by the model. Typically contains a single choice.",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "index": {
+                                        "type": "integer",
+                                        "description": "Zero-based index of this choice in the choices array."
+                                      },
+                                      "message": {
+                                        "type": "object",
+                                        "properties": {
+                                          "role": {
+                                            "type": "string",
+                                            "enum": [
+                                              "assistant"
+                                            ],
+                                            "description": "The role of the message author. Always 'assistant' for completion responses."
+                                          },
+                                          "content": {
+                                            "type": "string",
+                                            "nullable": true,
+                                            "description": "The text content of the assistant's response. May be null when the model makes tool calls instead of generating text."
+                                          },
+                                          "tool_calls": {
+                                            "type": "array",
+                                            "description": "Tool calls requested by the assistant. Present when the model decides to call one or more functions defined in the request's 'tools' parameter.",
+                                            "items": {
+                                              "type": "object",
+                                              "description": "A tool call requested by the assistant during a chat completion. Contains the function name and arguments the model wants to invoke.",
+                                              "properties": {
+                                                "id": {
+                                                  "type": "string",
+                                                  "description": "Unique identifier for this tool call, used to match tool responses back to the request (e.g., \"call_abc123\")."
+                                                },
+                                                "type": {
+                                                  "type": "string",
+                                                  "enum": [
+                                                    "function"
+                                                  ],
+                                                  "description": "The type of tool call. Currently only 'function' is supported."
+                                                },
+                                                "function": {
+                                                  "type": "object",
+                                                  "description": "The function to be called, including its name and arguments.",
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string",
+                                                      "description": "The name of the function to call (e.g., \"get_weather\")."
+                                                    },
+                                                    "arguments": {
+                                                      "type": "string",
+                                                      "description": "A JSON-encoded string of the arguments to pass to the function (e.g., \"{\\\"location\\\": \\\"Paris\\\"}\")."
+                                                    }
+                                                  }
+                                                }
+                                              },
+                                              "example": {
+                                                "id": "call_abc123",
+                                                "type": "function",
+                                                "function": {
+                                                  "name": "get_weather",
+                                                  "arguments": "{\"location\": \"Paris\"}"
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "finish_reason": {
+                                        "type": "string",
+                                        "enum": [
+                                          "stop",
+                                          "length",
+                                          "tool_calls",
+                                          "content_filter"
+                                        ],
+                                        "description": "The reason the model stopped generating. 'stop' means the model naturally finished, 'length' means max_tokens was reached, 'tool_calls' means the model wants to call a function, 'content_filter' means content was filtered by safety systems."
+                                      }
+                                    }
+                                  }
+                                },
+                                "usage": {
+                                  "type": "object",
+                                  "readOnly": true,
+                                  "description": "Token usage statistics for the completion request. Useful for tracking costs and monitoring token consumption.",
+                                  "properties": {
+                                    "prompt_tokens": {
+                                      "type": "integer",
+                                      "description": "Number of tokens in the input prompt (e.g., 9)."
+                                    },
+                                    "completion_tokens": {
+                                      "type": "integer",
+                                      "description": "Number of tokens generated in the completion response (e.g., 9)."
+                                    },
+                                    "total_tokens": {
+                                      "type": "integer",
+                                      "description": "Total number of tokens used (prompt_tokens + completion_tokens) (e.g., 18)."
+                                    }
+                                  }
+                                }
+                              },
+                              "required": [
+                                "uid",
+                                "object",
+                                "created_at",
+                                "model",
+                                "choices"
+                              ],
+                              "example": {
+                                "uid": "chatcmpl-1677652288-a1b2c3",
+                                "object": "chat.completion",
+                                "created_at": "2026-02-09T09:31:30.000Z",
+                                "model": "openai/gpt-4o-mini",
+                                "choices": [
+                                  {
+                                    "index": 0,
+                                    "message": {
+                                      "role": "assistant",
+                                      "content": "Hello! How can I help you today?"
+                                    },
+                                    "finish_reason": "stop"
+                                  }
+                                ],
+                                "usage": {
+                                  "prompt_tokens": 9,
+                                  "completion_tokens": 9,
+                                  "total_tokens": 18
+                                }
+                              },
+                              "readOnly": true
+                            },
+                            "error_message": {
+                              "type": "string",
+                              "readOnly": true,
+                              "description": "Error message describing the failure reason. Only present when status is 'FAILED'."
+                            }
+                          },
+                          "required": [
+                            "uid",
+                            "status",
+                            "created_at"
+                          ],
+                          "example": {
+                            "uid": "0ce1af9d-3337-419b-933c-02ea21d4d9ca",
+                            "status": "COMPLETED",
+                            "created_at": "2026-02-09T09:31:30.934Z",
+                            "updated_at": "2026-02-09T09:31:31.000Z",
+                            "result": {
+                              "uid": "chatcmpl-1677652288-a1b2c3",
+                              "object": "chat.completion",
+                              "created_at": "2026-02-09T09:31:30.000Z",
+                              "model": "openai/gpt-4o-mini",
+                              "choices": [
+                                {
+                                  "index": 0,
+                                  "message": {
+                                    "role": "assistant",
+                                    "content": "2 + 2 equals 4."
+                                  },
+                                  "finish_reason": "stop"
+                                }
+                              ],
+                              "usage": {
+                                "prompt_tokens": 14,
+                                "completion_tokens": 8,
+                                "total_tokens": 22
+                              }
+                            }
+                          }
                         }
                       }
                     }
@@ -2183,7 +6127,50 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "description": "Indicates whether the API request was successful (true) or failed (false)."
+                    },
+                    "data": {
+                      "type": "object",
+                      "description": "The response payload. Present on successful responses (success: true)."
+                    },
+                    "error": {
+                      "type": "string",
+                      "description": "Error message for simple error responses. Used in some legacy endpoints."
+                    },
+                    "errors": {
+                      "type": "array",
+                      "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string",
+                            "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                          },
+                          "message": {
+                            "type": "string",
+                            "description": "Human-readable error message."
+                          },
+                          "field": {
+                            "type": "string",
+                            "description": "The field that caused the error (for validation errors)."
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "success"
+                  ],
+                  "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                 },
                 "example": {
                   "success": false,
@@ -2202,7 +6189,50 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "description": "Indicates whether the API request was successful (true) or failed (false)."
+                    },
+                    "data": {
+                      "type": "object",
+                      "description": "The response payload. Present on successful responses (success: true)."
+                    },
+                    "error": {
+                      "type": "string",
+                      "description": "Error message for simple error responses. Used in some legacy endpoints."
+                    },
+                    "errors": {
+                      "type": "array",
+                      "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string",
+                            "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                          },
+                          "message": {
+                            "type": "string",
+                            "description": "Human-readable error message."
+                          },
+                          "field": {
+                            "type": "string",
+                            "description": "The field that caused the error (for validation errors)."
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "success"
+                  ],
+                  "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                 },
                 "example": {
                   "success": false,
@@ -2272,7 +6302,50 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
@@ -2291,7 +6364,50 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "description": "Indicates whether the API request was successful (true) or failed (false)."
+                    },
+                    "data": {
+                      "type": "object",
+                      "description": "The response payload. Present on successful responses (success: true)."
+                    },
+                    "error": {
+                      "type": "string",
+                      "description": "Error message for simple error responses. Used in some legacy endpoints."
+                    },
+                    "errors": {
+                      "type": "array",
+                      "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string",
+                            "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                          },
+                          "message": {
+                            "type": "string",
+                            "description": "Human-readable error message."
+                          },
+                          "field": {
+                            "type": "string",
+                            "description": "The field that caused the error (for validation errors)."
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "success"
+                  ],
+                  "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                 },
                 "example": {
                   "success": false,
@@ -2339,12 +6455,225 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/ai/TranscriptionRun.json"
+                          "type": "object",
+                          "description": "Represents an async transcription run. Poll this resource until status is COMPLETED or FAILED.",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "readOnly": true,
+                              "description": "Unique identifier of the transcription run."
+                            },
+                            "status": {
+                              "type": "string",
+                              "readOnly": true,
+                              "enum": [
+                                "QUEUED",
+                                "IN_PROGRESS",
+                                "COMPLETED",
+                                "FAILED"
+                              ],
+                              "description": "Current status of the run. Possible values: 'QUEUED' (job is waiting to be processed), 'IN_PROGRESS' (job is actively being processed by the transcription provider), 'COMPLETED' (job finished successfully and result is available), 'FAILED' (job encountered an error and error_message is available)."
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "readOnly": true,
+                              "description": "The date and time when the run was created, in ISO 8601 format (e.g., \"2026-02-08T13:18:39.698Z\")."
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "readOnly": true,
+                              "description": "The date and time when the run was last updated, in ISO 8601 format (e.g., \"2026-02-08T13:18:41.000Z\")."
+                            },
+                            "result": {
+                              "type": "object",
+                              "description": "The transcription result. Only present when status is 'COMPLETED'.",
+                              "properties": {
+                                "text": {
+                                  "type": "string",
+                                  "readOnly": true,
+                                  "description": "The full transcribed text output from the audio file."
+                                },
+                                "language": {
+                                  "type": "string",
+                                  "readOnly": true,
+                                  "description": "The detected or specified language code in ISO-639-1 format (e.g., \"en\" for English, \"es\" for Spanish, \"he\" for Hebrew)."
+                                },
+                                "duration": {
+                                  "type": "number",
+                                  "readOnly": true,
+                                  "description": "Total duration of the audio file in seconds (e.g., 3.5)."
+                                },
+                                "words": {
+                                  "type": "array",
+                                  "readOnly": true,
+                                  "description": "Word-level timestamps for each transcribed word. Only present when using the 'verbose_json' response format.",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "word": {
+                                        "type": "string",
+                                        "description": "The transcribed word."
+                                      },
+                                      "start": {
+                                        "type": "number",
+                                        "description": "Start time of the word in seconds from the beginning of the audio."
+                                      },
+                                      "end": {
+                                        "type": "number",
+                                        "description": "End time of the word in seconds from the beginning of the audio."
+                                      }
+                                    }
+                                  }
+                                },
+                                "segments": {
+                                  "type": "array",
+                                  "readOnly": true,
+                                  "description": "Segment-level data with timing and optional speaker information. Each segment represents a contiguous block of transcribed speech, useful for diarization and long audio files.",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "id": {
+                                        "type": "integer",
+                                        "description": "Sequential identifier for the segment (e.g., 0, 1, 2)."
+                                      },
+                                      "start": {
+                                        "type": "number",
+                                        "description": "Start time of the segment in seconds from the beginning of the audio."
+                                      },
+                                      "end": {
+                                        "type": "number",
+                                        "description": "End time of the segment in seconds from the beginning of the audio."
+                                      },
+                                      "text": {
+                                        "type": "string",
+                                        "description": "The transcribed text for this segment."
+                                      },
+                                      "speaker": {
+                                        "type": "string",
+                                        "description": "Speaker identifier when diarization is enabled (e.g., \"SPEAKER_00\", \"SPEAKER_01\")."
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              "required": [
+                                "text"
+                              ],
+                              "example": {
+                                "text": "For more information visit www.FEMA.gov",
+                                "language": "en",
+                                "duration": 3.5,
+                                "words": [
+                                  {
+                                    "word": "For",
+                                    "start": 0,
+                                    "end": 0.18
+                                  },
+                                  {
+                                    "word": "more",
+                                    "start": 0.18,
+                                    "end": 0.38
+                                  },
+                                  {
+                                    "word": "information",
+                                    "start": 0.38,
+                                    "end": 0.92
+                                  },
+                                  {
+                                    "word": "visit",
+                                    "start": 0.92,
+                                    "end": 1.24
+                                  },
+                                  {
+                                    "word": "www.FEMA.gov",
+                                    "start": 1.24,
+                                    "end": 3.5
+                                  }
+                                ],
+                                "segments": [
+                                  {
+                                    "id": 0,
+                                    "start": 0,
+                                    "end": 3.5,
+                                    "text": "For more information visit www.FEMA.gov",
+                                    "speaker": "SPEAKER_00"
+                                  }
+                                ]
+                              },
+                              "readOnly": true
+                            },
+                            "error_message": {
+                              "type": "string",
+                              "readOnly": true,
+                              "description": "Error message describing the failure reason. Only present when status is 'FAILED'."
+                            }
+                          },
+                          "required": [
+                            "uid",
+                            "status",
+                            "created_at"
+                          ],
+                          "example": {
+                            "uid": "85ade9f5-2690-48e8-ae5b-b07d6b57b457",
+                            "status": "COMPLETED",
+                            "created_at": "2026-02-08T13:18:39.698Z",
+                            "updated_at": "2026-02-08T13:18:41.000Z",
+                            "result": {
+                              "text": "For more information visit www.FEMA.gov",
+                              "language": "en",
+                              "duration": 3.5
+                            }
+                          }
                         }
                       }
                     }
@@ -2358,7 +6687,50 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "description": "Indicates whether the API request was successful (true) or failed (false)."
+                    },
+                    "data": {
+                      "type": "object",
+                      "description": "The response payload. Present on successful responses (success: true)."
+                    },
+                    "error": {
+                      "type": "string",
+                      "description": "Error message for simple error responses. Used in some legacy endpoints."
+                    },
+                    "errors": {
+                      "type": "array",
+                      "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string",
+                            "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                          },
+                          "message": {
+                            "type": "string",
+                            "description": "Human-readable error message."
+                          },
+                          "field": {
+                            "type": "string",
+                            "description": "The field that caused the error (for validation errors)."
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "success"
+                  ],
+                  "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                 },
                 "example": {
                   "success": false,
@@ -2377,7 +6749,50 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "description": "Indicates whether the API request was successful (true) or failed (false)."
+                    },
+                    "data": {
+                      "type": "object",
+                      "description": "The response payload. Present on successful responses (success: true)."
+                    },
+                    "error": {
+                      "type": "string",
+                      "description": "Error message for simple error responses. Used in some legacy endpoints."
+                    },
+                    "errors": {
+                      "type": "array",
+                      "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string",
+                            "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                          },
+                          "message": {
+                            "type": "string",
+                            "description": "Human-readable error message."
+                          },
+                          "field": {
+                            "type": "string",
+                            "description": "The field that caused the error (for validation errors)."
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "success"
+                  ],
+                  "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                 },
                 "example": {
                   "success": false,
@@ -2447,7 +6862,50 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
@@ -2466,7 +6924,50 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "description": "Indicates whether the API request was successful (true) or failed (false)."
+                    },
+                    "data": {
+                      "type": "object",
+                      "description": "The response payload. Present on successful responses (success: true)."
+                    },
+                    "error": {
+                      "type": "string",
+                      "description": "Error message for simple error responses. Used in some legacy endpoints."
+                    },
+                    "errors": {
+                      "type": "array",
+                      "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string",
+                            "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                          },
+                          "message": {
+                            "type": "string",
+                            "description": "Human-readable error message."
+                          },
+                          "field": {
+                            "type": "string",
+                            "description": "The field that caused the error (for validation errors)."
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "success"
+                  ],
+                  "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                 },
                 "example": {
                   "success": false,
@@ -2516,12 +7017,145 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/ai/staffAiSettings.json"
+                          "title": "StaffAiSettings",
+                          "description": "AI settings configuration for a staff member, controlling which AI features and recommendations are enabled",
+                          "type": "object",
+                          "properties": {
+                            "staff_uid": {
+                              "type": "string",
+                              "format": "uuid",
+                              "description": "The unique identifier of the staff member these settings belong to"
+                            },
+                            "ai_recommendations": {
+                              "type": "object",
+                              "description": "AI recommendations settings configuration for a staff member",
+                              "properties": {
+                                "enable": {
+                                  "type": "boolean",
+                                  "description": "Whether AI recommendations are enabled for this staff member"
+                                },
+                                "sub_options": {
+                                  "type": "object",
+                                  "description": "Specific AI recommendation sub-options that can be enabled or disabled individually",
+                                  "properties": {
+                                    "next_best_action": {
+                                      "type": "boolean",
+                                      "description": "Whether next best action recommendations are enabled"
+                                    },
+                                    "estimate": {
+                                      "type": "boolean",
+                                      "description": "Whether estimate recommendations are enabled"
+                                    },
+                                    "scheduling": {
+                                      "type": "boolean",
+                                      "description": "Whether scheduling recommendations are enabled"
+                                    }
+                                  },
+                                  "required": [
+                                    "next_best_action",
+                                    "estimate",
+                                    "scheduling"
+                                  ]
+                                }
+                              },
+                              "required": [
+                                "enable",
+                                "sub_options"
+                              ]
+                            },
+                            "smart_reply": {
+                              "type": "object",
+                              "description": "Smart reply settings configuration for a staff member",
+                              "properties": {
+                                "enable": {
+                                  "type": "boolean",
+                                  "description": "Whether smart reply feature is enabled for this staff member"
+                                }
+                              },
+                              "required": [
+                                "enable"
+                              ]
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "description": "The timestamp when the settings were created, in ISO 8601 format",
+                              "readOnly": true
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "description": "The timestamp when the settings were last updated, in ISO 8601 format",
+                              "readOnly": true
+                            }
+                          },
+                          "required": [
+                            "staff_uid"
+                          ],
+                          "example": {
+                            "staff_uid": "f390f1ee-6c54-4b01-90e6-d701748f0852",
+                            "ai_recommendations": {
+                              "enable": true,
+                              "sub_options": {
+                                "next_best_action": true,
+                                "estimate": false,
+                                "scheduling": true
+                              }
+                            },
+                            "smart_reply": {
+                              "enable": true
+                            },
+                            "created_at": "2025-01-20T14:00:00.000Z",
+                            "updated_at": "2025-01-20T14:30:00.000Z"
+                          }
                         }
                       }
                     }
@@ -2594,12 +7228,145 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/ai/staffAiSettings.json"
+                          "title": "StaffAiSettings",
+                          "description": "AI settings configuration for a staff member, controlling which AI features and recommendations are enabled",
+                          "type": "object",
+                          "properties": {
+                            "staff_uid": {
+                              "type": "string",
+                              "format": "uuid",
+                              "description": "The unique identifier of the staff member these settings belong to"
+                            },
+                            "ai_recommendations": {
+                              "type": "object",
+                              "description": "AI recommendations settings configuration for a staff member",
+                              "properties": {
+                                "enable": {
+                                  "type": "boolean",
+                                  "description": "Whether AI recommendations are enabled for this staff member"
+                                },
+                                "sub_options": {
+                                  "type": "object",
+                                  "description": "Specific AI recommendation sub-options that can be enabled or disabled individually",
+                                  "properties": {
+                                    "next_best_action": {
+                                      "type": "boolean",
+                                      "description": "Whether next best action recommendations are enabled"
+                                    },
+                                    "estimate": {
+                                      "type": "boolean",
+                                      "description": "Whether estimate recommendations are enabled"
+                                    },
+                                    "scheduling": {
+                                      "type": "boolean",
+                                      "description": "Whether scheduling recommendations are enabled"
+                                    }
+                                  },
+                                  "required": [
+                                    "next_best_action",
+                                    "estimate",
+                                    "scheduling"
+                                  ]
+                                }
+                              },
+                              "required": [
+                                "enable",
+                                "sub_options"
+                              ]
+                            },
+                            "smart_reply": {
+                              "type": "object",
+                              "description": "Smart reply settings configuration for a staff member",
+                              "properties": {
+                                "enable": {
+                                  "type": "boolean",
+                                  "description": "Whether smart reply feature is enabled for this staff member"
+                                }
+                              },
+                              "required": [
+                                "enable"
+                              ]
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "description": "The timestamp when the settings were created, in ISO 8601 format",
+                              "readOnly": true
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "description": "The timestamp when the settings were last updated, in ISO 8601 format",
+                              "readOnly": true
+                            }
+                          },
+                          "required": [
+                            "staff_uid"
+                          ],
+                          "example": {
+                            "staff_uid": "f390f1ee-6c54-4b01-90e6-d701748f0852",
+                            "ai_recommendations": {
+                              "enable": true,
+                              "sub_options": {
+                                "next_best_action": true,
+                                "estimate": false,
+                                "scheduling": true
+                              }
+                            },
+                            "smart_reply": {
+                              "enable": true
+                            },
+                            "created_at": "2025-01-20T14:00:00.000Z",
+                            "updated_at": "2025-01-20T14:30:00.000Z"
+                          }
                         }
                       }
                     }
@@ -2676,7 +7443,101 @@
                       "type": "boolean"
                     },
                     "data": {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/ai/AiGenerationFeedback.json"
+                      "type": "object",
+                      "properties": {
+                        "uid": {
+                          "type": "string",
+                          "description": "The unique identifier (UID) of the AI generation feedback"
+                        },
+                        "created_at": {
+                          "type": "string",
+                          "format": "date-time",
+                          "description": "The timestamp when the feedback was created, in ISO 8601 format"
+                        },
+                        "updated_at": {
+                          "type": "string",
+                          "format": "date-time",
+                          "description": "The timestamp when the feedback was last updated, in ISO 8601 format"
+                        },
+                        "type": {
+                          "type": "string",
+                          "description": "The type of feedback provided",
+                          "enum": [
+                            "int",
+                            "decimal",
+                            "text",
+                            "boolean"
+                          ]
+                        },
+                        "value": {
+                          "type": "string",
+                          "description": "The feedback value - stored as string regardless of feedback type (e.g., '4.5' for score, 'true' for boolean)"
+                        },
+                        "entity_type": {
+                          "type": "string",
+                          "description": "The type of entity this feedback is related to",
+                          "enum": [
+                            "AISmartReply",
+                            "AIRecommendation",
+                            "AIRecommendedAction"
+                          ]
+                        },
+                        "name": {
+                          "type": "string",
+                          "description": "The specific name/identifier for the feedback type",
+                          "enum": [
+                            "[AISmartReply] Business Sent Message UID",
+                            "[AISmartReply] Business Dismiss Reason"
+                          ]
+                        },
+                        "entity_uid": {
+                          "type": "string",
+                          "description": "The unique identifier of the related entity"
+                        }
+                      },
+                      "required": [
+                        "uid",
+                        "created_at",
+                        "updated_at",
+                        "type",
+                        "value",
+                        "entity_type",
+                        "entity_uid",
+                        "name"
+                      ],
+                      "examples": [
+                        {
+                          "uid": "fb-decimal-001",
+                          "created_at": "2025-02-04T14:15:00.000Z",
+                          "updated_at": "2025-02-04T14:15:00.000Z",
+                          "type": "decimal",
+                          "value": "4.5",
+                          "entity_type": "AIRecommendation",
+                          "entity_uid": "rec-d290f1ee-6c54-4b01-90e6-d701748f0851",
+                          "name": "[AISmartReply] Business Sent Message UID"
+                        },
+                        {
+                          "uid": "fb-bool-002",
+                          "created_at": "2025-02-04T14:20:00.000Z",
+                          "updated_at": "2025-02-04T14:20:00.000Z",
+                          "type": "boolean",
+                          "value": "true",
+                          "entity_type": "AISmartReply",
+                          "entity_uid": "sr-123",
+                          "name": "[AISmartReply] Business Dismiss Reason"
+                        },
+                        {
+                          "uid": "fb-text-003",
+                          "created_at": "2025-02-04T14:25:00.000Z",
+                          "updated_at": "2025-02-04T14:25:00.000Z",
+                          "type": "text",
+                          "value": "Great suggestion",
+                          "entity_type": "AIRecommendedAction",
+                          "entity_uid": "action-abc123",
+                          "name": "[AISmartReply] Business Sent Message UID"
+                        }
+                      ],
+                      "description": "Captures feedback on AI-generated outputs linked to specific entities."
                     }
                   }
                 }
@@ -2917,7 +7778,318 @@
             "description": "List of AI Recommendations",
             "type": "array",
             "items": {
-              "$ref": "https://vcita.github.io/developers-hub/entities/ai/AIRecommendation.json"
+              "type": "object",
+              "properties": {
+                "uid": {
+                  "type": "string",
+                  "description": "A unique identifier for the recommendation."
+                },
+                "producer": {
+                  "type": "string",
+                  "description": "Upstream agent or partner system that produced this recommendation (for example: 'client_agent', 'lead_capture_agent', 'partner_x')."
+                },
+                "business_uid": {
+                  "type": "string",
+                  "description": "The unique identifier (UID) of the business that owns this recommendation. Automatically set based on the authenticated token."
+                },
+                "created_at": {
+                  "type": "string",
+                  "format": "date-time",
+                  "description": "The timestamp when the recommendation was created, in ISO 8601 format."
+                },
+                "updated_at": {
+                  "type": "string",
+                  "format": "date-time",
+                  "description": "The timestamp when the recommendation was last updated, in ISO 8601 format."
+                },
+                "category": {
+                  "type": "string",
+                  "enum": [
+                    "needs_attention",
+                    "opportunity"
+                  ],
+                  "default": "needs_attention",
+                  "description": "Recommendation category set by the producer for interface use: 'needs_attention' (time-sensitive and requires the user's attention) or 'opportunity' (growth-focused value opportunity that does not require immediate action)."
+                },
+                "priority": {
+                  "type": "string",
+                  "enum": [
+                    "high",
+                    "standard"
+                  ],
+                  "default": "standard",
+                  "description": "Relative ordering priority within the same category: 'high' (higher priority, surfaced first) or 'standard' (default priority)."
+                },
+                "execution_policy": {
+                  "type": "string",
+                  "enum": [
+                    "auto_execute",
+                    "requires_human_approval"
+                  ],
+                  "default": "requires_human_approval",
+                  "description": "Indicates whether this recommendation is auto-executed by an agent or requires human review: 'auto_execute' (may be executed automatically by the system or an authorized agent) or 'requires_human_approval' (must be reviewed and approved by a human before execution)."
+                },
+                "tags": {
+                  "type": "array",
+                  "maxItems": 10,
+                  "description": "Optional user-facing tags that label the item's urgency, value, or context (for example: 'Hot lead', 'New', 'High value', 'Urgent', 'At risk', 'Follow up').",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "due_at": {
+                  "type": "string",
+                  "format": "date-time",
+                  "description": "Optional due or target time used for urgency and upcoming behavior, in ISO 8601 format."
+                },
+                "expired_at": {
+                  "type": "string",
+                  "format": "date-time",
+                  "description": "Optional expiry time used for dismissing or clearing the recommendation, in ISO 8601 format."
+                },
+                "actions": {
+                  "type": "array",
+                  "description": "A list of recommended actions related to this entity.",
+                  "items": {
+                    "type": "object",
+                    "description": "Represents a recommended action based on AI analysis.",
+                    "properties": {
+                      "uid": {
+                        "type": "string",
+                        "description": "A unique identifier for the recommended action."
+                      },
+                      "action": {
+                        "type": "string",
+                        "enum": [
+                          "reply",
+                          "estimate",
+                          "schedule",
+                          "acknowledge"
+                        ],
+                        "description": "The type of action recommended. Possible values:\n- 'reply': Suggests responding to a user message.\n- 'estimate': Suggests providing a price estimate.\n- 'schedule': Suggests scheduling an appointment or meeting.\n- 'acknowledge': No action or artifact is prepared; the user reviews the item and then completes or dismisses it."
+                      },
+                      "display": {
+                        "type": "object",
+                        "description": "Contains display-related information for the recommendation.",
+                        "properties": {
+                          "btn_text": {
+                            "type": "string",
+                            "description": "A human-readable title describing the recommendation."
+                          }
+                        }
+                      },
+                      "reason": {
+                        "type": "string",
+                        "description": "The reason why this action is recommended, providing context for decision-making."
+                      },
+                      "payload": {
+                        "type": "object",
+                        "description": "Additional data related to the recommended action. The structure depends on the action type."
+                      },
+                      "evidence": {
+                        "type": "array",
+                        "description": "A list of supporting statements or facts justifying the recommendation.",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "context": {
+                        "type": "object",
+                        "description": "The context in which the recommendation was generated.",
+                        "properties": {
+                          "context_uid": {
+                            "type": "string",
+                            "description": "A unique identifier for the context associated with this recommendation."
+                          },
+                          "context_type": {
+                            "type": "string",
+                            "description": "The type of context (e.g., 'matter','client', 'business').",
+                            "enum": [
+                              "matter",
+                              "client",
+                              "business"
+                            ]
+                          }
+                        }
+                      },
+                      "confidence": {
+                        "type": "number",
+                        "description": "A confidence score (0-1) indicating how confident the AI is in this recommendation."
+                      }
+                    },
+                    "required": [
+                      "uid",
+                      "action"
+                    ],
+                    "example": {
+                      "uid": "act-456",
+                      "action": "reply",
+                      "display": {
+                        "btn_text": "Generate Reply"
+                      },
+                      "reason": "User needs clarification on pricing",
+                      "evidence": [
+                        "User asked for price estimate"
+                      ],
+                      "payload": {
+                        "message": "Hi please send some more details"
+                      },
+                      "context": {
+                        "context_uid": "ctx-456",
+                        "context_type": "client"
+                      }
+                    }
+                  }
+                },
+                "display": {
+                  "type": "object",
+                  "description": "Contains display-related information for the recommendation.",
+                  "properties": {
+                    "title": {
+                      "type": "string",
+                      "description": "A human-readable title describing the recommendation."
+                    }
+                  }
+                },
+                "context": {
+                  "type": "object",
+                  "description": "The context in which the recommendation was generated.",
+                  "properties": {
+                    "context_uid": {
+                      "type": "string",
+                      "description": "A unique identifier for the context associated with this recommendation."
+                    },
+                    "context_type": {
+                      "type": "string",
+                      "description": "The type of context (e.g., 'matter','client', 'business').",
+                      "enum": [
+                        "matter",
+                        "client",
+                        "business"
+                      ]
+                    },
+                    "context_name": {
+                      "type": "string",
+                      "description": "The display name of the context object (referenced by 'context_uid') this recommendation is about, according to its 'context_type' - for example, the client's name when 'context_type' is 'client' (e.g., 'John Smith')."
+                    }
+                  }
+                },
+                "target": {
+                  "type": "object",
+                  "description": "The target entity for this recommendation, typically representing the user or business involved.",
+                  "properties": {
+                    "target_actor_uid": {
+                      "type": "string",
+                      "description": "A unique identifier for the target actor (e.g., a user or business)."
+                    },
+                    "target_actor_type": {
+                      "type": "string",
+                      "description": "The type of target actor (e.g., 'staff','directory').",
+                      "enum": [
+                        "staff",
+                        "directory"
+                      ]
+                    }
+                  }
+                },
+                "status": {
+                  "type": "object",
+                  "description": "Current lifecycle status of this recommendation, including the source of the latest status update.",
+                  "properties": {
+                    "state": {
+                      "type": "string",
+                      "enum": [
+                        "active",
+                        "completed",
+                        "dismissed",
+                        "approved",
+                        "snoozed"
+                      ],
+                      "default": "active",
+                      "description": "Lifecycle state of the recommendation: 'active' (available and not yet completed), 'completed' (executed successfully or otherwise resolved), 'dismissed' (explicitly dismissed without resolving the underlying need), 'approved' (approved by the user but not yet at a terminal outcome), or 'snoozed' (deferred to a later time or trigger condition)."
+                    },
+                    "state_source_type": {
+                      "type": "string",
+                      "enum": [
+                        "user",
+                        "system"
+                      ],
+                      "description": "Source of the current status: 'user' (change via Pulse UI) or 'system' (change by the originating service or agent)."
+                    },
+                    "dismissed": {
+                      "type": "boolean",
+                      "description": "Indicates whether the recommendation has been dismissed."
+                    },
+                    "dismissed_source_type": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "enum": [
+                        "user",
+                        "system",
+                        null
+                      ],
+                      "description": "The source that dismissed the recommendation. Null when the recommendation has not been dismissed."
+                    }
+                  }
+                }
+              },
+              "required": [
+                "uid",
+                "actions",
+                "display",
+                "context",
+                "target",
+                "status"
+              ],
+              "example": {
+                "uid": "rec-123",
+                "producer": "client_agent",
+                "business_uid": "biz-1234abcd",
+                "created_at": "2025-02-04T12:00:00Z",
+                "updated_at": "2025-02-04T12:30:00Z",
+                "category": "needs_attention",
+                "priority": "high",
+                "execution_policy": "requires_human_approval",
+                "tags": [
+                  "Hot lead"
+                ],
+                "due_at": "2026-06-08T09:00:00Z",
+                "actions": [
+                  {
+                    "uid": "act-456",
+                    "action": "reply",
+                    "reason": "Clarification needed",
+                    "display": {
+                      "btn_text": "Generate Reply"
+                    },
+                    "evidence": [
+                      "User asked for price estimate"
+                    ],
+                    "payload": {
+                      "message": "Hi, I can provide you with a roofing estimate. Please provide me with the address and any other relevant details."
+                    },
+                    "confidence": 0.85
+                  }
+                ],
+                "context": {
+                  "context_uid": "ctx-456",
+                  "context_type": "client",
+                  "context_name": "John Smith"
+                },
+                "target": {
+                  "target_actor_uid": "staff-789",
+                  "target_actor_type": "staff"
+                },
+                "status": {
+                  "state": "active",
+                  "state_source_type": "system",
+                  "dismissed": false,
+                  "dismissed_source_type": "user"
+                },
+                "description": "An AI-generated recommendation with context, target, actions, and status metadata."
+              }
             }
           }
         }
@@ -3065,7 +8237,103 @@
             "description": "List of history records",
             "type": "array",
             "items": {
-              "$ref": "https://vcita.github.io/developers-hub/entities/ai/BusinessRuleHistory.json"
+              "type": "object",
+              "description": "Represents a historical record of a change made to a business rule. Each time a rule is created, updated, or deleted, a history entry is recorded capturing the state of the rule at that point in time, who made the change, and what type of change it was. This provides a full audit trail for business rule management.",
+              "properties": {
+                "uid": {
+                  "type": "string",
+                  "readOnly": true,
+                  "description": "The unique identifier (UID) of the history record (e.g., \"hist-a1b2c3d4-e5f6-7890-abcd-ef1234567890\"). Assigned automatically by the system."
+                },
+                "rule_uid": {
+                  "type": "string",
+                  "readOnly": true,
+                  "description": "The UID of the business rule this history entry belongs to (e.g., \"br-a1b2c3d4-5678-90ef-ghij-klmnopqrstuv\"). Links back to the original business rule."
+                },
+                "business_uid": {
+                  "type": "string",
+                  "readOnly": true,
+                  "description": "The unique identifier (UID) of the business that owns the rule (e.g., \"biz-1234abcd-5678-90ef-ghij-klmnopqrstuv\")."
+                },
+                "content": {
+                  "type": "string",
+                  "description": "The content of the rule at the time of the change (e.g., \"Always use a friendly and professional tone when communicating with clients\"). This captures the exact state of the rule content when the history entry was recorded."
+                },
+                "source": {
+                  "type": "string",
+                  "description": "Indicates whether the change was made by the AI system or by a user (staff member).\n\n* `system` - The change was made automatically by the AI system.\n* `user` - The change was made manually by a staff member.",
+                  "enum": [
+                    "system",
+                    "user"
+                  ]
+                },
+                "action": {
+                  "type": "string",
+                  "description": "The type of change that was made to the business rule.\n\n* `created` - The rule was newly created.\n* `updated` - The rule's content, category, status, or other fields were modified.\n* `deleted` - The rule was removed.",
+                  "enum": [
+                    "created",
+                    "updated",
+                    "deleted"
+                  ]
+                },
+                "changed_by_staff_uid": {
+                  "type": "string",
+                  "description": "The UID of the staff member who made the change (e.g., \"stf-9876wxyz-5432-10ab-cdef-ghijklmnopqr\"). Will be null if the change was made by the system automatically.",
+                  "nullable": true
+                },
+                "changed_at": {
+                  "type": "string",
+                  "format": "date-time",
+                  "description": "The date and time when the change was made, in ISO 8601 format (e.g., \"2024-12-16T14:30:00.000Z\")."
+                },
+                "created_at": {
+                  "type": "string",
+                  "format": "date-time",
+                  "readOnly": true,
+                  "description": "The date and time when the history record was created, in ISO 8601 format (e.g., \"2024-12-16T14:30:00.000Z\")."
+                },
+                "updated_at": {
+                  "type": "string",
+                  "format": "date-time",
+                  "readOnly": true,
+                  "description": "The date and time when the history record was last updated, in ISO 8601 format (e.g., \"2024-12-16T14:30:00.000Z\")."
+                },
+                "category_code": {
+                  "type": "string",
+                  "description": "The category of the business rule at the time of the change.\n\n* `tone_of_voice` - Rules about communication style, language, and tone the AI should adopt.\n* `policies_and_info` - Rules about business operations, pricing, and scheduling policies.\n* `things_to_avoid` - Rules about topics, phrases, or actions the AI should not mention or perform.\n* `faq` - Frequently asked questions and their answers.",
+                  "enum": [
+                    "tone_of_voice",
+                    "policies_and_info",
+                    "things_to_avoid",
+                    "faq"
+                  ]
+                }
+              },
+              "required": [
+                "uid",
+                "rule_uid",
+                "business_uid",
+                "category_code",
+                "content",
+                "source",
+                "action",
+                "changed_at",
+                "created_at",
+                "updated_at"
+              ],
+              "example": {
+                "uid": "hist-a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                "rule_uid": "br-a1b2c3d4-5678-90ef-ghij-klmnopqrstuv",
+                "business_uid": "biz-1234abcd-5678-90ef-ghij-klmnopqrstuv",
+                "content": "Always use a friendly and professional tone when communicating with clients",
+                "source": "user",
+                "action": "updated",
+                "changed_by_staff_uid": "stf-9876wxyz-5432-10ab-cdef-ghijklmnopqr",
+                "changed_at": "2024-12-16T14:30:00.000Z",
+                "created_at": "2024-12-16T14:30:00.000Z",
+                "updated_at": "2024-12-16T14:30:00.000Z",
+                "category_code": "tone_of_voice"
+              }
             }
           },
           "total": {
@@ -3085,7 +8353,161 @@
             "description": "List of BusinessRules",
             "type": "array",
             "items": {
-              "$ref": "https://vcita.github.io/developers-hub/entities/ai/BusinessRule.json"
+              "type": "object",
+              "description": "Represents a business rule that guides AI behavior for a specific business. Rules are organized by category (tone of voice, business policies, things to avoid, FAQ) and can be AI-generated (system) or user-created. For FAQ category rules, the metadata contains structured question and answer fields extracted from the content. Rules can be activated, deactivated, or held in a pending approval state.",
+              "properties": {
+                "uid": {
+                  "type": "string",
+                  "readOnly": true,
+                  "description": "The unique identifier (UID) of the business rule (e.g., \"br-a1b2c3d4-5678-90ef-ghij-klmnopqrstuv\"). Assigned automatically by the system upon creation."
+                },
+                "business_uid": {
+                  "type": "string",
+                  "readOnly": true,
+                  "description": "The unique identifier (UID) of the business that owns this rule (e.g., \"biz-1234abcd-5678-90ef-ghij-klmnopqrstuv\"). Automatically set based on the authenticated token."
+                },
+                "content": {
+                  "type": "string",
+                  "description": "The content or text of the business rule (e.g., \"Always use a friendly and professional tone when communicating with clients\"). For FAQ rules, this typically contains both the question and answer in a combined format."
+                },
+                "status": {
+                  "type": "string",
+                  "description": "The current status of the business rule, controlling whether the AI agent actively uses it.\n\n* `active` - The rule is currently in effect and will be used by the AI agent.\n* `pending_approval` - The rule has been suggested (typically by the system) and is awaiting staff review before becoming active.\n* `inactive` - The rule has been deactivated and will not be used by the AI agent.",
+                  "enum": [
+                    "active",
+                    "pending_approval",
+                    "inactive"
+                  ]
+                },
+                "source": {
+                  "type": "string",
+                  "readOnly": true,
+                  "description": "Indicates whether the rule was created by the AI system or by a user (staff member).\n\n* `system` - The rule was generated automatically by the AI based on analysis of business conversations.\n* `user` - The rule was manually created or edited by a staff member.",
+                  "enum": [
+                    "system",
+                    "user"
+                  ]
+                },
+                "created_by_staff_uid": {
+                  "type": "string",
+                  "readOnly": true,
+                  "description": "The UID of the staff member who created the rule (e.g., \"stf-9876wxyz-5432-10ab-cdef-ghijklmnopqr\"). Will be null for system-generated rules that have not been manually edited.",
+                  "nullable": true
+                },
+                "updated_by_staff_uid": {
+                  "type": "string",
+                  "readOnly": true,
+                  "description": "The UID of the staff member who last updated the rule (e.g., \"stf-9876wxyz-5432-10ab-cdef-ghijklmnopqr\"). Will be null if the rule has never been updated by a staff member.",
+                  "nullable": true
+                },
+                "sort_order": {
+                  "type": "integer",
+                  "description": "Sort order for displaying rules within a category (e.g., 0). Lower values appear first. Rules within the same category are ordered by this field in ascending order."
+                },
+                "metadata": {
+                  "type": "object",
+                  "description": "Additional metadata associated with the rule. For FAQ rules, includes structured `question` and `answer` fields. For system-generated rules, may include `confidence`, `reasoning`, and `evidence` from the AI analysis.",
+                  "nullable": true,
+                  "properties": {
+                    "question": {
+                      "type": "string",
+                      "description": "The question part of an FAQ rule (e.g., \"What are your business hours?\"). Only present for rules with category `faq`."
+                    },
+                    "answer": {
+                      "type": "string",
+                      "description": "The answer part of an FAQ rule (e.g., \"We are open Monday to Friday, 9 AM to 5 PM.\"). Only present for rules with category `faq`."
+                    },
+                    "confidence": {
+                      "type": "number",
+                      "description": "AI confidence score ranging from 0.0 to 1.0 indicating how confident the system is about this rule (e.g., 0.92). Only present for system-generated rules."
+                    },
+                    "reasoning": {
+                      "type": "string",
+                      "description": "AI-generated reasoning explaining why this rule was created or suggested (e.g., \"Consistent friendly tone observed across 15 client conversations\"). Only present for system-generated rules."
+                    },
+                    "evidence": {
+                      "type": "array",
+                      "description": "Evidence from conversations that supports this rule. Contains quotes and references from actual client-staff interactions.",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "client_uid": {
+                            "type": "string",
+                            "description": "The UID of the client involved in the conversation."
+                          },
+                          "message_uid": {
+                            "type": "string",
+                            "description": "The UID of the specific message used as evidence."
+                          },
+                          "quote": {
+                            "type": "string",
+                            "description": "A direct quote from the conversation used as evidence."
+                          },
+                          "speaker": {
+                            "type": "string",
+                            "enum": [
+                              "staff",
+                              "client"
+                            ],
+                            "description": "Identifies whether the quote is from a staff member or a client.\n\n* `staff` - The quote is from a staff member.\n* `client` - The quote is from a client."
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "created_at": {
+                  "type": "string",
+                  "format": "date-time",
+                  "readOnly": true,
+                  "description": "The date and time when the business rule was created, in ISO 8601 format (e.g., \"2024-12-15T10:30:00.000Z\")."
+                },
+                "updated_at": {
+                  "type": "string",
+                  "format": "date-time",
+                  "readOnly": true,
+                  "description": "The date and time when the business rule was last updated, in ISO 8601 format (e.g., \"2024-12-16T14:00:00.000Z\")."
+                },
+                "category_code": {
+                  "type": "string",
+                  "description": "The category of the business rule. Determines how the AI agent uses this rule.\n\n* `tone_of_voice` - Rules about communication style, language, and tone the AI should adopt when interacting with clients.\n* `policies_and_info` - Rules about business operations, pricing, scheduling policies, and other operational guidelines.\n* `things_to_avoid` - Rules about topics, phrases, or actions the AI should not mention or perform.\n* `faq` - Frequently asked questions and their answers. When this category is used, the metadata field should contain structured `question` and `answer` fields.\n* `client_facing_bot_policies` - Rules specifically for client-facing bot interactions, defining bot behavior, limitations, and escalation policies.",
+                  "enum": [
+                    "tone_of_voice",
+                    "policies_and_info",
+                    "things_to_avoid",
+                    "faq",
+                    "client_facing_bot_policies"
+                  ]
+                }
+              },
+              "required": [
+                "uid",
+                "business_uid",
+                "category_code",
+                "content",
+                "status",
+                "source",
+                "sort_order",
+                "created_at",
+                "updated_at"
+              ],
+              "example": {
+                "uid": "br-a1b2c3d4-5678-90ef-ghij-klmnopqrstuv",
+                "business_uid": "biz-1234abcd-5678-90ef-ghij-klmnopqrstuv",
+                "content": "Always use a friendly and professional tone when communicating with clients",
+                "status": "active",
+                "source": "system",
+                "created_by_staff_uid": "stf-9876wxyz-5432-10ab-cdef-ghijklmnopqr",
+                "updated_by_staff_uid": null,
+                "sort_order": 0,
+                "metadata": {
+                  "confidence": 0.92,
+                  "reasoning": "Consistent friendly tone observed across 15 client conversations"
+                },
+                "created_at": "2024-12-15T10:30:00.000Z",
+                "updated_at": "2024-12-15T10:30:00.000Z",
+                "category_code": "tone_of_voice"
+              }
             }
           }
         },
@@ -3186,7 +8608,80 @@
             "description": "List of BizAIChats",
             "type": "array",
             "items": {
-              "$ref": "https://vcita.github.io/developers-hub/entities/ai/BizAIChat.json"
+              "type": "object",
+              "properties": {
+                "uid": {
+                  "type": "string",
+                  "description": "The unique identifier (UID) of the chat"
+                },
+                "actor_uid": {
+                  "type": "string",
+                  "description": "The unique identifier (UID) of the actor that created the chat"
+                },
+                "agent": {
+                  "type": "string",
+                  "description": "Agent associated with the chat"
+                },
+                "metadata": {
+                  "type": "object",
+                  "description": "A JSON string used to pass additional information to the chat agent in run time"
+                },
+                "config": {
+                  "type": "object",
+                  "description": "The agent configuration settings for this chat session",
+                  "properties": {
+                    "instruction": {
+                      "oneOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "object"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "description": "The instructions for the agent. Can be a simple string prompt, a structured object with template variables, or null if not configured."
+                    },
+                    "model_name": {
+                      "type": "string",
+                      "description": "The AI model name used for the agent"
+                    }
+                  }
+                },
+                "created_at": {
+                  "type": "string",
+                  "description": "Date the chat was created"
+                },
+                "updated_at": {
+                  "type": "string",
+                  "description": "Date the chat was last updated"
+                }
+              },
+              "required": [
+                "uid",
+                "actor_uid",
+                "agent",
+                "created_at",
+                "updated_at"
+              ],
+              "example": {
+                "uid": "d290f1ee-6c54-4b01-90e6-d701748f0851",
+                "actor_uid": "ghp0f1ee-6c54-4b01-90e6-d701748f0851",
+                "agent": "vanilla",
+                "metadata": {
+                  "directory_uid": "k98axtpqg7h1whh6",
+                  "instruction": "You are a helpful assistant. Answer all questions to the best of your ability."
+                },
+                "config": {
+                  "instruction": "You are an experienced business consultant with a friendly voice.",
+                  "model_name": "gpt-4"
+                },
+                "created_at": "2021-07-20T14:00:00.000Z",
+                "updated_at": "2021-07-20T14:00:00.000Z"
+              },
+              "description": "Represents a business AI chat session, including agent, metadata, and audit timestamps."
             }
           }
         },
@@ -3278,7 +8773,44 @@
             "description": "List of BizAIChatMessages",
             "type": "array",
             "items": {
-              "$ref": "https://vcita.github.io/developers-hub/entities/ai/BizAIChatMessage.json"
+              "type": "object",
+              "properties": {
+                "uid": {
+                  "type": "string",
+                  "description": "The unique identifier (UID) of the message"
+                },
+                "content": {
+                  "type": "string",
+                  "description": "The content of the message"
+                },
+                "author_role": {
+                  "type": "string",
+                  "description": "The role of the author of the message"
+                },
+                "created_at": {
+                  "type": "string",
+                  "description": "The date the message was created"
+                },
+                "updated_at": {
+                  "type": "string",
+                  "description": "The date the message was last updated"
+                }
+              },
+              "required": [
+                "uid",
+                "content",
+                "author_role",
+                "created_at",
+                "updated_at"
+              ],
+              "example": {
+                "uid": "d290f1ee-6c54-4b01-90e6-d701748f0851",
+                "content": "Hello, how can I help you?",
+                "author_role": "human",
+                "created_at": "2021-07-20T14:00:00.000Z",
+                "updated_at": "2021-07-20T14:00:00.000Z"
+              },
+              "description": "Represents a single message within a BizAI chat, including author role and timestamps."
             }
           }
         },
@@ -3434,7 +8966,111 @@
           "smart_replies": {
             "type": "array",
             "items": {
-              "$ref": "https://vcita.github.io/developers-hub/entities/ai/AISmartReply.json"
+              "type": "object",
+              "description": "Represents a smart reply generated by AI with different message formats for various communication channels.",
+              "properties": {
+                "uid": {
+                  "type": "string",
+                  "description": "The unique identifier (UID) of the smart reply"
+                },
+                "created_at": {
+                  "type": "string",
+                  "format": "date-time",
+                  "description": "The timestamp when the smart reply was created, in ISO 8601 format"
+                },
+                "updated_at": {
+                  "type": "string",
+                  "format": "date-time",
+                  "description": "The timestamp when the smart reply was last updated, in ISO 8601 format"
+                },
+                "display": {
+                  "type": "object",
+                  "description": "Contains display-related information for the smart reply.",
+                  "properties": {
+                    "btn_text": {
+                      "type": "string",
+                      "description": "A human-readable title for the smart reply button."
+                    }
+                  }
+                },
+                "reason": {
+                  "type": "string",
+                  "description": "The reason why this smart reply was generated, providing context for decision-making."
+                },
+                "payload": {
+                  "type": "object",
+                  "description": "Contains the generated reply messages for different communication channels.",
+                  "properties": {
+                    "email_message": {
+                      "type": "string",
+                      "description": "The generated reply formatted for email communication"
+                    },
+                    "sms_message": {
+                      "type": "string",
+                      "description": "The generated reply formatted for SMS communication"
+                    },
+                    "FB_message": {
+                      "type": "string",
+                      "description": "The generated reply formatted for Facebook messaging"
+                    },
+                    "other_message": {
+                      "type": "string",
+                      "description": "The generated reply formatted for other communication channels"
+                    }
+                  },
+                  "required": [
+                    "email_message",
+                    "sms_message",
+                    "FB_message",
+                    "other_message"
+                  ]
+                },
+                "evidence": {
+                  "oneOf": [
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "description": "Supporting statements or facts that led to the generation of this smart reply. Can be an array of strings or a single string."
+                },
+                "matter_uid": {
+                  "type": "string",
+                  "description": "The unique identifier of the associated matter"
+                }
+              },
+              "required": [
+                "uid",
+                "created_at",
+                "updated_at",
+                "reason",
+                "payload",
+                "matter_uid"
+              ],
+              "example": {
+                "uid": "d290f1ee-6c54-4b01-90e6-d701748f0851",
+                "created_at": "2025-02-04T14:00:00.000Z",
+                "updated_at": "2025-02-04T14:00:00.000Z",
+                "display": {
+                  "btn_text": "Generate Reply"
+                },
+                "reason": "User needs clarification on pricing",
+                "payload": {
+                  "email_message": "I need more details to send you a quote<br/>best regards,<br/>ramster",
+                  "sms_message": "I need more details to send you a quote",
+                  "FB_message": "I need more details to send you a quote",
+                  "other_message": "I need more details to send you a quote"
+                },
+                "evidence": [
+                  "User asked for price estimate"
+                ],
+                "matter_uid": "7f8a9b32d4e"
+              }
             }
           }
         }
@@ -3446,7 +9082,237 @@
           "chat_completion_runs": {
             "type": "array",
             "items": {
-              "$ref": "https://vcita.github.io/developers-hub/entities/ai/ChatCompletionRun.json"
+              "type": "object",
+              "description": "Represents an async chat completion run. Poll this resource until status is COMPLETED or FAILED.",
+              "properties": {
+                "uid": {
+                  "type": "string",
+                  "readOnly": true,
+                  "description": "Unique identifier of the chat completion run."
+                },
+                "status": {
+                  "type": "string",
+                  "readOnly": true,
+                  "enum": [
+                    "QUEUED",
+                    "IN_PROGRESS",
+                    "COMPLETED",
+                    "FAILED"
+                  ],
+                  "description": "Current status of the run. Possible values: 'QUEUED' (job is waiting to be processed), 'IN_PROGRESS' (job is actively being processed by the LLM provider), 'COMPLETED' (job finished successfully and result is available), 'FAILED' (job encountered an error and error_message is available)."
+                },
+                "created_at": {
+                  "type": "string",
+                  "format": "date-time",
+                  "readOnly": true,
+                  "description": "The date and time when the run was created, in ISO 8601 format (e.g., \"2026-02-09T09:31:30.934Z\")."
+                },
+                "updated_at": {
+                  "type": "string",
+                  "format": "date-time",
+                  "readOnly": true,
+                  "description": "The date and time when the run was last updated, in ISO 8601 format (e.g., \"2026-02-09T09:31:31.000Z\")."
+                },
+                "result": {
+                  "type": "object",
+                  "description": "The completion result. Only present when status is 'COMPLETED'.",
+                  "properties": {
+                    "uid": {
+                      "type": "string",
+                      "readOnly": true,
+                      "description": "Unique identifier for this completion (e.g., \"chatcmpl-1677652288-a1b2c3\")."
+                    },
+                    "object": {
+                      "type": "string",
+                      "readOnly": true,
+                      "description": "Object type identifier. Always 'chat.completion' for non-streaming responses.",
+                      "enum": [
+                        "chat.completion"
+                      ]
+                    },
+                    "created_at": {
+                      "type": "string",
+                      "format": "date-time",
+                      "readOnly": true,
+                      "description": "The date and time when the completion was created, in ISO 8601 format (e.g., \"2026-02-09T09:31:30.000Z\")."
+                    },
+                    "model": {
+                      "type": "string",
+                      "readOnly": true,
+                      "description": "The model used for the completion in provider/model format (e.g., \"openai/gpt-4o-mini\", \"anthropic/claude-sonnet-4-5-20250929\")."
+                    },
+                    "choices": {
+                      "type": "array",
+                      "readOnly": true,
+                      "description": "Array of completion choices generated by the model. Typically contains a single choice.",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "index": {
+                            "type": "integer",
+                            "description": "Zero-based index of this choice in the choices array."
+                          },
+                          "message": {
+                            "type": "object",
+                            "properties": {
+                              "role": {
+                                "type": "string",
+                                "enum": [
+                                  "assistant"
+                                ],
+                                "description": "The role of the message author. Always 'assistant' for completion responses."
+                              },
+                              "content": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "The text content of the assistant's response. May be null when the model makes tool calls instead of generating text."
+                              },
+                              "tool_calls": {
+                                "type": "array",
+                                "description": "Tool calls requested by the assistant. Present when the model decides to call one or more functions defined in the request's 'tools' parameter.",
+                                "items": {
+                                  "type": "object",
+                                  "description": "A tool call requested by the assistant during a chat completion. Contains the function name and arguments the model wants to invoke.",
+                                  "properties": {
+                                    "id": {
+                                      "type": "string",
+                                      "description": "Unique identifier for this tool call, used to match tool responses back to the request (e.g., \"call_abc123\")."
+                                    },
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "function"
+                                      ],
+                                      "description": "The type of tool call. Currently only 'function' is supported."
+                                    },
+                                    "function": {
+                                      "type": "object",
+                                      "description": "The function to be called, including its name and arguments.",
+                                      "properties": {
+                                        "name": {
+                                          "type": "string",
+                                          "description": "The name of the function to call (e.g., \"get_weather\")."
+                                        },
+                                        "arguments": {
+                                          "type": "string",
+                                          "description": "A JSON-encoded string of the arguments to pass to the function (e.g., \"{\\\"location\\\": \\\"Paris\\\"}\")."
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "example": {
+                                    "id": "call_abc123",
+                                    "type": "function",
+                                    "function": {
+                                      "name": "get_weather",
+                                      "arguments": "{\"location\": \"Paris\"}"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "finish_reason": {
+                            "type": "string",
+                            "enum": [
+                              "stop",
+                              "length",
+                              "tool_calls",
+                              "content_filter"
+                            ],
+                            "description": "The reason the model stopped generating. 'stop' means the model naturally finished, 'length' means max_tokens was reached, 'tool_calls' means the model wants to call a function, 'content_filter' means content was filtered by safety systems."
+                          }
+                        }
+                      }
+                    },
+                    "usage": {
+                      "type": "object",
+                      "readOnly": true,
+                      "description": "Token usage statistics for the completion request. Useful for tracking costs and monitoring token consumption.",
+                      "properties": {
+                        "prompt_tokens": {
+                          "type": "integer",
+                          "description": "Number of tokens in the input prompt (e.g., 9)."
+                        },
+                        "completion_tokens": {
+                          "type": "integer",
+                          "description": "Number of tokens generated in the completion response (e.g., 9)."
+                        },
+                        "total_tokens": {
+                          "type": "integer",
+                          "description": "Total number of tokens used (prompt_tokens + completion_tokens) (e.g., 18)."
+                        }
+                      }
+                    }
+                  },
+                  "required": [
+                    "uid",
+                    "object",
+                    "created_at",
+                    "model",
+                    "choices"
+                  ],
+                  "example": {
+                    "uid": "chatcmpl-1677652288-a1b2c3",
+                    "object": "chat.completion",
+                    "created_at": "2026-02-09T09:31:30.000Z",
+                    "model": "openai/gpt-4o-mini",
+                    "choices": [
+                      {
+                        "index": 0,
+                        "message": {
+                          "role": "assistant",
+                          "content": "Hello! How can I help you today?"
+                        },
+                        "finish_reason": "stop"
+                      }
+                    ],
+                    "usage": {
+                      "prompt_tokens": 9,
+                      "completion_tokens": 9,
+                      "total_tokens": 18
+                    }
+                  },
+                  "readOnly": true
+                },
+                "error_message": {
+                  "type": "string",
+                  "readOnly": true,
+                  "description": "Error message describing the failure reason. Only present when status is 'FAILED'."
+                }
+              },
+              "required": [
+                "uid",
+                "status",
+                "created_at"
+              ],
+              "example": {
+                "uid": "0ce1af9d-3337-419b-933c-02ea21d4d9ca",
+                "status": "COMPLETED",
+                "created_at": "2026-02-09T09:31:30.934Z",
+                "updated_at": "2026-02-09T09:31:31.000Z",
+                "result": {
+                  "uid": "chatcmpl-1677652288-a1b2c3",
+                  "object": "chat.completion",
+                  "created_at": "2026-02-09T09:31:30.000Z",
+                  "model": "openai/gpt-4o-mini",
+                  "choices": [
+                    {
+                      "index": 0,
+                      "message": {
+                        "role": "assistant",
+                        "content": "2 + 2 equals 4."
+                      },
+                      "finish_reason": "stop"
+                    }
+                  ],
+                  "usage": {
+                    "prompt_tokens": 14,
+                    "completion_tokens": 8,
+                    "total_tokens": 22
+                  }
+                }
+              }
             }
           }
         }
@@ -3458,7 +9324,177 @@
           "transcription_runs": {
             "type": "array",
             "items": {
-              "$ref": "https://vcita.github.io/developers-hub/entities/ai/TranscriptionRun.json"
+              "type": "object",
+              "description": "Represents an async transcription run. Poll this resource until status is COMPLETED or FAILED.",
+              "properties": {
+                "uid": {
+                  "type": "string",
+                  "readOnly": true,
+                  "description": "Unique identifier of the transcription run."
+                },
+                "status": {
+                  "type": "string",
+                  "readOnly": true,
+                  "enum": [
+                    "QUEUED",
+                    "IN_PROGRESS",
+                    "COMPLETED",
+                    "FAILED"
+                  ],
+                  "description": "Current status of the run. Possible values: 'QUEUED' (job is waiting to be processed), 'IN_PROGRESS' (job is actively being processed by the transcription provider), 'COMPLETED' (job finished successfully and result is available), 'FAILED' (job encountered an error and error_message is available)."
+                },
+                "created_at": {
+                  "type": "string",
+                  "format": "date-time",
+                  "readOnly": true,
+                  "description": "The date and time when the run was created, in ISO 8601 format (e.g., \"2026-02-08T13:18:39.698Z\")."
+                },
+                "updated_at": {
+                  "type": "string",
+                  "format": "date-time",
+                  "readOnly": true,
+                  "description": "The date and time when the run was last updated, in ISO 8601 format (e.g., \"2026-02-08T13:18:41.000Z\")."
+                },
+                "result": {
+                  "type": "object",
+                  "description": "The transcription result. Only present when status is 'COMPLETED'.",
+                  "properties": {
+                    "text": {
+                      "type": "string",
+                      "readOnly": true,
+                      "description": "The full transcribed text output from the audio file."
+                    },
+                    "language": {
+                      "type": "string",
+                      "readOnly": true,
+                      "description": "The detected or specified language code in ISO-639-1 format (e.g., \"en\" for English, \"es\" for Spanish, \"he\" for Hebrew)."
+                    },
+                    "duration": {
+                      "type": "number",
+                      "readOnly": true,
+                      "description": "Total duration of the audio file in seconds (e.g., 3.5)."
+                    },
+                    "words": {
+                      "type": "array",
+                      "readOnly": true,
+                      "description": "Word-level timestamps for each transcribed word. Only present when using the 'verbose_json' response format.",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "word": {
+                            "type": "string",
+                            "description": "The transcribed word."
+                          },
+                          "start": {
+                            "type": "number",
+                            "description": "Start time of the word in seconds from the beginning of the audio."
+                          },
+                          "end": {
+                            "type": "number",
+                            "description": "End time of the word in seconds from the beginning of the audio."
+                          }
+                        }
+                      }
+                    },
+                    "segments": {
+                      "type": "array",
+                      "readOnly": true,
+                      "description": "Segment-level data with timing and optional speaker information. Each segment represents a contiguous block of transcribed speech, useful for diarization and long audio files.",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "integer",
+                            "description": "Sequential identifier for the segment (e.g., 0, 1, 2)."
+                          },
+                          "start": {
+                            "type": "number",
+                            "description": "Start time of the segment in seconds from the beginning of the audio."
+                          },
+                          "end": {
+                            "type": "number",
+                            "description": "End time of the segment in seconds from the beginning of the audio."
+                          },
+                          "text": {
+                            "type": "string",
+                            "description": "The transcribed text for this segment."
+                          },
+                          "speaker": {
+                            "type": "string",
+                            "description": "Speaker identifier when diarization is enabled (e.g., \"SPEAKER_00\", \"SPEAKER_01\")."
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "required": [
+                    "text"
+                  ],
+                  "example": {
+                    "text": "For more information visit www.FEMA.gov",
+                    "language": "en",
+                    "duration": 3.5,
+                    "words": [
+                      {
+                        "word": "For",
+                        "start": 0,
+                        "end": 0.18
+                      },
+                      {
+                        "word": "more",
+                        "start": 0.18,
+                        "end": 0.38
+                      },
+                      {
+                        "word": "information",
+                        "start": 0.38,
+                        "end": 0.92
+                      },
+                      {
+                        "word": "visit",
+                        "start": 0.92,
+                        "end": 1.24
+                      },
+                      {
+                        "word": "www.FEMA.gov",
+                        "start": 1.24,
+                        "end": 3.5
+                      }
+                    ],
+                    "segments": [
+                      {
+                        "id": 0,
+                        "start": 0,
+                        "end": 3.5,
+                        "text": "For more information visit www.FEMA.gov",
+                        "speaker": "SPEAKER_00"
+                      }
+                    ]
+                  },
+                  "readOnly": true
+                },
+                "error_message": {
+                  "type": "string",
+                  "readOnly": true,
+                  "description": "Error message describing the failure reason. Only present when status is 'FAILED'."
+                }
+              },
+              "required": [
+                "uid",
+                "status",
+                "created_at"
+              ],
+              "example": {
+                "uid": "85ade9f5-2690-48e8-ae5b-b07d6b57b457",
+                "status": "COMPLETED",
+                "created_at": "2026-02-08T13:18:39.698Z",
+                "updated_at": "2026-02-08T13:18:41.000Z",
+                "result": {
+                  "text": "For more information visit www.FEMA.gov",
+                  "language": "en",
+                  "duration": 3.5
+                }
+              }
             }
           }
         }

--- a/mcp_swagger/apps.json
+++ b/mcp_swagger/apps.json
@@ -185,7 +185,566 @@
                             "apps": {
                               "type": "array",
                               "items": {
-                                "$ref": "https://vcita.github.io/developers-hub/entities/apps/app.json"
+                                "type": "object",
+                                "description": "Represents an app that can be installed and used on the inTandem platform.",
+                                "properties": {
+                                  "uid": {
+                                    "type": "string",
+                                    "readOnly": true,
+                                    "description": "Unique identifier of the app."
+                                  },
+                                  "app_code_name": {
+                                    "type": "string",
+                                    "description": "Unique code name of the app (e.g., \"calendar_sync\")."
+                                  },
+                                  "name": {
+                                    "type": "string",
+                                    "description": "App display name (e.g., \"Calendar Sync\")."
+                                  },
+                                  "redirect_uri": {
+                                    "type": "string",
+                                    "description": "The app main landing page. The platform uses this URI when opening the app."
+                                  },
+                                  "app_host": {
+                                    "type": "string",
+                                    "readOnly": true,
+                                    "description": "Computed URL used by the platform to open the app (based on `redirect_uri` plus runtime query parameters)."
+                                  },
+                                  "url_params": {
+                                    "type": "array",
+                                    "description": "A list of standard platform context parameters that the platform injects into the query string when building `app_host`. Each value is a predefined key whose value is resolved at runtime by the platform (e.g., selecting \"business_uid\" causes the caller's business UID to be appended as `?business_uid=...`).\n\nThis is different from the `additional_params` entry in `extensions`, which defines custom, app-specific key-value pairs that are also appended to the URL.",
+                                    "items": {
+                                      "type": "string",
+                                      "enum": [
+                                        "impersonate",
+                                        "business_uid",
+                                        "staff_role",
+                                        "staff_uid",
+                                        "payment_permissions",
+                                        "language",
+                                        "package",
+                                        "brand_host"
+                                      ]
+                                    }
+                                  },
+                                  "app_types": {
+                                    "type": "array",
+                                    "readOnly": true,
+                                    "description": "A list of app types / integration points associated with the app. This mirrors core's `app_type` field and is related to (and can be derived from) the app's extension configuration.\n\nValid values are based on core validation rules and may include internal-only values.",
+                                    "items": {
+                                      "type": "string",
+                                      "enum": [
+                                        "internal",
+                                        "billing_app",
+                                        "payments",
+                                        "wallets",
+                                        "communication",
+                                        "menu_items",
+                                        "docuforms",
+                                        "import_clients",
+                                        "automated_flows",
+                                        "signatures",
+                                        "onboarding_wizard",
+                                        "notifications",
+                                        "receipts",
+                                        "calendar_sync",
+                                        "document_signature",
+                                        "tips",
+                                        "ai_assistant",
+                                        "attachments",
+                                        "widgets",
+                                        "voice_calls",
+                                        "texting",
+                                        "licensing.subscription.admin.read"
+                                      ]
+                                    },
+                                    "uniqueItems": true
+                                  },
+                                  "open_in_new_tab": {
+                                    "type": "boolean",
+                                    "description": "Whether the app is opened in a new browser tab instead of an in-product iframe.",
+                                    "default": false
+                                  },
+                                  "supported_in_mobile": {
+                                    "type": "boolean",
+                                    "description": "Whether the app is supported in mobile experiences.",
+                                    "default": true
+                                  },
+                                  "permissions": {
+                                    "type": "array",
+                                    "description": "A list of permission codes required for certain app capabilities or UI entries (e.g., \"can_view_payments\").",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "uniqueItems": true
+                                  },
+                                  "trusted": {
+                                    "type": "boolean",
+                                    "description": "Whether the app can skip the user consent screen when authorizing access.",
+                                    "default": false
+                                  },
+                                  "oauth_redirect_uris": {
+                                    "type": "array",
+                                    "description": "An array of URLs to redirect the user to after a successful OAuth login.",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "assignment_types": {
+                                    "type": "array",
+                                    "readOnly": true,
+                                    "description": "How the app is available to the caller. An app can have multiple assignment types simultaneously. Heuristics: `installed` and `internal` cannot happen at the same time. The only combination is `installed` + `directory_offering`.",
+                                    "items": {
+                                      "type": "string",
+                                      "enum": [
+                                        "installed",
+                                        "directory_offering",
+                                        "internal"
+                                      ]
+                                    },
+                                    "uniqueItems": true
+                                  },
+                                  "owner": {
+                                    "type": "boolean",
+                                    "readOnly": true,
+                                    "description": "Whether the caller is the owner of the app. For Internal tokens, apps with no owning directory are returned with `owner=true`."
+                                  },
+                                  "app_market": {
+                                    "type": "object",
+                                    "description": "App market metadata shown to users in the app market.",
+                                    "properties": {
+                                      "description": {
+                                        "type": "object",
+                                        "description": "App description texts and logo.",
+                                        "properties": {
+                                          "logo": {
+                                            "type": "string",
+                                            "description": "Public URL to the app logo (e.g., \"https://cdn.example.com/apps/calendar_sync/logo.png\")."
+                                          },
+                                          "short_description": {
+                                            "type": "string",
+                                            "description": "Short description displayed in app cards (e.g., \"Two-way sync with your calendar\")."
+                                          },
+                                          "text": {
+                                            "type": "string",
+                                            "description": "Long description displayed in the app details page."
+                                          }
+                                        }
+                                      },
+                                      "app_features": {
+                                        "type": "array",
+                                        "description": "A list of app features displayed in the app market.",
+                                        "items": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "app_screenshot_uris": {
+                                        "type": "array",
+                                        "description": "Links to screenshots or demo videos shown on desktop.",
+                                        "items": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "app_mobile_screenshot_uris": {
+                                        "type": "array",
+                                        "description": "Links to screenshots or demo videos shown on mobile.",
+                                        "items": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "supported_countries": {
+                                        "type": "array",
+                                        "description": "Countries in which the app is available. Use full country names (e.g., \"United States\"). Use an empty array for all countries.",
+                                        "items": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "locales": {
+                                        "type": "array",
+                                        "description": "Locales supported by the app (e.g., \"en\", \"he\").",
+                                        "items": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "privacy_policy_link": {
+                                        "type": "string",
+                                        "description": "Link to the app privacy policy."
+                                      },
+                                      "contact_support_link": {
+                                        "type": "string",
+                                        "description": "Link to the app contact support page."
+                                      },
+                                      "personal_connection": {
+                                        "type": "boolean",
+                                        "description": "Whether each staff member needs to connect separately to the app."
+                                      }
+                                    }
+                                  },
+                                  "internal": {
+                                    "type": "object",
+                                    "description": "Internal-runtime app metadata used by clients that render the app shell.",
+                                    "properties": {
+                                      "api_uri": {
+                                        "type": "string",
+                                        "description": "Link to the application's API."
+                                      },
+                                      "full_screen": {
+                                        "type": "boolean",
+                                        "description": "Whether the app is opened in a full screen mode.",
+                                        "default": false
+                                      },
+                                      "deep_link": {
+                                        "type": "object",
+                                        "description": "Deep link to an inner product page.",
+                                        "properties": {
+                                          "path": {
+                                            "type": "string",
+                                            "description": "Relative path to the page (e.g., \"/app/somepath\")."
+                                          },
+                                          "path_params": {
+                                            "type": "object",
+                                            "description": "Optional query parameters to be added to the URL.",
+                                            "additionalProperties": true
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "extensions": {
+                                    "type": "array",
+                                    "readOnly": true,
+                                    "description": "Developer-provided extension configuration entries. Each entry contains a `type` key identifying the extension and a `value` key holding its configuration. Only extensions with non-empty values are included. The array contains at most one entry per `type`.",
+                                    "items": {
+                                      "oneOf": [
+                                        {
+                                          "type": "object",
+                                          "description": "Menu items extension. Adds entries to the left sidebar navigation.",
+                                          "properties": {
+                                            "type": {
+                                              "type": "string",
+                                              "enum": [
+                                                "menu_items"
+                                              ]
+                                            },
+                                            "value": {
+                                              "type": "object",
+                                              "properties": {
+                                                "subitems": {
+                                                  "type": "array",
+                                                  "description": "Menu items to be added to the left sidebar.",
+                                                  "items": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "category": {
+                                                        "type": "string",
+                                                        "description": "Section of the left menu in which the item will appear (e.g., \\\"clients\\\").",
+                                                        "enum": [
+                                                          "calendar",
+                                                          "clients",
+                                                          "payments",
+                                                          "inbox",
+                                                          "documents",
+                                                          "campaigns",
+                                                          "reputation",
+                                                          "my-livesite",
+                                                          "social",
+                                                          "social_info",
+                                                          "app_market",
+                                                          "reports",
+                                                          "team-chat",
+                                                          "advertising",
+                                                          "subscriptions",
+                                                          "my_account",
+                                                          "cashflow",
+                                                          "workforce",
+                                                          "setupguide",
+                                                          "reviews",
+                                                          "social_media",
+                                                          "online_listing"
+                                                        ]
+                                                      },
+                                                      "item_name": {
+                                                        "type": "object",
+                                                        "description": "Item names per language code (e.g., `{ \"en\": \"My Page\" }`).",
+                                                        "additionalProperties": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "route": {
+                                                        "type": "string",
+                                                        "description": "Suffix route relative to the app domain (e.g., \\\"rdbms\\\")."
+                                                      },
+                                                      "display_order": {
+                                                        "type": "integer",
+                                                        "minimum": 0,
+                                                        "description": "Display order within the category. Starts from 0."
+                                                      },
+                                                      "block_impersonation": {
+                                                        "type": "boolean",
+                                                        "description": "Whether the menu item should be blocked when an operator is impersonating as a staff member.",
+                                                        "default": false
+                                                      },
+                                                      "permissions": {
+                                                        "type": "array",
+                                                        "description": "Optional permissions required to see this menu item.",
+                                                        "items": {
+                                                          "type": "string"
+                                                        }
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "category",
+                                                      "item_name",
+                                                      "route"
+                                                    ]
+                                                  }
+                                                }
+                                              },
+                                              "required": [
+                                                "subitems"
+                                              ]
+                                            }
+                                          },
+                                          "required": [
+                                            "type",
+                                            "value"
+                                          ]
+                                        },
+                                        {
+                                          "type": "object",
+                                          "description": "Additional params extension. Defines custom, app-specific key-value query parameters appended to `app_host` when opening the app.",
+                                          "properties": {
+                                            "type": {
+                                              "type": "string",
+                                              "enum": [
+                                                "additional_params"
+                                              ]
+                                            },
+                                            "value": {
+                                              "type": "object",
+                                              "description": "Custom key-value query parameters appended to the app URL.",
+                                              "additionalProperties": true
+                                            }
+                                          },
+                                          "required": [
+                                            "type",
+                                            "value"
+                                          ]
+                                        },
+                                        {
+                                          "type": "object",
+                                          "description": "Deep link extension. Configures a deep link to an inner product page.",
+                                          "properties": {
+                                            "type": {
+                                              "type": "string",
+                                              "enum": [
+                                                "deep_link"
+                                              ]
+                                            },
+                                            "value": {
+                                              "type": "object",
+                                              "properties": {
+                                                "path": {
+                                                  "type": "string",
+                                                  "description": "Relative path to the page (e.g., \"/app/somepath\")."
+                                                },
+                                                "path_params": {
+                                                  "type": "object",
+                                                  "description": "Optional query parameters to be added to the URL.",
+                                                  "additionalProperties": true
+                                                }
+                                              }
+                                            }
+                                          },
+                                          "required": [
+                                            "type",
+                                            "value"
+                                          ]
+                                        },
+                                        {
+                                          "type": "object",
+                                          "description": "Old integration name extension. Identifies the app as a legacy integration.",
+                                          "properties": {
+                                            "type": {
+                                              "type": "string",
+                                              "enum": [
+                                                "old_integration_name"
+                                              ]
+                                            },
+                                            "value": {
+                                              "type": "string",
+                                              "description": "The legacy integration identifier string."
+                                            }
+                                          },
+                                          "required": [
+                                            "type",
+                                            "value"
+                                          ]
+                                        },
+                                        {
+                                          "type": "object",
+                                          "description": "Personal connection extension. Indicates whether each staff member needs to connect separately to the app.",
+                                          "properties": {
+                                            "type": {
+                                              "type": "string",
+                                              "enum": [
+                                                "personal_connection"
+                                              ]
+                                            },
+                                            "value": {
+                                              "type": "boolean",
+                                              "description": "Whether personal connection is required."
+                                            }
+                                          },
+                                          "required": [
+                                            "type",
+                                            "value"
+                                          ]
+                                        },
+                                        {
+                                          "type": "object",
+                                          "description": "Full screen extension. Indicates whether the app opens in full screen mode.",
+                                          "properties": {
+                                            "type": {
+                                              "type": "string",
+                                              "enum": [
+                                                "full_screen"
+                                              ]
+                                            },
+                                            "value": {
+                                              "type": "boolean",
+                                              "description": "Whether the app opens in full screen mode."
+                                            }
+                                          },
+                                          "required": [
+                                            "type",
+                                            "value"
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  "created_at": {
+                                    "type": "string",
+                                    "readOnly": true,
+                                    "description": "Timestamp indicating when the app was created.",
+                                    "format": "date-time"
+                                  },
+                                  "updated_at": {
+                                    "type": "string",
+                                    "readOnly": true,
+                                    "description": "Timestamp indicating when the app was last updated.",
+                                    "format": "date-time"
+                                  }
+                                },
+                                "required": [
+                                  "uid",
+                                  "app_code_name",
+                                  "name",
+                                  "redirect_uri",
+                                  "assignment_types",
+                                  "created_at",
+                                  "updated_at"
+                                ],
+                                "example": {
+                                  "uid": "d290f1ee-26c5-4e91-b1a0-4f8b1c2d3e4f",
+                                  "app_code_name": "calendar_sync",
+                                  "name": "Calendar Sync",
+                                  "redirect_uri": "https://calendar-sync.example.com/app",
+                                  "app_host": "https://calendar-sync.example.com/app?business_uid=d290f1ee-26c5-4e91-b1a0-4f8b1c2d3e4f&staff_uid=stf_123&language=en",
+                                  "url_params": [
+                                    "business_uid",
+                                    "staff_uid",
+                                    "language"
+                                  ],
+                                  "app_types": [
+                                    "communication",
+                                    "menu_items"
+                                  ],
+                                  "open_in_new_tab": false,
+                                  "supported_in_mobile": true,
+                                  "permissions": [
+                                    "can_view_payments"
+                                  ],
+                                  "trusted": false,
+                                  "oauth_redirect_uris": [
+                                    "https://calendar-sync.example.com/oauth/callback"
+                                  ],
+                                  "assignment_types": [
+                                    "installed",
+                                    "directory_offering"
+                                  ],
+                                  "app_market": {
+                                    "description": {
+                                      "logo": "https://cdn.example.com/apps/calendar_sync/logo.png",
+                                      "short_description": "Two-way sync between your calendar and inTandem bookings.",
+                                      "text": "Sync bookings to your calendar automatically and avoid double-booking across devices."
+                                    },
+                                    "app_features": [
+                                      "Two-way sync",
+                                      "Conflict detection"
+                                    ],
+                                    "app_screenshot_uris": [
+                                      "https://cdn.example.com/apps/calendar_sync/screenshots/1.png"
+                                    ],
+                                    "app_mobile_screenshot_uris": [
+                                      "https://cdn.example.com/apps/calendar_sync/screenshots/mobile_1.png"
+                                    ],
+                                    "supported_countries": [
+                                      "United States",
+                                      "United Kingdom",
+                                      "Israel"
+                                    ],
+                                    "locales": [
+                                      "en",
+                                      "he"
+                                    ],
+                                    "privacy_policy_link": "https://calendar-sync.example.com/privacy",
+                                    "contact_support_link": "https://calendar-sync.example.com/support",
+                                    "personal_connection": true
+                                  },
+                                  "internal": {
+                                    "api_uri": "https://calendar-sync.example.com/api",
+                                    "full_screen": false,
+                                    "deep_link": {
+                                      "path": "/apps/calendar_sync/settings",
+                                      "path_params": {
+                                        "tab": "connections"
+                                      }
+                                    }
+                                  },
+                                  "owner": true,
+                                  "extensions": [
+                                    {
+                                      "type": "menu_items",
+                                      "value": {
+                                        "subitems": [
+                                          {
+                                            "category": "clients",
+                                            "item_name": {
+                                              "en": "Calendar Sync"
+                                            },
+                                            "route": "calendar-sync",
+                                            "display_order": 0,
+                                            "block_impersonation": false
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    {
+                                      "type": "additional_params",
+                                      "value": {
+                                        "open_channel_communication": true
+                                      }
+                                    },
+                                    {
+                                      "type": "full_screen",
+                                      "value": true
+                                    }
+                                  ],
+                                  "created_at": "2026-02-01T10:30:00Z",
+                                  "updated_at": "2026-02-20T09:15:00Z"
+                                }
                               }
                             }
                           },
@@ -252,7 +811,566 @@
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/apps/app.json"
+                          "type": "object",
+                          "description": "Represents an app that can be installed and used on the inTandem platform.",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "readOnly": true,
+                              "description": "Unique identifier of the app."
+                            },
+                            "app_code_name": {
+                              "type": "string",
+                              "description": "Unique code name of the app (e.g., \"calendar_sync\")."
+                            },
+                            "name": {
+                              "type": "string",
+                              "description": "App display name (e.g., \"Calendar Sync\")."
+                            },
+                            "redirect_uri": {
+                              "type": "string",
+                              "description": "The app main landing page. The platform uses this URI when opening the app."
+                            },
+                            "app_host": {
+                              "type": "string",
+                              "readOnly": true,
+                              "description": "Computed URL used by the platform to open the app (based on `redirect_uri` plus runtime query parameters)."
+                            },
+                            "url_params": {
+                              "type": "array",
+                              "description": "A list of standard platform context parameters that the platform injects into the query string when building `app_host`. Each value is a predefined key whose value is resolved at runtime by the platform (e.g., selecting \"business_uid\" causes the caller's business UID to be appended as `?business_uid=...`).\n\nThis is different from the `additional_params` entry in `extensions`, which defines custom, app-specific key-value pairs that are also appended to the URL.",
+                              "items": {
+                                "type": "string",
+                                "enum": [
+                                  "impersonate",
+                                  "business_uid",
+                                  "staff_role",
+                                  "staff_uid",
+                                  "payment_permissions",
+                                  "language",
+                                  "package",
+                                  "brand_host"
+                                ]
+                              }
+                            },
+                            "app_types": {
+                              "type": "array",
+                              "readOnly": true,
+                              "description": "A list of app types / integration points associated with the app. This mirrors core's `app_type` field and is related to (and can be derived from) the app's extension configuration.\n\nValid values are based on core validation rules and may include internal-only values.",
+                              "items": {
+                                "type": "string",
+                                "enum": [
+                                  "internal",
+                                  "billing_app",
+                                  "payments",
+                                  "wallets",
+                                  "communication",
+                                  "menu_items",
+                                  "docuforms",
+                                  "import_clients",
+                                  "automated_flows",
+                                  "signatures",
+                                  "onboarding_wizard",
+                                  "notifications",
+                                  "receipts",
+                                  "calendar_sync",
+                                  "document_signature",
+                                  "tips",
+                                  "ai_assistant",
+                                  "attachments",
+                                  "widgets",
+                                  "voice_calls",
+                                  "texting",
+                                  "licensing.subscription.admin.read"
+                                ]
+                              },
+                              "uniqueItems": true
+                            },
+                            "open_in_new_tab": {
+                              "type": "boolean",
+                              "description": "Whether the app is opened in a new browser tab instead of an in-product iframe.",
+                              "default": false
+                            },
+                            "supported_in_mobile": {
+                              "type": "boolean",
+                              "description": "Whether the app is supported in mobile experiences.",
+                              "default": true
+                            },
+                            "permissions": {
+                              "type": "array",
+                              "description": "A list of permission codes required for certain app capabilities or UI entries (e.g., \"can_view_payments\").",
+                              "items": {
+                                "type": "string"
+                              },
+                              "uniqueItems": true
+                            },
+                            "trusted": {
+                              "type": "boolean",
+                              "description": "Whether the app can skip the user consent screen when authorizing access.",
+                              "default": false
+                            },
+                            "oauth_redirect_uris": {
+                              "type": "array",
+                              "description": "An array of URLs to redirect the user to after a successful OAuth login.",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "assignment_types": {
+                              "type": "array",
+                              "readOnly": true,
+                              "description": "How the app is available to the caller. An app can have multiple assignment types simultaneously. Heuristics: `installed` and `internal` cannot happen at the same time. The only combination is `installed` + `directory_offering`.",
+                              "items": {
+                                "type": "string",
+                                "enum": [
+                                  "installed",
+                                  "directory_offering",
+                                  "internal"
+                                ]
+                              },
+                              "uniqueItems": true
+                            },
+                            "owner": {
+                              "type": "boolean",
+                              "readOnly": true,
+                              "description": "Whether the caller is the owner of the app. For Internal tokens, apps with no owning directory are returned with `owner=true`."
+                            },
+                            "app_market": {
+                              "type": "object",
+                              "description": "App market metadata shown to users in the app market.",
+                              "properties": {
+                                "description": {
+                                  "type": "object",
+                                  "description": "App description texts and logo.",
+                                  "properties": {
+                                    "logo": {
+                                      "type": "string",
+                                      "description": "Public URL to the app logo (e.g., \"https://cdn.example.com/apps/calendar_sync/logo.png\")."
+                                    },
+                                    "short_description": {
+                                      "type": "string",
+                                      "description": "Short description displayed in app cards (e.g., \"Two-way sync with your calendar\")."
+                                    },
+                                    "text": {
+                                      "type": "string",
+                                      "description": "Long description displayed in the app details page."
+                                    }
+                                  }
+                                },
+                                "app_features": {
+                                  "type": "array",
+                                  "description": "A list of app features displayed in the app market.",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                },
+                                "app_screenshot_uris": {
+                                  "type": "array",
+                                  "description": "Links to screenshots or demo videos shown on desktop.",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                },
+                                "app_mobile_screenshot_uris": {
+                                  "type": "array",
+                                  "description": "Links to screenshots or demo videos shown on mobile.",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                },
+                                "supported_countries": {
+                                  "type": "array",
+                                  "description": "Countries in which the app is available. Use full country names (e.g., \"United States\"). Use an empty array for all countries.",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                },
+                                "locales": {
+                                  "type": "array",
+                                  "description": "Locales supported by the app (e.g., \"en\", \"he\").",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                },
+                                "privacy_policy_link": {
+                                  "type": "string",
+                                  "description": "Link to the app privacy policy."
+                                },
+                                "contact_support_link": {
+                                  "type": "string",
+                                  "description": "Link to the app contact support page."
+                                },
+                                "personal_connection": {
+                                  "type": "boolean",
+                                  "description": "Whether each staff member needs to connect separately to the app."
+                                }
+                              }
+                            },
+                            "internal": {
+                              "type": "object",
+                              "description": "Internal-runtime app metadata used by clients that render the app shell.",
+                              "properties": {
+                                "api_uri": {
+                                  "type": "string",
+                                  "description": "Link to the application's API."
+                                },
+                                "full_screen": {
+                                  "type": "boolean",
+                                  "description": "Whether the app is opened in a full screen mode.",
+                                  "default": false
+                                },
+                                "deep_link": {
+                                  "type": "object",
+                                  "description": "Deep link to an inner product page.",
+                                  "properties": {
+                                    "path": {
+                                      "type": "string",
+                                      "description": "Relative path to the page (e.g., \"/app/somepath\")."
+                                    },
+                                    "path_params": {
+                                      "type": "object",
+                                      "description": "Optional query parameters to be added to the URL.",
+                                      "additionalProperties": true
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "extensions": {
+                              "type": "array",
+                              "readOnly": true,
+                              "description": "Developer-provided extension configuration entries. Each entry contains a `type` key identifying the extension and a `value` key holding its configuration. Only extensions with non-empty values are included. The array contains at most one entry per `type`.",
+                              "items": {
+                                "oneOf": [
+                                  {
+                                    "type": "object",
+                                    "description": "Menu items extension. Adds entries to the left sidebar navigation.",
+                                    "properties": {
+                                      "type": {
+                                        "type": "string",
+                                        "enum": [
+                                          "menu_items"
+                                        ]
+                                      },
+                                      "value": {
+                                        "type": "object",
+                                        "properties": {
+                                          "subitems": {
+                                            "type": "array",
+                                            "description": "Menu items to be added to the left sidebar.",
+                                            "items": {
+                                              "type": "object",
+                                              "properties": {
+                                                "category": {
+                                                  "type": "string",
+                                                  "description": "Section of the left menu in which the item will appear (e.g., \\\"clients\\\").",
+                                                  "enum": [
+                                                    "calendar",
+                                                    "clients",
+                                                    "payments",
+                                                    "inbox",
+                                                    "documents",
+                                                    "campaigns",
+                                                    "reputation",
+                                                    "my-livesite",
+                                                    "social",
+                                                    "social_info",
+                                                    "app_market",
+                                                    "reports",
+                                                    "team-chat",
+                                                    "advertising",
+                                                    "subscriptions",
+                                                    "my_account",
+                                                    "cashflow",
+                                                    "workforce",
+                                                    "setupguide",
+                                                    "reviews",
+                                                    "social_media",
+                                                    "online_listing"
+                                                  ]
+                                                },
+                                                "item_name": {
+                                                  "type": "object",
+                                                  "description": "Item names per language code (e.g., `{ \"en\": \"My Page\" }`).",
+                                                  "additionalProperties": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "route": {
+                                                  "type": "string",
+                                                  "description": "Suffix route relative to the app domain (e.g., \\\"rdbms\\\")."
+                                                },
+                                                "display_order": {
+                                                  "type": "integer",
+                                                  "minimum": 0,
+                                                  "description": "Display order within the category. Starts from 0."
+                                                },
+                                                "block_impersonation": {
+                                                  "type": "boolean",
+                                                  "description": "Whether the menu item should be blocked when an operator is impersonating as a staff member.",
+                                                  "default": false
+                                                },
+                                                "permissions": {
+                                                  "type": "array",
+                                                  "description": "Optional permissions required to see this menu item.",
+                                                  "items": {
+                                                    "type": "string"
+                                                  }
+                                                }
+                                              },
+                                              "required": [
+                                                "category",
+                                                "item_name",
+                                                "route"
+                                              ]
+                                            }
+                                          }
+                                        },
+                                        "required": [
+                                          "subitems"
+                                        ]
+                                      }
+                                    },
+                                    "required": [
+                                      "type",
+                                      "value"
+                                    ]
+                                  },
+                                  {
+                                    "type": "object",
+                                    "description": "Additional params extension. Defines custom, app-specific key-value query parameters appended to `app_host` when opening the app.",
+                                    "properties": {
+                                      "type": {
+                                        "type": "string",
+                                        "enum": [
+                                          "additional_params"
+                                        ]
+                                      },
+                                      "value": {
+                                        "type": "object",
+                                        "description": "Custom key-value query parameters appended to the app URL.",
+                                        "additionalProperties": true
+                                      }
+                                    },
+                                    "required": [
+                                      "type",
+                                      "value"
+                                    ]
+                                  },
+                                  {
+                                    "type": "object",
+                                    "description": "Deep link extension. Configures a deep link to an inner product page.",
+                                    "properties": {
+                                      "type": {
+                                        "type": "string",
+                                        "enum": [
+                                          "deep_link"
+                                        ]
+                                      },
+                                      "value": {
+                                        "type": "object",
+                                        "properties": {
+                                          "path": {
+                                            "type": "string",
+                                            "description": "Relative path to the page (e.g., \"/app/somepath\")."
+                                          },
+                                          "path_params": {
+                                            "type": "object",
+                                            "description": "Optional query parameters to be added to the URL.",
+                                            "additionalProperties": true
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "required": [
+                                      "type",
+                                      "value"
+                                    ]
+                                  },
+                                  {
+                                    "type": "object",
+                                    "description": "Old integration name extension. Identifies the app as a legacy integration.",
+                                    "properties": {
+                                      "type": {
+                                        "type": "string",
+                                        "enum": [
+                                          "old_integration_name"
+                                        ]
+                                      },
+                                      "value": {
+                                        "type": "string",
+                                        "description": "The legacy integration identifier string."
+                                      }
+                                    },
+                                    "required": [
+                                      "type",
+                                      "value"
+                                    ]
+                                  },
+                                  {
+                                    "type": "object",
+                                    "description": "Personal connection extension. Indicates whether each staff member needs to connect separately to the app.",
+                                    "properties": {
+                                      "type": {
+                                        "type": "string",
+                                        "enum": [
+                                          "personal_connection"
+                                        ]
+                                      },
+                                      "value": {
+                                        "type": "boolean",
+                                        "description": "Whether personal connection is required."
+                                      }
+                                    },
+                                    "required": [
+                                      "type",
+                                      "value"
+                                    ]
+                                  },
+                                  {
+                                    "type": "object",
+                                    "description": "Full screen extension. Indicates whether the app opens in full screen mode.",
+                                    "properties": {
+                                      "type": {
+                                        "type": "string",
+                                        "enum": [
+                                          "full_screen"
+                                        ]
+                                      },
+                                      "value": {
+                                        "type": "boolean",
+                                        "description": "Whether the app opens in full screen mode."
+                                      }
+                                    },
+                                    "required": [
+                                      "type",
+                                      "value"
+                                    ]
+                                  }
+                                ]
+                              }
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "readOnly": true,
+                              "description": "Timestamp indicating when the app was created.",
+                              "format": "date-time"
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "readOnly": true,
+                              "description": "Timestamp indicating when the app was last updated.",
+                              "format": "date-time"
+                            }
+                          },
+                          "required": [
+                            "uid",
+                            "app_code_name",
+                            "name",
+                            "redirect_uri",
+                            "assignment_types",
+                            "created_at",
+                            "updated_at"
+                          ],
+                          "example": {
+                            "uid": "d290f1ee-26c5-4e91-b1a0-4f8b1c2d3e4f",
+                            "app_code_name": "calendar_sync",
+                            "name": "Calendar Sync",
+                            "redirect_uri": "https://calendar-sync.example.com/app",
+                            "app_host": "https://calendar-sync.example.com/app?business_uid=d290f1ee-26c5-4e91-b1a0-4f8b1c2d3e4f&staff_uid=stf_123&language=en",
+                            "url_params": [
+                              "business_uid",
+                              "staff_uid",
+                              "language"
+                            ],
+                            "app_types": [
+                              "communication",
+                              "menu_items"
+                            ],
+                            "open_in_new_tab": false,
+                            "supported_in_mobile": true,
+                            "permissions": [
+                              "can_view_payments"
+                            ],
+                            "trusted": false,
+                            "oauth_redirect_uris": [
+                              "https://calendar-sync.example.com/oauth/callback"
+                            ],
+                            "assignment_types": [
+                              "installed",
+                              "directory_offering"
+                            ],
+                            "app_market": {
+                              "description": {
+                                "logo": "https://cdn.example.com/apps/calendar_sync/logo.png",
+                                "short_description": "Two-way sync between your calendar and inTandem bookings.",
+                                "text": "Sync bookings to your calendar automatically and avoid double-booking across devices."
+                              },
+                              "app_features": [
+                                "Two-way sync",
+                                "Conflict detection"
+                              ],
+                              "app_screenshot_uris": [
+                                "https://cdn.example.com/apps/calendar_sync/screenshots/1.png"
+                              ],
+                              "app_mobile_screenshot_uris": [
+                                "https://cdn.example.com/apps/calendar_sync/screenshots/mobile_1.png"
+                              ],
+                              "supported_countries": [
+                                "United States",
+                                "United Kingdom",
+                                "Israel"
+                              ],
+                              "locales": [
+                                "en",
+                                "he"
+                              ],
+                              "privacy_policy_link": "https://calendar-sync.example.com/privacy",
+                              "contact_support_link": "https://calendar-sync.example.com/support",
+                              "personal_connection": true
+                            },
+                            "internal": {
+                              "api_uri": "https://calendar-sync.example.com/api",
+                              "full_screen": false,
+                              "deep_link": {
+                                "path": "/apps/calendar_sync/settings",
+                                "path_params": {
+                                  "tab": "connections"
+                                }
+                              }
+                            },
+                            "owner": true,
+                            "extensions": [
+                              {
+                                "type": "menu_items",
+                                "value": {
+                                  "subitems": [
+                                    {
+                                      "category": "clients",
+                                      "item_name": {
+                                        "en": "Calendar Sync"
+                                      },
+                                      "route": "calendar-sync",
+                                      "display_order": 0,
+                                      "block_impersonation": false
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "type": "additional_params",
+                                "value": {
+                                  "open_channel_communication": true
+                                }
+                              },
+                              {
+                                "type": "full_screen",
+                                "value": true
+                              }
+                            ],
+                            "created_at": "2026-02-01T10:30:00Z",
+                            "updated_at": "2026-02-20T09:15:00Z"
+                          }
                         }
                       }
                     }
@@ -348,7 +1466,42 @@
                             "business_app_installs": {
                               "type": "array",
                               "items": {
-                                "$ref": "https://vcita.github.io/developers-hub/entities/apps/businessAppInstall.json"
+                                "type": "object",
+                                "description": "Represents an installed app for a business.",
+                                "properties": {
+                                  "uid": {
+                                    "type": "string",
+                                    "readOnly": true,
+                                    "description": "Unique identifier for the business app install record."
+                                  },
+                                  "business_uid": {
+                                    "type": "string",
+                                    "description": "Unique identifier of the business that has the app installed."
+                                  },
+                                  "app_code_name": {
+                                    "type": "string",
+                                    "description": "The unique code name of the installed app (e.g., \"calendar_sync\")."
+                                  },
+                                  "created_at": {
+                                    "type": "string",
+                                    "format": "date-time",
+                                    "readOnly": true,
+                                    "description": "The date and time when the install record was created, in ISO 8601 format."
+                                  },
+                                  "updated_at": {
+                                    "type": "string",
+                                    "format": "date-time",
+                                    "readOnly": true,
+                                    "description": "The date and time when the install record was last updated, in ISO 8601 format."
+                                  }
+                                },
+                                "example": {
+                                  "uid": "a1b2c3d4e5f6a1b2",
+                                  "business_uid": "d290f1ee6c544b01",
+                                  "app_code_name": "calendar_sync",
+                                  "created_at": "2024-01-15T10:30:00Z",
+                                  "updated_at": "2024-01-15T10:30:00Z"
+                                }
                               }
                             }
                           },
@@ -406,7 +1559,42 @@
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/apps/businessAppInstall.json"
+                          "type": "object",
+                          "description": "Represents an installed app for a business.",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "readOnly": true,
+                              "description": "Unique identifier for the business app install record."
+                            },
+                            "business_uid": {
+                              "type": "string",
+                              "description": "Unique identifier of the business that has the app installed."
+                            },
+                            "app_code_name": {
+                              "type": "string",
+                              "description": "The unique code name of the installed app (e.g., \"calendar_sync\")."
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "readOnly": true,
+                              "description": "The date and time when the install record was created, in ISO 8601 format."
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "readOnly": true,
+                              "description": "The date and time when the install record was last updated, in ISO 8601 format."
+                            }
+                          },
+                          "example": {
+                            "uid": "a1b2c3d4e5f6a1b2",
+                            "business_uid": "d290f1ee6c544b01",
+                            "app_code_name": "calendar_sync",
+                            "created_at": "2024-01-15T10:30:00Z",
+                            "updated_at": "2024-01-15T10:30:00Z"
+                          }
                         }
                       }
                     }
@@ -467,7 +1655,42 @@
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/apps/businessAppInstall.json"
+                          "type": "object",
+                          "description": "Represents an installed app for a business.",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "readOnly": true,
+                              "description": "Unique identifier for the business app install record."
+                            },
+                            "business_uid": {
+                              "type": "string",
+                              "description": "Unique identifier of the business that has the app installed."
+                            },
+                            "app_code_name": {
+                              "type": "string",
+                              "description": "The unique code name of the installed app (e.g., \"calendar_sync\")."
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "readOnly": true,
+                              "description": "The date and time when the install record was created, in ISO 8601 format."
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "readOnly": true,
+                              "description": "The date and time when the install record was last updated, in ISO 8601 format."
+                            }
+                          },
+                          "example": {
+                            "uid": "a1b2c3d4e5f6a1b2",
+                            "business_uid": "d290f1ee6c544b01",
+                            "app_code_name": "calendar_sync",
+                            "created_at": "2024-01-15T10:30:00Z",
+                            "updated_at": "2024-01-15T10:30:00Z"
+                          }
                         }
                       }
                     }
@@ -600,7 +1823,85 @@
                             "app_assignments": {
                               "type": "array",
                               "items": {
-                                "$ref": "https://vcita.github.io/developers-hub/entities/apps/appAssignment.json"
+                                "type": "object",
+                                "properties": {
+                                  "uid": {
+                                    "type": "string",
+                                    "description": "A unique identifier for the app assignment record"
+                                  },
+                                  "created_at": {
+                                    "type": "string",
+                                    "description": "Timestamp when the app assignment was created",
+                                    "format": "date-time"
+                                  },
+                                  "updated_at": {
+                                    "type": "string",
+                                    "description": "Timestamp when the app assignment was last updated",
+                                    "format": "date-time"
+                                  },
+                                  "assignee_type": {
+                                    "type": "string",
+                                    "description": "The type of entity this app is assigned to",
+                                    "enum": [
+                                      "business",
+                                      "package",
+                                      "directory"
+                                    ]
+                                  },
+                                  "assignee_uid": {
+                                    "type": "string",
+                                    "description": "The uid of the entity this app is assigned to"
+                                  },
+                                  "assignee_name": {
+                                    "type": "string",
+                                    "description": "A unique code name for the underlying package or directory"
+                                  },
+                                  "app_code_name": {
+                                    "type": "string",
+                                    "description": "The unique identifier of the app"
+                                  },
+                                  "directory_uid": {
+                                    "type": "string",
+                                    "description": "The uid of the directory this app is assigned to"
+                                  },
+                                  "settings": {
+                                    "type": "object",
+                                    "description": "Settings for the app assignment",
+                                    "properties": {
+                                      "assignment_mode": {
+                                        "type": "string",
+                                        "description": "App setting:\n 'internal' - App does not show in the app market but still available to use in all relevant integration points;\n 'pre_installed' - Define the app as pre-installed for all new accounts, app shows in app market as installed on first appearance. The user will be able to uninstall it later if they wish to. This is relevant only to account with platform app market",
+                                        "enum": [
+                                          "internal",
+                                          "pre_installed"
+                                        ]
+                                      }
+                                    },
+                                    "required": [
+                                      "assignment_mode"
+                                    ]
+                                  }
+                                },
+                                "required": [
+                                  "assignee_type",
+                                  "assignee_uid",
+                                  "app_code_name",
+                                  "settings"
+                                ],
+                                "example": {
+                                  "uid": "ba7f2e8d-9a1b-4c5d-8e9f-1a2b3c4d5e6f",
+                                  "created_at": "2024-01-15T10:30:00Z",
+                                  "updated_at": "2024-01-15T10:30:00Z",
+                                  "assignee_type": "package",
+                                  "assignee_uid": "6c71874z-4d2b-46q1-bbdd-f8c7e12e66d0",
+                                  "assignee_name": "package_1",
+                                  "app_code_name": "calendar_sync",
+                                  "directory_uid": "6c71874z-4d2b-46q1-bbdd-f8c7e12e66d0",
+                                  "settings": {
+                                    "assignment_mode": "pre_installed"
+                                  }
+                                },
+                                "description": "Defines assignment of an app to a business, package, or directory, including settings."
                               }
                             }
                           },
@@ -665,7 +1966,85 @@
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/apps/appAssignment.json"
+                          "type": "object",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "description": "A unique identifier for the app assignment record"
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "description": "Timestamp when the app assignment was created",
+                              "format": "date-time"
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "description": "Timestamp when the app assignment was last updated",
+                              "format": "date-time"
+                            },
+                            "assignee_type": {
+                              "type": "string",
+                              "description": "The type of entity this app is assigned to",
+                              "enum": [
+                                "business",
+                                "package",
+                                "directory"
+                              ]
+                            },
+                            "assignee_uid": {
+                              "type": "string",
+                              "description": "The uid of the entity this app is assigned to"
+                            },
+                            "assignee_name": {
+                              "type": "string",
+                              "description": "A unique code name for the underlying package or directory"
+                            },
+                            "app_code_name": {
+                              "type": "string",
+                              "description": "The unique identifier of the app"
+                            },
+                            "directory_uid": {
+                              "type": "string",
+                              "description": "The uid of the directory this app is assigned to"
+                            },
+                            "settings": {
+                              "type": "object",
+                              "description": "Settings for the app assignment",
+                              "properties": {
+                                "assignment_mode": {
+                                  "type": "string",
+                                  "description": "App setting:\n 'internal' - App does not show in the app market but still available to use in all relevant integration points;\n 'pre_installed' - Define the app as pre-installed for all new accounts, app shows in app market as installed on first appearance. The user will be able to uninstall it later if they wish to. This is relevant only to account with platform app market",
+                                  "enum": [
+                                    "internal",
+                                    "pre_installed"
+                                  ]
+                                }
+                              },
+                              "required": [
+                                "assignment_mode"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "assignee_type",
+                            "assignee_uid",
+                            "app_code_name",
+                            "settings"
+                          ],
+                          "example": {
+                            "uid": "ba7f2e8d-9a1b-4c5d-8e9f-1a2b3c4d5e6f",
+                            "created_at": "2024-01-15T10:30:00Z",
+                            "updated_at": "2024-01-15T10:30:00Z",
+                            "assignee_type": "package",
+                            "assignee_uid": "6c71874z-4d2b-46q1-bbdd-f8c7e12e66d0",
+                            "assignee_name": "package_1",
+                            "app_code_name": "calendar_sync",
+                            "directory_uid": "6c71874z-4d2b-46q1-bbdd-f8c7e12e66d0",
+                            "settings": {
+                              "assignment_mode": "pre_installed"
+                            }
+                          },
+                          "description": "Defines assignment of an app to a business, package, or directory, including settings."
                         }
                       }
                     }
@@ -726,7 +2105,85 @@
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/apps/appAssignment.json"
+                          "type": "object",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "description": "A unique identifier for the app assignment record"
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "description": "Timestamp when the app assignment was created",
+                              "format": "date-time"
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "description": "Timestamp when the app assignment was last updated",
+                              "format": "date-time"
+                            },
+                            "assignee_type": {
+                              "type": "string",
+                              "description": "The type of entity this app is assigned to",
+                              "enum": [
+                                "business",
+                                "package",
+                                "directory"
+                              ]
+                            },
+                            "assignee_uid": {
+                              "type": "string",
+                              "description": "The uid of the entity this app is assigned to"
+                            },
+                            "assignee_name": {
+                              "type": "string",
+                              "description": "A unique code name for the underlying package or directory"
+                            },
+                            "app_code_name": {
+                              "type": "string",
+                              "description": "The unique identifier of the app"
+                            },
+                            "directory_uid": {
+                              "type": "string",
+                              "description": "The uid of the directory this app is assigned to"
+                            },
+                            "settings": {
+                              "type": "object",
+                              "description": "Settings for the app assignment",
+                              "properties": {
+                                "assignment_mode": {
+                                  "type": "string",
+                                  "description": "App setting:\n 'internal' - App does not show in the app market but still available to use in all relevant integration points;\n 'pre_installed' - Define the app as pre-installed for all new accounts, app shows in app market as installed on first appearance. The user will be able to uninstall it later if they wish to. This is relevant only to account with platform app market",
+                                  "enum": [
+                                    "internal",
+                                    "pre_installed"
+                                  ]
+                                }
+                              },
+                              "required": [
+                                "assignment_mode"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "assignee_type",
+                            "assignee_uid",
+                            "app_code_name",
+                            "settings"
+                          ],
+                          "example": {
+                            "uid": "ba7f2e8d-9a1b-4c5d-8e9f-1a2b3c4d5e6f",
+                            "created_at": "2024-01-15T10:30:00Z",
+                            "updated_at": "2024-01-15T10:30:00Z",
+                            "assignee_type": "package",
+                            "assignee_uid": "6c71874z-4d2b-46q1-bbdd-f8c7e12e66d0",
+                            "assignee_name": "package_1",
+                            "app_code_name": "calendar_sync",
+                            "directory_uid": "6c71874z-4d2b-46q1-bbdd-f8c7e12e66d0",
+                            "settings": {
+                              "assignment_mode": "pre_installed"
+                            }
+                          },
+                          "description": "Defines assignment of an app to a business, package, or directory, including settings."
                         }
                       }
                     }
@@ -821,7 +2278,50 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "type": "object",
@@ -832,7 +2332,63 @@
                             "business_mappings": {
                               "type": "array",
                               "items": {
-                                "$ref": "https://vcita.github.io/developers-hub/entities/apps/appBusinessMapping.json"
+                                "type": "object",
+                                "description": "Maps a vcita business to one or more third-party application identifiers for a specific integrated app. Used by partner-facing tooling to associate an SMB with external app identifiers (e.g., a Yext business and user code for app_code_name \"yext\").",
+                                "properties": {
+                                  "uid": {
+                                    "type": "string",
+                                    "readOnly": true,
+                                    "description": "Unique identifier for the app business mapping record (e.g., \"abm_7f2e8d9a1b4c\")."
+                                  },
+                                  "business_uid": {
+                                    "type": "string",
+                                    "description": "Unique identifier of the vcita business being mapped (e.g., \"d290f1ee6c544b01\")."
+                                  },
+                                  "directory_uid": {
+                                    "type": "string",
+                                    "description": "Unique identifier of the directory (partner) that owns this mapping (e.g., \"dir_partner_xyz\")."
+                                  },
+                                  "app_code_name": {
+                                    "type": "string",
+                                    "description": "Code name of the third-party integrated app this mapping applies to (e.g., \"yext\")."
+                                  },
+                                  "mapped_business_uid": {
+                                    "type": "string",
+                                    "description": "Third-party business identifier for the mapped business in the external app (e.g., \"yext-business-id-42\")."
+                                  },
+                                  "mapped_user_uid": {
+                                    "type": "string",
+                                    "nullable": true,
+                                    "description": "Optional third-party user identifier for the mapped business in the external app (e.g., \"yext-user-code-42\" or null)."
+                                  },
+                                  "created_at": {
+                                    "type": "string",
+                                    "format": "date-time",
+                                    "readOnly": true,
+                                    "description": "The date and time when the mapping was created, in ISO 8601 format (e.g., \"2026-06-10T10:30:00Z\")."
+                                  },
+                                  "updated_at": {
+                                    "type": "string",
+                                    "format": "date-time",
+                                    "readOnly": true,
+                                    "description": "The date and time when the mapping was last updated, in ISO 8601 format (e.g., \"2026-06-10T10:30:00Z\")."
+                                  }
+                                },
+                                "required": [
+                                  "business_uid",
+                                  "app_code_name",
+                                  "mapped_business_uid"
+                                ],
+                                "example": {
+                                  "uid": "abm_7f2e8d9a1b4c",
+                                  "business_uid": "d290f1ee6c544b01",
+                                  "directory_uid": "dir_partner_xyz",
+                                  "app_code_name": "yext",
+                                  "mapped_business_uid": "yext-business-id-42",
+                                  "mapped_user_uid": "yext-user-code-42",
+                                  "created_at": "2026-06-10T10:30:00Z",
+                                  "updated_at": "2026-06-10T10:30:00Z"
+                                }
                               }
                             }
                           }
@@ -956,13 +2512,112 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "type": "object",
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/apps/appBusinessMapping.json"
+                          "type": "object",
+                          "description": "Maps a vcita business to one or more third-party application identifiers for a specific integrated app. Used by partner-facing tooling to associate an SMB with external app identifiers (e.g., a Yext business and user code for app_code_name \"yext\").",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "readOnly": true,
+                              "description": "Unique identifier for the app business mapping record (e.g., \"abm_7f2e8d9a1b4c\")."
+                            },
+                            "business_uid": {
+                              "type": "string",
+                              "description": "Unique identifier of the vcita business being mapped (e.g., \"d290f1ee6c544b01\")."
+                            },
+                            "directory_uid": {
+                              "type": "string",
+                              "description": "Unique identifier of the directory (partner) that owns this mapping (e.g., \"dir_partner_xyz\")."
+                            },
+                            "app_code_name": {
+                              "type": "string",
+                              "description": "Code name of the third-party integrated app this mapping applies to (e.g., \"yext\")."
+                            },
+                            "mapped_business_uid": {
+                              "type": "string",
+                              "description": "Third-party business identifier for the mapped business in the external app (e.g., \"yext-business-id-42\")."
+                            },
+                            "mapped_user_uid": {
+                              "type": "string",
+                              "nullable": true,
+                              "description": "Optional third-party user identifier for the mapped business in the external app (e.g., \"yext-user-code-42\" or null)."
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "readOnly": true,
+                              "description": "The date and time when the mapping was created, in ISO 8601 format (e.g., \"2026-06-10T10:30:00Z\")."
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "readOnly": true,
+                              "description": "The date and time when the mapping was last updated, in ISO 8601 format (e.g., \"2026-06-10T10:30:00Z\")."
+                            }
+                          },
+                          "required": [
+                            "business_uid",
+                            "app_code_name",
+                            "mapped_business_uid"
+                          ],
+                          "example": {
+                            "uid": "abm_7f2e8d9a1b4c",
+                            "business_uid": "d290f1ee6c544b01",
+                            "directory_uid": "dir_partner_xyz",
+                            "app_code_name": "yext",
+                            "mapped_business_uid": "yext-business-id-42",
+                            "mapped_user_uid": "yext-user-code-42",
+                            "created_at": "2026-06-10T10:30:00Z",
+                            "updated_at": "2026-06-10T10:30:00Z"
+                          }
                         }
                       }
                     }
@@ -1117,13 +2772,112 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "type": "object",
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/apps/appBusinessMapping.json"
+                          "type": "object",
+                          "description": "Maps a vcita business to one or more third-party application identifiers for a specific integrated app. Used by partner-facing tooling to associate an SMB with external app identifiers (e.g., a Yext business and user code for app_code_name \"yext\").",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "readOnly": true,
+                              "description": "Unique identifier for the app business mapping record (e.g., \"abm_7f2e8d9a1b4c\")."
+                            },
+                            "business_uid": {
+                              "type": "string",
+                              "description": "Unique identifier of the vcita business being mapped (e.g., \"d290f1ee6c544b01\")."
+                            },
+                            "directory_uid": {
+                              "type": "string",
+                              "description": "Unique identifier of the directory (partner) that owns this mapping (e.g., \"dir_partner_xyz\")."
+                            },
+                            "app_code_name": {
+                              "type": "string",
+                              "description": "Code name of the third-party integrated app this mapping applies to (e.g., \"yext\")."
+                            },
+                            "mapped_business_uid": {
+                              "type": "string",
+                              "description": "Third-party business identifier for the mapped business in the external app (e.g., \"yext-business-id-42\")."
+                            },
+                            "mapped_user_uid": {
+                              "type": "string",
+                              "nullable": true,
+                              "description": "Optional third-party user identifier for the mapped business in the external app (e.g., \"yext-user-code-42\" or null)."
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "readOnly": true,
+                              "description": "The date and time when the mapping was created, in ISO 8601 format (e.g., \"2026-06-10T10:30:00Z\")."
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "readOnly": true,
+                              "description": "The date and time when the mapping was last updated, in ISO 8601 format (e.g., \"2026-06-10T10:30:00Z\")."
+                            }
+                          },
+                          "required": [
+                            "business_uid",
+                            "app_code_name",
+                            "mapped_business_uid"
+                          ],
+                          "example": {
+                            "uid": "abm_7f2e8d9a1b4c",
+                            "business_uid": "d290f1ee6c544b01",
+                            "directory_uid": "dir_partner_xyz",
+                            "app_code_name": "yext",
+                            "mapped_business_uid": "yext-business-id-42",
+                            "mapped_user_uid": "yext-user-code-42",
+                            "created_at": "2026-06-10T10:30:00Z",
+                            "updated_at": "2026-06-10T10:30:00Z"
+                          }
                         }
                       }
                     }
@@ -1249,13 +3003,112 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "type": "object",
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/apps/appBusinessMapping.json"
+                          "type": "object",
+                          "description": "Maps a vcita business to one or more third-party application identifiers for a specific integrated app. Used by partner-facing tooling to associate an SMB with external app identifiers (e.g., a Yext business and user code for app_code_name \"yext\").",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "readOnly": true,
+                              "description": "Unique identifier for the app business mapping record (e.g., \"abm_7f2e8d9a1b4c\")."
+                            },
+                            "business_uid": {
+                              "type": "string",
+                              "description": "Unique identifier of the vcita business being mapped (e.g., \"d290f1ee6c544b01\")."
+                            },
+                            "directory_uid": {
+                              "type": "string",
+                              "description": "Unique identifier of the directory (partner) that owns this mapping (e.g., \"dir_partner_xyz\")."
+                            },
+                            "app_code_name": {
+                              "type": "string",
+                              "description": "Code name of the third-party integrated app this mapping applies to (e.g., \"yext\")."
+                            },
+                            "mapped_business_uid": {
+                              "type": "string",
+                              "description": "Third-party business identifier for the mapped business in the external app (e.g., \"yext-business-id-42\")."
+                            },
+                            "mapped_user_uid": {
+                              "type": "string",
+                              "nullable": true,
+                              "description": "Optional third-party user identifier for the mapped business in the external app (e.g., \"yext-user-code-42\" or null)."
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "readOnly": true,
+                              "description": "The date and time when the mapping was created, in ISO 8601 format (e.g., \"2026-06-10T10:30:00Z\")."
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "readOnly": true,
+                              "description": "The date and time when the mapping was last updated, in ISO 8601 format (e.g., \"2026-06-10T10:30:00Z\")."
+                            }
+                          },
+                          "required": [
+                            "business_uid",
+                            "app_code_name",
+                            "mapped_business_uid"
+                          ],
+                          "example": {
+                            "uid": "abm_7f2e8d9a1b4c",
+                            "business_uid": "d290f1ee6c544b01",
+                            "directory_uid": "dir_partner_xyz",
+                            "app_code_name": "yext",
+                            "mapped_business_uid": "yext-business-id-42",
+                            "mapped_user_uid": "yext-user-code-42",
+                            "created_at": "2026-06-10T10:30:00Z",
+                            "updated_at": "2026-06-10T10:30:00Z"
+                          }
                         }
                       }
                     }
@@ -1407,13 +3260,112 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "type": "object",
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/apps/appBusinessMapping.json"
+                          "type": "object",
+                          "description": "Maps a vcita business to one or more third-party application identifiers for a specific integrated app. Used by partner-facing tooling to associate an SMB with external app identifiers (e.g., a Yext business and user code for app_code_name \"yext\").",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "readOnly": true,
+                              "description": "Unique identifier for the app business mapping record (e.g., \"abm_7f2e8d9a1b4c\")."
+                            },
+                            "business_uid": {
+                              "type": "string",
+                              "description": "Unique identifier of the vcita business being mapped (e.g., \"d290f1ee6c544b01\")."
+                            },
+                            "directory_uid": {
+                              "type": "string",
+                              "description": "Unique identifier of the directory (partner) that owns this mapping (e.g., \"dir_partner_xyz\")."
+                            },
+                            "app_code_name": {
+                              "type": "string",
+                              "description": "Code name of the third-party integrated app this mapping applies to (e.g., \"yext\")."
+                            },
+                            "mapped_business_uid": {
+                              "type": "string",
+                              "description": "Third-party business identifier for the mapped business in the external app (e.g., \"yext-business-id-42\")."
+                            },
+                            "mapped_user_uid": {
+                              "type": "string",
+                              "nullable": true,
+                              "description": "Optional third-party user identifier for the mapped business in the external app (e.g., \"yext-user-code-42\" or null)."
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "readOnly": true,
+                              "description": "The date and time when the mapping was created, in ISO 8601 format (e.g., \"2026-06-10T10:30:00Z\")."
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "readOnly": true,
+                              "description": "The date and time when the mapping was last updated, in ISO 8601 format (e.g., \"2026-06-10T10:30:00Z\")."
+                            }
+                          },
+                          "required": [
+                            "business_uid",
+                            "app_code_name",
+                            "mapped_business_uid"
+                          ],
+                          "example": {
+                            "uid": "abm_7f2e8d9a1b4c",
+                            "business_uid": "d290f1ee6c544b01",
+                            "directory_uid": "dir_partner_xyz",
+                            "app_code_name": "yext",
+                            "mapped_business_uid": "yext-business-id-42",
+                            "mapped_user_uid": "yext-user-code-42",
+                            "created_at": "2026-06-10T10:30:00Z",
+                            "updated_at": "2026-06-10T10:30:00Z"
+                          }
                         }
                       }
                     }
@@ -2846,7 +4798,50 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "type": "object",
@@ -2857,7 +4852,240 @@
                             "navigation_items": {
                               "type": "array",
                               "items": {
-                                "$ref": "https://vcita.github.io/developers-hub/entities/apps/navigation_item.json"
+                                "type": "object",
+                                "description": "Represents a navigation menu item that defines how partners configure their platform navigation structure. Navigation items support hierarchical menus, localized titles, permission-based visibility, and mobile-specific settings.",
+                                "properties": {
+                                  "uid": {
+                                    "type": "string",
+                                    "readOnly": true,
+                                    "description": "Unique identifier for the navigation item (e.g., \"nav-item-abc123\")."
+                                  },
+                                  "parent_uid": {
+                                    "type": "string",
+                                    "nullable": true,
+                                    "description": "The UID of the parent navigation item. Set to null only for the root item, which represents the logo. Only one root item should exist per directory (e.g., \"nav-item-parent123\" or null)."
+                                  },
+                                  "directory_uid": {
+                                    "type": "string",
+                                    "readOnly": true,
+                                    "description": "Unique identifier of the directory (partner) that owns this navigation item. Automatically set from the authenticated token context (e.g., \"dir-abc123\")."
+                                  },
+                                  "order": {
+                                    "type": "integer",
+                                    "minimum": 0,
+                                    "default": 0,
+                                    "description": "Display order within the parent level. Lower numbers appear first. Items with the same order are sorted by creation time (e.g., 0, 1, 2)."
+                                  },
+                                  "title": {
+                                    "type": "object",
+                                    "description": "Localized titles for the navigation item. Must include at least the 'en' (English) locale.",
+                                    "propertyNames": {
+                                      "type": "string",
+                                      "enum": [
+                                        "de",
+                                        "en",
+                                        "es",
+                                        "fr",
+                                        "he",
+                                        "it",
+                                        "pl",
+                                        "pt",
+                                        "ru",
+                                        "sl",
+                                        "tr"
+                                      ]
+                                    },
+                                    "properties": {
+                                      "en": {
+                                        "type": "string",
+                                        "description": "English title (required)."
+                                      },
+                                      "he": {
+                                        "type": "string",
+                                        "description": "Hebrew title (optional)."
+                                      }
+                                    },
+                                    "required": [
+                                      "en"
+                                    ],
+                                    "additionalProperties": {
+                                      "type": "string",
+                                      "description": "Additional locale titles (e.g., \"es\", \"fr\", \"de\")."
+                                    }
+                                  },
+                                  "icon": {
+                                    "type": "string",
+                                    "nullable": true,
+                                    "maxLength": 255,
+                                    "description": "Icon identifier from the platform icon library. For a list of supported icon identifiers, refer to the inTandem UI icon library used by the platform (e.g., \"icon-Dashboard_POV\", \"icon-Settings\")."
+                                  },
+                                  "key": {
+                                    "type": "string",
+                                    "maxLength": 255,
+                                    "description": "Human-readable unique identifier within the directory. Used by API consumers for programmatic access. Must be stable across title/translation changes (e.g., \"dashboard\", \"settings\", \"custom_module\")."
+                                  },
+                                  "modules": {
+                                    "type": "array",
+                                    "nullable": true,
+                                    "uniqueItems": true,
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "description": "Array of module identifiers required for this item to be visible. Item is shown only if the business has at least one of these modules enabled. The list of enabled modules can be retrieved from the features endpoint (e.g., \"https://developers.intandem.tech/reference/get_platform-v1-businesses-business-id-features\"). (e.g., [\"scheduling\", \"payments\"])."
+                                  },
+                                  "permissions": {
+                                    "type": "array",
+                                    "nullable": true,
+                                    "uniqueItems": true,
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "description": "Array of permission identifiers required to view this item. Item is shown only if the staff member has at least one of these permissions. To retrieve valid permission codes, use the endpoint (GET \"/v3/access_control/permissions\"). (e.g., [\"payments.invoices.export\", \"clients.manage\"])."
+                                  },
+                                  "badge_code": {
+                                    "type": "string",
+                                    "nullable": true,
+                                    "enum": [
+                                      "inbox_unread"
+                                    ],
+                                    "description": "Badge code that displays a notification indicator on this navigation item. Supported values are finite and managed by the platform (e.g., \"inbox_unread\" or null)."
+                                  },
+                                  "action": {
+                                    "type": "object",
+                                    "description": "Action configuration that defines the behavior when the navigation item is clicked. Actions are handled by the inTandem JS SDK. Every navigation item must have an action. Supported action types: \"navigate\" (navigates to a page) and \"openModal\" (opens a modal dialog).",
+                                    "properties": {
+                                      "name": {
+                                        "type": "string",
+                                        "enum": [
+                                          "navigate",
+                                          "openModal"
+                                        ],
+                                        "description": "Action type identifier. Supported values: \"navigate\" (navigates to a page using the inTandem JS SDK navigate function, see the [navigate documentation](https://developers.intandem.tech/docs/navigate)), \"openModal\" (opens a modal dialog using the inTandem JS SDK, see the [openModal documentation](https://developers.intandem.tech/docs/openmodal))."
+                                      },
+                                      "payload": {
+                                        "type": "object",
+                                        "description": "Action-specific payload. For \"navigate\": must include 'type' and 'path' (required), and optionally 'new_tab'. For \"openModal\": must include the modal configuration (e.g., {\"modalName\": \"AppMarket\"}). See the inTandem JS SDK documentation for complete parameter specifications."
+                                      }
+                                    },
+                                    "required": [
+                                      "name",
+                                      "payload"
+                                    ]
+                                  },
+                                  "available_in_mobile": {
+                                    "type": "boolean",
+                                    "default": true,
+                                    "description": "Whether this navigation item should appear in mobile app navigation. Set to false for desktop-only features (e.g., true, false)."
+                                  },
+                                  "favorite_in_mobile": {
+                                    "type": "boolean",
+                                    "default": false,
+                                    "description": "Whether this item appears in the mobile favorites/quick-access section. Only applicable when available_in_mobile is true (e.g., true, false)."
+                                  },
+                                  "upsell_handling": {
+                                    "type": "string",
+                                    "nullable": true,
+                                    "enum": [
+                                      "hide",
+                                      "show_upsell"
+                                    ],
+                                    "description": "Behavior when user lacks required modules/permissions. 'hide' removes the item completely, 'show_upsell' displays it with an upgrade prompt. Null means default behavior (hide)."
+                                  },
+                                  "role": {
+                                    "type": "string",
+                                    "nullable": true,
+                                    "enum": [
+                                      "settings"
+                                    ],
+                                    "description": "Semantic role of the navigation item that can trigger special behavior, e.g. \"settings\" causes a settings cog icon to be displayed in the full menu screen. Null means no special role (e.g., \"settings\" or null)."
+                                  },
+                                  "app_code_name": {
+                                    "type": "string",
+                                    "nullable": true,
+                                    "maxLength": 255,
+                                    "description": "App code name to gate this item by app availability. When set, the item is only visible to staff who have the corresponding app assigned. Must match an existing app's app_code_name. Null means the item is not gated by app availability (e.g., \"myapp\" or null)."
+                                  },
+                                  "is_bmp": {
+                                    "type": "boolean",
+                                    "default": false,
+                                    "description": "Indicates if this is a Business Management Platform (BMP) sub-menu item. When set to true, BMP children are built by inTandem internal logic. Available for **Directory tokens** via create and update operations (e.g., true, false)."
+                                  },
+                                  "created_by": {
+                                    "type": "string",
+                                    "nullable": true,
+                                    "readOnly": true,
+                                    "enum": [
+                                      "vcita",
+                                      "app",
+                                      "directory",
+                                      null
+                                    ],
+                                    "description": "Indicates who created this navigation item. Supported values are: \"vcita\" (created by vcita system), \"app\" (created by an application or integration), \"directory\" (created by the directory owner). Null means unknown or legacy value."
+                                  },
+                                  "updated_by": {
+                                    "type": "string",
+                                    "nullable": true,
+                                    "readOnly": true,
+                                    "enum": [
+                                      "vcita",
+                                      "app",
+                                      "directory",
+                                      null
+                                    ],
+                                    "description": "Indicates who last updated this navigation item. Supported values are: \"vcita\" (updated by vcita system), \"app\" (updated by an application or integration), \"directory\" (updated by the directory owner). Null means unknown or legacy value."
+                                  },
+                                  "created_at": {
+                                    "type": "string",
+                                    "format": "date-time",
+                                    "readOnly": true,
+                                    "description": "The date and time when the navigation item was created, in ISO 8601 format (e.g., \"2026-01-15T10:30:00Z\")."
+                                  },
+                                  "updated_at": {
+                                    "type": "string",
+                                    "format": "date-time",
+                                    "readOnly": true,
+                                    "description": "The date and time when the navigation item was last updated, in ISO 8601 format (e.g., \"2026-01-15T14:45:00Z\")."
+                                  }
+                                },
+                                "required": [
+                                  "order",
+                                  "title",
+                                  "key",
+                                  "action"
+                                ],
+                                "example": {
+                                  "uid": "nav-item-abc123",
+                                  "parent_uid": null,
+                                  "directory_uid": "dir-xyz789",
+                                  "order": 1,
+                                  "title": {
+                                    "en": "Dashboard",
+                                    "he": "לוח בקרה"
+                                  },
+                                  "icon": "icon-Dashboard_POV",
+                                  "key": "dashboard",
+                                  "modules": null,
+                                  "permissions": null,
+                                  "badge_code": null,
+                                  "action": {
+                                    "name": "navigate",
+                                    "payload": {
+                                      "type": "relative",
+                                      "path": "/app/dashboard",
+                                      "new_tab": false
+                                    }
+                                  },
+                                  "available_in_mobile": true,
+                                  "favorite_in_mobile": true,
+                                  "upsell_handling": null,
+                                  "role": "settings",
+                                  "app_code_name": null,
+                                  "is_bmp": false,
+                                  "created_by": "directory",
+                                  "updated_by": "directory",
+                                  "created_at": "2026-01-15T10:30:00Z",
+                                  "updated_at": "2026-01-15T10:30:00Z"
+                                }
                               }
                             }
                           }
@@ -3005,13 +5233,289 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "type": "object",
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/apps/navigation_item.json"
+                          "type": "object",
+                          "description": "Represents a navigation menu item that defines how partners configure their platform navigation structure. Navigation items support hierarchical menus, localized titles, permission-based visibility, and mobile-specific settings.",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "readOnly": true,
+                              "description": "Unique identifier for the navigation item (e.g., \"nav-item-abc123\")."
+                            },
+                            "parent_uid": {
+                              "type": "string",
+                              "nullable": true,
+                              "description": "The UID of the parent navigation item. Set to null only for the root item, which represents the logo. Only one root item should exist per directory (e.g., \"nav-item-parent123\" or null)."
+                            },
+                            "directory_uid": {
+                              "type": "string",
+                              "readOnly": true,
+                              "description": "Unique identifier of the directory (partner) that owns this navigation item. Automatically set from the authenticated token context (e.g., \"dir-abc123\")."
+                            },
+                            "order": {
+                              "type": "integer",
+                              "minimum": 0,
+                              "default": 0,
+                              "description": "Display order within the parent level. Lower numbers appear first. Items with the same order are sorted by creation time (e.g., 0, 1, 2)."
+                            },
+                            "title": {
+                              "type": "object",
+                              "description": "Localized titles for the navigation item. Must include at least the 'en' (English) locale.",
+                              "propertyNames": {
+                                "type": "string",
+                                "enum": [
+                                  "de",
+                                  "en",
+                                  "es",
+                                  "fr",
+                                  "he",
+                                  "it",
+                                  "pl",
+                                  "pt",
+                                  "ru",
+                                  "sl",
+                                  "tr"
+                                ]
+                              },
+                              "properties": {
+                                "en": {
+                                  "type": "string",
+                                  "description": "English title (required)."
+                                },
+                                "he": {
+                                  "type": "string",
+                                  "description": "Hebrew title (optional)."
+                                }
+                              },
+                              "required": [
+                                "en"
+                              ],
+                              "additionalProperties": {
+                                "type": "string",
+                                "description": "Additional locale titles (e.g., \"es\", \"fr\", \"de\")."
+                              }
+                            },
+                            "icon": {
+                              "type": "string",
+                              "nullable": true,
+                              "maxLength": 255,
+                              "description": "Icon identifier from the platform icon library. For a list of supported icon identifiers, refer to the inTandem UI icon library used by the platform (e.g., \"icon-Dashboard_POV\", \"icon-Settings\")."
+                            },
+                            "key": {
+                              "type": "string",
+                              "maxLength": 255,
+                              "description": "Human-readable unique identifier within the directory. Used by API consumers for programmatic access. Must be stable across title/translation changes (e.g., \"dashboard\", \"settings\", \"custom_module\")."
+                            },
+                            "modules": {
+                              "type": "array",
+                              "nullable": true,
+                              "uniqueItems": true,
+                              "items": {
+                                "type": "string"
+                              },
+                              "description": "Array of module identifiers required for this item to be visible. Item is shown only if the business has at least one of these modules enabled. The list of enabled modules can be retrieved from the features endpoint (e.g., \"https://developers.intandem.tech/reference/get_platform-v1-businesses-business-id-features\"). (e.g., [\"scheduling\", \"payments\"])."
+                            },
+                            "permissions": {
+                              "type": "array",
+                              "nullable": true,
+                              "uniqueItems": true,
+                              "items": {
+                                "type": "string"
+                              },
+                              "description": "Array of permission identifiers required to view this item. Item is shown only if the staff member has at least one of these permissions. To retrieve valid permission codes, use the endpoint (GET \"/v3/access_control/permissions\"). (e.g., [\"payments.invoices.export\", \"clients.manage\"])."
+                            },
+                            "badge_code": {
+                              "type": "string",
+                              "nullable": true,
+                              "enum": [
+                                "inbox_unread"
+                              ],
+                              "description": "Badge code that displays a notification indicator on this navigation item. Supported values are finite and managed by the platform (e.g., \"inbox_unread\" or null)."
+                            },
+                            "action": {
+                              "type": "object",
+                              "description": "Action configuration that defines the behavior when the navigation item is clicked. Actions are handled by the inTandem JS SDK. Every navigation item must have an action. Supported action types: \"navigate\" (navigates to a page) and \"openModal\" (opens a modal dialog).",
+                              "properties": {
+                                "name": {
+                                  "type": "string",
+                                  "enum": [
+                                    "navigate",
+                                    "openModal"
+                                  ],
+                                  "description": "Action type identifier. Supported values: \"navigate\" (navigates to a page using the inTandem JS SDK navigate function, see the [navigate documentation](https://developers.intandem.tech/docs/navigate)), \"openModal\" (opens a modal dialog using the inTandem JS SDK, see the [openModal documentation](https://developers.intandem.tech/docs/openmodal))."
+                                },
+                                "payload": {
+                                  "type": "object",
+                                  "description": "Action-specific payload. For \"navigate\": must include 'type' and 'path' (required), and optionally 'new_tab'. For \"openModal\": must include the modal configuration (e.g., {\"modalName\": \"AppMarket\"}). See the inTandem JS SDK documentation for complete parameter specifications."
+                                }
+                              },
+                              "required": [
+                                "name",
+                                "payload"
+                              ]
+                            },
+                            "available_in_mobile": {
+                              "type": "boolean",
+                              "default": true,
+                              "description": "Whether this navigation item should appear in mobile app navigation. Set to false for desktop-only features (e.g., true, false)."
+                            },
+                            "favorite_in_mobile": {
+                              "type": "boolean",
+                              "default": false,
+                              "description": "Whether this item appears in the mobile favorites/quick-access section. Only applicable when available_in_mobile is true (e.g., true, false)."
+                            },
+                            "upsell_handling": {
+                              "type": "string",
+                              "nullable": true,
+                              "enum": [
+                                "hide",
+                                "show_upsell"
+                              ],
+                              "description": "Behavior when user lacks required modules/permissions. 'hide' removes the item completely, 'show_upsell' displays it with an upgrade prompt. Null means default behavior (hide)."
+                            },
+                            "role": {
+                              "type": "string",
+                              "nullable": true,
+                              "enum": [
+                                "settings"
+                              ],
+                              "description": "Semantic role of the navigation item that can trigger special behavior, e.g. \"settings\" causes a settings cog icon to be displayed in the full menu screen. Null means no special role (e.g., \"settings\" or null)."
+                            },
+                            "app_code_name": {
+                              "type": "string",
+                              "nullable": true,
+                              "maxLength": 255,
+                              "description": "App code name to gate this item by app availability. When set, the item is only visible to staff who have the corresponding app assigned. Must match an existing app's app_code_name. Null means the item is not gated by app availability (e.g., \"myapp\" or null)."
+                            },
+                            "is_bmp": {
+                              "type": "boolean",
+                              "default": false,
+                              "description": "Indicates if this is a Business Management Platform (BMP) sub-menu item. When set to true, BMP children are built by inTandem internal logic. Available for **Directory tokens** via create and update operations (e.g., true, false)."
+                            },
+                            "created_by": {
+                              "type": "string",
+                              "nullable": true,
+                              "readOnly": true,
+                              "enum": [
+                                "vcita",
+                                "app",
+                                "directory",
+                                null
+                              ],
+                              "description": "Indicates who created this navigation item. Supported values are: \"vcita\" (created by vcita system), \"app\" (created by an application or integration), \"directory\" (created by the directory owner). Null means unknown or legacy value."
+                            },
+                            "updated_by": {
+                              "type": "string",
+                              "nullable": true,
+                              "readOnly": true,
+                              "enum": [
+                                "vcita",
+                                "app",
+                                "directory",
+                                null
+                              ],
+                              "description": "Indicates who last updated this navigation item. Supported values are: \"vcita\" (updated by vcita system), \"app\" (updated by an application or integration), \"directory\" (updated by the directory owner). Null means unknown or legacy value."
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "readOnly": true,
+                              "description": "The date and time when the navigation item was created, in ISO 8601 format (e.g., \"2026-01-15T10:30:00Z\")."
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "readOnly": true,
+                              "description": "The date and time when the navigation item was last updated, in ISO 8601 format (e.g., \"2026-01-15T14:45:00Z\")."
+                            }
+                          },
+                          "required": [
+                            "order",
+                            "title",
+                            "key",
+                            "action"
+                          ],
+                          "example": {
+                            "uid": "nav-item-abc123",
+                            "parent_uid": null,
+                            "directory_uid": "dir-xyz789",
+                            "order": 1,
+                            "title": {
+                              "en": "Dashboard",
+                              "he": "לוח בקרה"
+                            },
+                            "icon": "icon-Dashboard_POV",
+                            "key": "dashboard",
+                            "modules": null,
+                            "permissions": null,
+                            "badge_code": null,
+                            "action": {
+                              "name": "navigate",
+                              "payload": {
+                                "type": "relative",
+                                "path": "/app/dashboard",
+                                "new_tab": false
+                              }
+                            },
+                            "available_in_mobile": true,
+                            "favorite_in_mobile": true,
+                            "upsell_handling": null,
+                            "role": "settings",
+                            "app_code_name": null,
+                            "is_bmp": false,
+                            "created_by": "directory",
+                            "updated_by": "directory",
+                            "created_at": "2026-01-15T10:30:00Z",
+                            "updated_at": "2026-01-15T10:30:00Z"
+                          }
                         }
                       }
                     }
@@ -3209,13 +5713,289 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "type": "object",
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/apps/navigation_item.json"
+                          "type": "object",
+                          "description": "Represents a navigation menu item that defines how partners configure their platform navigation structure. Navigation items support hierarchical menus, localized titles, permission-based visibility, and mobile-specific settings.",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "readOnly": true,
+                              "description": "Unique identifier for the navigation item (e.g., \"nav-item-abc123\")."
+                            },
+                            "parent_uid": {
+                              "type": "string",
+                              "nullable": true,
+                              "description": "The UID of the parent navigation item. Set to null only for the root item, which represents the logo. Only one root item should exist per directory (e.g., \"nav-item-parent123\" or null)."
+                            },
+                            "directory_uid": {
+                              "type": "string",
+                              "readOnly": true,
+                              "description": "Unique identifier of the directory (partner) that owns this navigation item. Automatically set from the authenticated token context (e.g., \"dir-abc123\")."
+                            },
+                            "order": {
+                              "type": "integer",
+                              "minimum": 0,
+                              "default": 0,
+                              "description": "Display order within the parent level. Lower numbers appear first. Items with the same order are sorted by creation time (e.g., 0, 1, 2)."
+                            },
+                            "title": {
+                              "type": "object",
+                              "description": "Localized titles for the navigation item. Must include at least the 'en' (English) locale.",
+                              "propertyNames": {
+                                "type": "string",
+                                "enum": [
+                                  "de",
+                                  "en",
+                                  "es",
+                                  "fr",
+                                  "he",
+                                  "it",
+                                  "pl",
+                                  "pt",
+                                  "ru",
+                                  "sl",
+                                  "tr"
+                                ]
+                              },
+                              "properties": {
+                                "en": {
+                                  "type": "string",
+                                  "description": "English title (required)."
+                                },
+                                "he": {
+                                  "type": "string",
+                                  "description": "Hebrew title (optional)."
+                                }
+                              },
+                              "required": [
+                                "en"
+                              ],
+                              "additionalProperties": {
+                                "type": "string",
+                                "description": "Additional locale titles (e.g., \"es\", \"fr\", \"de\")."
+                              }
+                            },
+                            "icon": {
+                              "type": "string",
+                              "nullable": true,
+                              "maxLength": 255,
+                              "description": "Icon identifier from the platform icon library. For a list of supported icon identifiers, refer to the inTandem UI icon library used by the platform (e.g., \"icon-Dashboard_POV\", \"icon-Settings\")."
+                            },
+                            "key": {
+                              "type": "string",
+                              "maxLength": 255,
+                              "description": "Human-readable unique identifier within the directory. Used by API consumers for programmatic access. Must be stable across title/translation changes (e.g., \"dashboard\", \"settings\", \"custom_module\")."
+                            },
+                            "modules": {
+                              "type": "array",
+                              "nullable": true,
+                              "uniqueItems": true,
+                              "items": {
+                                "type": "string"
+                              },
+                              "description": "Array of module identifiers required for this item to be visible. Item is shown only if the business has at least one of these modules enabled. The list of enabled modules can be retrieved from the features endpoint (e.g., \"https://developers.intandem.tech/reference/get_platform-v1-businesses-business-id-features\"). (e.g., [\"scheduling\", \"payments\"])."
+                            },
+                            "permissions": {
+                              "type": "array",
+                              "nullable": true,
+                              "uniqueItems": true,
+                              "items": {
+                                "type": "string"
+                              },
+                              "description": "Array of permission identifiers required to view this item. Item is shown only if the staff member has at least one of these permissions. To retrieve valid permission codes, use the endpoint (GET \"/v3/access_control/permissions\"). (e.g., [\"payments.invoices.export\", \"clients.manage\"])."
+                            },
+                            "badge_code": {
+                              "type": "string",
+                              "nullable": true,
+                              "enum": [
+                                "inbox_unread"
+                              ],
+                              "description": "Badge code that displays a notification indicator on this navigation item. Supported values are finite and managed by the platform (e.g., \"inbox_unread\" or null)."
+                            },
+                            "action": {
+                              "type": "object",
+                              "description": "Action configuration that defines the behavior when the navigation item is clicked. Actions are handled by the inTandem JS SDK. Every navigation item must have an action. Supported action types: \"navigate\" (navigates to a page) and \"openModal\" (opens a modal dialog).",
+                              "properties": {
+                                "name": {
+                                  "type": "string",
+                                  "enum": [
+                                    "navigate",
+                                    "openModal"
+                                  ],
+                                  "description": "Action type identifier. Supported values: \"navigate\" (navigates to a page using the inTandem JS SDK navigate function, see the [navigate documentation](https://developers.intandem.tech/docs/navigate)), \"openModal\" (opens a modal dialog using the inTandem JS SDK, see the [openModal documentation](https://developers.intandem.tech/docs/openmodal))."
+                                },
+                                "payload": {
+                                  "type": "object",
+                                  "description": "Action-specific payload. For \"navigate\": must include 'type' and 'path' (required), and optionally 'new_tab'. For \"openModal\": must include the modal configuration (e.g., {\"modalName\": \"AppMarket\"}). See the inTandem JS SDK documentation for complete parameter specifications."
+                                }
+                              },
+                              "required": [
+                                "name",
+                                "payload"
+                              ]
+                            },
+                            "available_in_mobile": {
+                              "type": "boolean",
+                              "default": true,
+                              "description": "Whether this navigation item should appear in mobile app navigation. Set to false for desktop-only features (e.g., true, false)."
+                            },
+                            "favorite_in_mobile": {
+                              "type": "boolean",
+                              "default": false,
+                              "description": "Whether this item appears in the mobile favorites/quick-access section. Only applicable when available_in_mobile is true (e.g., true, false)."
+                            },
+                            "upsell_handling": {
+                              "type": "string",
+                              "nullable": true,
+                              "enum": [
+                                "hide",
+                                "show_upsell"
+                              ],
+                              "description": "Behavior when user lacks required modules/permissions. 'hide' removes the item completely, 'show_upsell' displays it with an upgrade prompt. Null means default behavior (hide)."
+                            },
+                            "role": {
+                              "type": "string",
+                              "nullable": true,
+                              "enum": [
+                                "settings"
+                              ],
+                              "description": "Semantic role of the navigation item that can trigger special behavior, e.g. \"settings\" causes a settings cog icon to be displayed in the full menu screen. Null means no special role (e.g., \"settings\" or null)."
+                            },
+                            "app_code_name": {
+                              "type": "string",
+                              "nullable": true,
+                              "maxLength": 255,
+                              "description": "App code name to gate this item by app availability. When set, the item is only visible to staff who have the corresponding app assigned. Must match an existing app's app_code_name. Null means the item is not gated by app availability (e.g., \"myapp\" or null)."
+                            },
+                            "is_bmp": {
+                              "type": "boolean",
+                              "default": false,
+                              "description": "Indicates if this is a Business Management Platform (BMP) sub-menu item. When set to true, BMP children are built by inTandem internal logic. Available for **Directory tokens** via create and update operations (e.g., true, false)."
+                            },
+                            "created_by": {
+                              "type": "string",
+                              "nullable": true,
+                              "readOnly": true,
+                              "enum": [
+                                "vcita",
+                                "app",
+                                "directory",
+                                null
+                              ],
+                              "description": "Indicates who created this navigation item. Supported values are: \"vcita\" (created by vcita system), \"app\" (created by an application or integration), \"directory\" (created by the directory owner). Null means unknown or legacy value."
+                            },
+                            "updated_by": {
+                              "type": "string",
+                              "nullable": true,
+                              "readOnly": true,
+                              "enum": [
+                                "vcita",
+                                "app",
+                                "directory",
+                                null
+                              ],
+                              "description": "Indicates who last updated this navigation item. Supported values are: \"vcita\" (updated by vcita system), \"app\" (updated by an application or integration), \"directory\" (updated by the directory owner). Null means unknown or legacy value."
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "readOnly": true,
+                              "description": "The date and time when the navigation item was created, in ISO 8601 format (e.g., \"2026-01-15T10:30:00Z\")."
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "readOnly": true,
+                              "description": "The date and time when the navigation item was last updated, in ISO 8601 format (e.g., \"2026-01-15T14:45:00Z\")."
+                            }
+                          },
+                          "required": [
+                            "order",
+                            "title",
+                            "key",
+                            "action"
+                          ],
+                          "example": {
+                            "uid": "nav-item-abc123",
+                            "parent_uid": null,
+                            "directory_uid": "dir-xyz789",
+                            "order": 1,
+                            "title": {
+                              "en": "Dashboard",
+                              "he": "לוח בקרה"
+                            },
+                            "icon": "icon-Dashboard_POV",
+                            "key": "dashboard",
+                            "modules": null,
+                            "permissions": null,
+                            "badge_code": null,
+                            "action": {
+                              "name": "navigate",
+                              "payload": {
+                                "type": "relative",
+                                "path": "/app/dashboard",
+                                "new_tab": false
+                              }
+                            },
+                            "available_in_mobile": true,
+                            "favorite_in_mobile": true,
+                            "upsell_handling": null,
+                            "role": "settings",
+                            "app_code_name": null,
+                            "is_bmp": false,
+                            "created_by": "directory",
+                            "updated_by": "directory",
+                            "created_at": "2026-01-15T10:30:00Z",
+                            "updated_at": "2026-01-15T10:30:00Z"
+                          }
                         }
                       }
                     }
@@ -3592,7 +6372,107 @@
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/apps/widget.json"
+                          "type": "object",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "description": "Unique identifier of the dashboardWidget object"
+                            },
+                            "app_code_name": {
+                              "type": "string",
+                              "description": "The code name of the app that owns the widget"
+                            },
+                            "display_name": {
+                              "type": "object",
+                              "description": "The widget display name in different languages"
+                            },
+                            "permissions": {
+                              "type": "array",
+                              "description": "The permissions required for the widget to show up for a staff member. If it is **null**, no restrictions will be enforced"
+                            },
+                            "module": {
+                              "type": "string",
+                              "description": "The module (FF) requeired for the widget to show up for a staff member"
+                            },
+                            "component_data": {
+                              "type": "object",
+                              "description": "a configuration object that is passed to the widget to initialize it. Can vary based on the widget class"
+                            },
+                            "dimensions": {
+                              "type": "object",
+                              "description": "The dimensions of the widget in grid units",
+                              "properties": {
+                                "min_width": {
+                                  "type": "integer",
+                                  "description": "the minimum width of the widget in grid units"
+                                },
+                                "min_height": {
+                                  "type": "integer",
+                                  "description": "the minimum height of the widget in grid units"
+                                },
+                                "height": {
+                                  "type": "integer",
+                                  "description": "the default height of the widget"
+                                },
+                                "width": {
+                                  "type": "integer",
+                                  "description": "the default width of the widget"
+                                },
+                                "max_width": {
+                                  "type": "integer",
+                                  "description": "the maximum width of the widget in grid units"
+                                },
+                                "max_height": {
+                                  "type": "integer",
+                                  "description": "the maximum height of the widget in grid units"
+                                }
+                              },
+                              "required": [
+                                "min_width",
+                                "min_height",
+                                "max_width",
+                                "max_height"
+                              ]
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "description": "The time the staffWidgetsBoard was created"
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "description": "The time the staffWidgetsBoard was last updated"
+                            }
+                          },
+                          "description": "A widget that can be added to the dashboard to display information or functionality",
+                          "example": {
+                            "uid": "d290f1ee-6c54-4b01-90e6-d701748f0851",
+                            "app_code_name": "myappcode",
+                            "display_name": {
+                              "en": "Payments",
+                              "fr": "Paiements"
+                            },
+                            "permissions": [
+                              "payments_edit",
+                              "payments_read"
+                            ],
+                            "module": "Payment",
+                            "dimensions": {
+                              "max_height": 2,
+                              "min_height": 1,
+                              "height": 2,
+                              "max_width": 3,
+                              "min_width": 1,
+                              "width": 2
+                            },
+                            "component_data": {
+                              "name": "iFrame",
+                              "config": {
+                                "url": "www.partnerdomain.com/calendar"
+                              }
+                            },
+                            "created_at": "2021-07-20T14:00:00.000Z",
+                            "updated_at": "2021-07-20T14:00:00.000Z"
+                          }
                         }
                       }
                     }
@@ -3744,7 +6624,107 @@
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/apps/widget.json"
+                          "type": "object",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "description": "Unique identifier of the dashboardWidget object"
+                            },
+                            "app_code_name": {
+                              "type": "string",
+                              "description": "The code name of the app that owns the widget"
+                            },
+                            "display_name": {
+                              "type": "object",
+                              "description": "The widget display name in different languages"
+                            },
+                            "permissions": {
+                              "type": "array",
+                              "description": "The permissions required for the widget to show up for a staff member. If it is **null**, no restrictions will be enforced"
+                            },
+                            "module": {
+                              "type": "string",
+                              "description": "The module (FF) requeired for the widget to show up for a staff member"
+                            },
+                            "component_data": {
+                              "type": "object",
+                              "description": "a configuration object that is passed to the widget to initialize it. Can vary based on the widget class"
+                            },
+                            "dimensions": {
+                              "type": "object",
+                              "description": "The dimensions of the widget in grid units",
+                              "properties": {
+                                "min_width": {
+                                  "type": "integer",
+                                  "description": "the minimum width of the widget in grid units"
+                                },
+                                "min_height": {
+                                  "type": "integer",
+                                  "description": "the minimum height of the widget in grid units"
+                                },
+                                "height": {
+                                  "type": "integer",
+                                  "description": "the default height of the widget"
+                                },
+                                "width": {
+                                  "type": "integer",
+                                  "description": "the default width of the widget"
+                                },
+                                "max_width": {
+                                  "type": "integer",
+                                  "description": "the maximum width of the widget in grid units"
+                                },
+                                "max_height": {
+                                  "type": "integer",
+                                  "description": "the maximum height of the widget in grid units"
+                                }
+                              },
+                              "required": [
+                                "min_width",
+                                "min_height",
+                                "max_width",
+                                "max_height"
+                              ]
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "description": "The time the staffWidgetsBoard was created"
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "description": "The time the staffWidgetsBoard was last updated"
+                            }
+                          },
+                          "description": "A widget that can be added to the dashboard to display information or functionality",
+                          "example": {
+                            "uid": "d290f1ee-6c54-4b01-90e6-d701748f0851",
+                            "app_code_name": "myappcode",
+                            "display_name": {
+                              "en": "Payments",
+                              "fr": "Paiements"
+                            },
+                            "permissions": [
+                              "payments_edit",
+                              "payments_read"
+                            ],
+                            "module": "Payment",
+                            "dimensions": {
+                              "max_height": 2,
+                              "min_height": 1,
+                              "height": 2,
+                              "max_width": 3,
+                              "min_width": 1,
+                              "width": 2
+                            },
+                            "component_data": {
+                              "name": "iFrame",
+                              "config": {
+                                "url": "www.partnerdomain.com/calendar"
+                              }
+                            },
+                            "created_at": "2021-07-20T14:00:00.000Z",
+                            "updated_at": "2021-07-20T14:00:00.000Z"
+                          }
                         }
                       }
                     }
@@ -3799,7 +6779,220 @@
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/apps/staffWidgetsBoard.json"
+                          "type": "object",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "description": "Unique identifier of the staffWidgetsBoard object"
+                            },
+                            "board_layout_code_name": {
+                              "type": "string",
+                              "description": "A string representing the board layout. Common values include 'MainAndSideBar2Columns', 'MainAndSideBar3Columns', etc."
+                            },
+                            "type": {
+                              "type": "string",
+                              "description": "The grid frame of the layout, determines the layout frame containing the board. Common values include 'home', 'dashboard', etc."
+                            },
+                            "sections": {
+                              "description": "An array of dashboard sections. Each section contains a set of properties defining it and a list of widgets that will be populated into the section once it is displayed",
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "code_name": {
+                                    "type": "string",
+                                    "description": "A code name representing the type of the section"
+                                  },
+                                  "widgets": {
+                                    "description": "An array of widgets which will be populated in the section",
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "uid": {
+                                          "type": "string",
+                                          "description": "Unique identifier of the dashboardWidget object"
+                                        },
+                                        "app_code_name": {
+                                          "type": "string",
+                                          "description": "The code name of the app that owns the widget"
+                                        },
+                                        "display_name": {
+                                          "type": "object",
+                                          "description": "The widget display name in different languages"
+                                        },
+                                        "permissions": {
+                                          "type": "array",
+                                          "description": "The permissions required for the widget to show up for a staff member. If it is **null**, no restrictions will be enforced"
+                                        },
+                                        "module": {
+                                          "type": "string",
+                                          "description": "The module (FF) requeired for the widget to show up for a staff member"
+                                        },
+                                        "component_data": {
+                                          "type": "object",
+                                          "description": "a configuration object that is passed to the widget to initialize it. Can vary based on the widget class"
+                                        },
+                                        "dimensions": {
+                                          "type": "object",
+                                          "description": "The dimensions of the widget in grid units",
+                                          "properties": {
+                                            "min_width": {
+                                              "type": "integer",
+                                              "description": "the minimum width of the widget in grid units"
+                                            },
+                                            "min_height": {
+                                              "type": "integer",
+                                              "description": "the minimum height of the widget in grid units"
+                                            },
+                                            "height": {
+                                              "type": "integer",
+                                              "description": "the default height of the widget"
+                                            },
+                                            "width": {
+                                              "type": "integer",
+                                              "description": "the default width of the widget"
+                                            },
+                                            "max_width": {
+                                              "type": "integer",
+                                              "description": "the maximum width of the widget in grid units"
+                                            },
+                                            "max_height": {
+                                              "type": "integer",
+                                              "description": "the maximum height of the widget in grid units"
+                                            }
+                                          },
+                                          "required": [
+                                            "min_width",
+                                            "min_height",
+                                            "max_width",
+                                            "max_height"
+                                          ]
+                                        },
+                                        "created_at": {
+                                          "type": "string",
+                                          "description": "The time the staffWidgetsBoard was created"
+                                        },
+                                        "updated_at": {
+                                          "type": "string",
+                                          "description": "The time the staffWidgetsBoard was last updated"
+                                        }
+                                      },
+                                      "description": "A widget that can be added to the dashboard to display information or functionality",
+                                      "example": {
+                                        "uid": "d290f1ee-6c54-4b01-90e6-d701748f0851",
+                                        "app_code_name": "myappcode",
+                                        "display_name": {
+                                          "en": "Payments",
+                                          "fr": "Paiements"
+                                        },
+                                        "permissions": [
+                                          "payments_edit",
+                                          "payments_read"
+                                        ],
+                                        "module": "Payment",
+                                        "dimensions": {
+                                          "max_height": 2,
+                                          "min_height": 1,
+                                          "height": 2,
+                                          "max_width": 3,
+                                          "min_width": 1,
+                                          "width": 2
+                                        },
+                                        "component_data": {
+                                          "name": "iFrame",
+                                          "config": {
+                                            "url": "www.partnerdomain.com/calendar"
+                                          }
+                                        },
+                                        "created_at": "2021-07-20T14:00:00.000Z",
+                                        "updated_at": "2021-07-20T14:00:00.000Z"
+                                      }
+                                    }
+                                  },
+                                  "created_at": {
+                                    "type": "string",
+                                    "format": "date-time",
+                                    "description": "The time the section was created"
+                                  },
+                                  "updated_at": {
+                                    "type": "string",
+                                    "format": "date-time",
+                                    "description": "The time the section was last updated"
+                                  }
+                                }
+                              }
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "description": "The time the staffWidgetsBoard was created"
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "description": "The time the staffWidgetsBoard was last updated"
+                            }
+                          },
+                          "example": {
+                            "uid": "d290f1ee-6c54-4b01-90e6-d701748f0851",
+                            "board_layout": "MainAndSideBar3Columns",
+                            "type": "dashboard",
+                            "sections": [
+                              {
+                                "code_name": "Main",
+                                "widgets": [
+                                  {
+                                    "uid": "d290f1ee-6c54-4b01-90e6-d701748f0851",
+                                    "app_code_name": "myappcode",
+                                    "display_name": {
+                                      "en": "Payments",
+                                      "fr": "Paiements"
+                                    },
+                                    "dimensions": {
+                                      "max_height": 2,
+                                      "min_height": 1,
+                                      "height": 2,
+                                      "max_width": 3,
+                                      "min_width": 1,
+                                      "width": 2
+                                    },
+                                    "component_data": {
+                                      "name": "iFrame",
+                                      "config": {
+                                        "title": "calendar",
+                                        "url": "www.partnerdomain.com/calendar"
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "uid": "d290f1ee-6c54-4b01-90e6-d701748f03434",
+                                    "app_code_name": "myappcode2",
+                                    "display_name": {
+                                      "en": "Clients",
+                                      "fr": "Clientèle"
+                                    },
+                                    "dimensions": {
+                                      "max_height": 3,
+                                      "min_height": 2,
+                                      "height": 3,
+                                      "max_width": 4,
+                                      "min_width": 1,
+                                      "width": 3
+                                    },
+                                    "component_data": {
+                                      "name": "iFrame",
+                                      "config": {
+                                        "title": "clients",
+                                        "url": "www.partnerdomain.com/clients"
+                                      }
+                                    }
+                                  }
+                                ]
+                              }
+                            ],
+                            "created_at": "2021-06-20T14:00:00.000Z",
+                            "updated_at": "2021-07-15T14:00:00.000Z"
+                          },
+                          "description": "Defines a staff member's dashboard board layout and its widget sections."
                         }
                       }
                     }
@@ -3951,7 +7144,220 @@
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/apps/staffWidgetsBoard.json"
+                          "type": "object",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "description": "Unique identifier of the staffWidgetsBoard object"
+                            },
+                            "board_layout_code_name": {
+                              "type": "string",
+                              "description": "A string representing the board layout. Common values include 'MainAndSideBar2Columns', 'MainAndSideBar3Columns', etc."
+                            },
+                            "type": {
+                              "type": "string",
+                              "description": "The grid frame of the layout, determines the layout frame containing the board. Common values include 'home', 'dashboard', etc."
+                            },
+                            "sections": {
+                              "description": "An array of dashboard sections. Each section contains a set of properties defining it and a list of widgets that will be populated into the section once it is displayed",
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "code_name": {
+                                    "type": "string",
+                                    "description": "A code name representing the type of the section"
+                                  },
+                                  "widgets": {
+                                    "description": "An array of widgets which will be populated in the section",
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "uid": {
+                                          "type": "string",
+                                          "description": "Unique identifier of the dashboardWidget object"
+                                        },
+                                        "app_code_name": {
+                                          "type": "string",
+                                          "description": "The code name of the app that owns the widget"
+                                        },
+                                        "display_name": {
+                                          "type": "object",
+                                          "description": "The widget display name in different languages"
+                                        },
+                                        "permissions": {
+                                          "type": "array",
+                                          "description": "The permissions required for the widget to show up for a staff member. If it is **null**, no restrictions will be enforced"
+                                        },
+                                        "module": {
+                                          "type": "string",
+                                          "description": "The module (FF) requeired for the widget to show up for a staff member"
+                                        },
+                                        "component_data": {
+                                          "type": "object",
+                                          "description": "a configuration object that is passed to the widget to initialize it. Can vary based on the widget class"
+                                        },
+                                        "dimensions": {
+                                          "type": "object",
+                                          "description": "The dimensions of the widget in grid units",
+                                          "properties": {
+                                            "min_width": {
+                                              "type": "integer",
+                                              "description": "the minimum width of the widget in grid units"
+                                            },
+                                            "min_height": {
+                                              "type": "integer",
+                                              "description": "the minimum height of the widget in grid units"
+                                            },
+                                            "height": {
+                                              "type": "integer",
+                                              "description": "the default height of the widget"
+                                            },
+                                            "width": {
+                                              "type": "integer",
+                                              "description": "the default width of the widget"
+                                            },
+                                            "max_width": {
+                                              "type": "integer",
+                                              "description": "the maximum width of the widget in grid units"
+                                            },
+                                            "max_height": {
+                                              "type": "integer",
+                                              "description": "the maximum height of the widget in grid units"
+                                            }
+                                          },
+                                          "required": [
+                                            "min_width",
+                                            "min_height",
+                                            "max_width",
+                                            "max_height"
+                                          ]
+                                        },
+                                        "created_at": {
+                                          "type": "string",
+                                          "description": "The time the staffWidgetsBoard was created"
+                                        },
+                                        "updated_at": {
+                                          "type": "string",
+                                          "description": "The time the staffWidgetsBoard was last updated"
+                                        }
+                                      },
+                                      "description": "A widget that can be added to the dashboard to display information or functionality",
+                                      "example": {
+                                        "uid": "d290f1ee-6c54-4b01-90e6-d701748f0851",
+                                        "app_code_name": "myappcode",
+                                        "display_name": {
+                                          "en": "Payments",
+                                          "fr": "Paiements"
+                                        },
+                                        "permissions": [
+                                          "payments_edit",
+                                          "payments_read"
+                                        ],
+                                        "module": "Payment",
+                                        "dimensions": {
+                                          "max_height": 2,
+                                          "min_height": 1,
+                                          "height": 2,
+                                          "max_width": 3,
+                                          "min_width": 1,
+                                          "width": 2
+                                        },
+                                        "component_data": {
+                                          "name": "iFrame",
+                                          "config": {
+                                            "url": "www.partnerdomain.com/calendar"
+                                          }
+                                        },
+                                        "created_at": "2021-07-20T14:00:00.000Z",
+                                        "updated_at": "2021-07-20T14:00:00.000Z"
+                                      }
+                                    }
+                                  },
+                                  "created_at": {
+                                    "type": "string",
+                                    "format": "date-time",
+                                    "description": "The time the section was created"
+                                  },
+                                  "updated_at": {
+                                    "type": "string",
+                                    "format": "date-time",
+                                    "description": "The time the section was last updated"
+                                  }
+                                }
+                              }
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "description": "The time the staffWidgetsBoard was created"
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "description": "The time the staffWidgetsBoard was last updated"
+                            }
+                          },
+                          "example": {
+                            "uid": "d290f1ee-6c54-4b01-90e6-d701748f0851",
+                            "board_layout": "MainAndSideBar3Columns",
+                            "type": "dashboard",
+                            "sections": [
+                              {
+                                "code_name": "Main",
+                                "widgets": [
+                                  {
+                                    "uid": "d290f1ee-6c54-4b01-90e6-d701748f0851",
+                                    "app_code_name": "myappcode",
+                                    "display_name": {
+                                      "en": "Payments",
+                                      "fr": "Paiements"
+                                    },
+                                    "dimensions": {
+                                      "max_height": 2,
+                                      "min_height": 1,
+                                      "height": 2,
+                                      "max_width": 3,
+                                      "min_width": 1,
+                                      "width": 2
+                                    },
+                                    "component_data": {
+                                      "name": "iFrame",
+                                      "config": {
+                                        "title": "calendar",
+                                        "url": "www.partnerdomain.com/calendar"
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "uid": "d290f1ee-6c54-4b01-90e6-d701748f03434",
+                                    "app_code_name": "myappcode2",
+                                    "display_name": {
+                                      "en": "Clients",
+                                      "fr": "Clientèle"
+                                    },
+                                    "dimensions": {
+                                      "max_height": 3,
+                                      "min_height": 2,
+                                      "height": 3,
+                                      "max_width": 4,
+                                      "min_width": 1,
+                                      "width": 3
+                                    },
+                                    "component_data": {
+                                      "name": "iFrame",
+                                      "config": {
+                                        "title": "clients",
+                                        "url": "www.partnerdomain.com/clients"
+                                      }
+                                    }
+                                  }
+                                ]
+                              }
+                            ],
+                            "created_at": "2021-06-20T14:00:00.000Z",
+                            "updated_at": "2021-07-15T14:00:00.000Z"
+                          },
+                          "description": "Defines a staff member's dashboard board layout and its widget sections."
                         }
                       }
                     }
@@ -4012,7 +7418,46 @@
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/apps/staffWidgetsBoardsTemplate.json"
+                          "type": "object",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "description": "Unique identifier of the entity"
+                            },
+                            "owner_type": {
+                              "type": "string",
+                              "description": "The type of template owner, e.g directory, business, etc.",
+                              "enum": [
+                                "directory",
+                                "business"
+                              ]
+                            },
+                            "owner_uid": {
+                              "type": "string",
+                              "description": "The unique identifier of the template's owner"
+                            },
+                            "staff_uid": {
+                              "type": "string",
+                              "description": "The unique identifier of the staff member whose template is being cloned"
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "description": "The timestamp indicating when the template was created, in ISO 8601 format"
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "description": "The timestamp indicating the last time the template was updated, in ISO 8601 format"
+                            }
+                          },
+                          "description": "Defines the default widget board template for all members within a directory",
+                          "example": {
+                            "uid": "d290f1ee-6c54-4b01-90e6-d701748f0851",
+                            "owner_type": "directory",
+                            "owner_uid": "d290f1ee-6c54-4b01-90e6-d701748f0851",
+                            "staff_uid": "d290f1ee-6c54-4b01-90e6-d701748f0851",
+                            "created_at": "2021-07-20T14:00:00.000Z",
+                            "updated_at": "2021-07-20T14:00:00.000Z"
+                          }
                         }
                       }
                     }
@@ -4181,7 +7626,46 @@
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/apps/staffWidgetsBoardsTemplate.json"
+                          "type": "object",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "description": "Unique identifier of the entity"
+                            },
+                            "owner_type": {
+                              "type": "string",
+                              "description": "The type of template owner, e.g directory, business, etc.",
+                              "enum": [
+                                "directory",
+                                "business"
+                              ]
+                            },
+                            "owner_uid": {
+                              "type": "string",
+                              "description": "The unique identifier of the template's owner"
+                            },
+                            "staff_uid": {
+                              "type": "string",
+                              "description": "The unique identifier of the staff member whose template is being cloned"
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "description": "The timestamp indicating when the template was created, in ISO 8601 format"
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "description": "The timestamp indicating the last time the template was updated, in ISO 8601 format"
+                            }
+                          },
+                          "description": "Defines the default widget board template for all members within a directory",
+                          "example": {
+                            "uid": "d290f1ee-6c54-4b01-90e6-d701748f0851",
+                            "owner_type": "directory",
+                            "owner_uid": "d290f1ee-6c54-4b01-90e6-d701748f0851",
+                            "staff_uid": "d290f1ee-6c54-4b01-90e6-d701748f0851",
+                            "created_at": "2021-07-20T14:00:00.000Z",
+                            "updated_at": "2021-07-20T14:00:00.000Z"
+                          }
                         }
                       }
                     }
@@ -4233,7 +7717,46 @@
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/apps/staffWidgetsBoardsTemplate.json"
+                          "type": "object",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "description": "Unique identifier of the entity"
+                            },
+                            "owner_type": {
+                              "type": "string",
+                              "description": "The type of template owner, e.g directory, business, etc.",
+                              "enum": [
+                                "directory",
+                                "business"
+                              ]
+                            },
+                            "owner_uid": {
+                              "type": "string",
+                              "description": "The unique identifier of the template's owner"
+                            },
+                            "staff_uid": {
+                              "type": "string",
+                              "description": "The unique identifier of the staff member whose template is being cloned"
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "description": "The timestamp indicating when the template was created, in ISO 8601 format"
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "description": "The timestamp indicating the last time the template was updated, in ISO 8601 format"
+                            }
+                          },
+                          "description": "Defines the default widget board template for all members within a directory",
+                          "example": {
+                            "uid": "d290f1ee-6c54-4b01-90e6-d701748f0851",
+                            "owner_type": "directory",
+                            "owner_uid": "d290f1ee-6c54-4b01-90e6-d701748f0851",
+                            "staff_uid": "d290f1ee-6c54-4b01-90e6-d701748f0851",
+                            "created_at": "2021-07-20T14:00:00.000Z",
+                            "updated_at": "2021-07-20T14:00:00.000Z"
+                          }
                         }
                       }
                     }
@@ -4504,12 +8027,81 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/apps/compactJWSToken.json"
+                          "type": "object",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "description": "Unique identifier of the compactJWSToken object"
+                            },
+                            "token": {
+                              "type": "string",
+                              "description": "The JWS token that is used to authenticate the staff member to the app. The token is signed by the app's private key and can be verified by the app's public key it contains information about the staff member, the actor generating the token and the app"
+                            },
+                            "expiry_date": {
+                              "type": "string",
+                              "description": "The date and time the token will expire",
+                              "format": "date-time"
+                            },
+                            "app_code_name": {
+                              "type": "string",
+                              "description": "The code name of the app that the token is generated for"
+                            }
+                          },
+                          "description": "A compact JWS token object that is used to authenticate a staff member to an inTandem app using a JWKS process. The token is signed by the app's private key and can be verified by the inTandem platform's public key",
+                          "example": {
+                            "uid": "eyJ0eXAiOiJKV1QiLA0KIC",
+                            "token": "eyJ0eXAiOiJKV1QiLA0KICJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFtcGxlLmNvbS9pc19yb290Ijp0cnVlfQ.dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk",
+                            "expiry_date": "2021-07-20T14:00:00.000Z",
+                            "app_code_name": "quickbooks"
+                          }
                         }
                       }
                     }
@@ -4591,8 +8183,33 @@
                                 "description": "Status of the creation for the entity. Possible values: true (success), false (error)."
                               },
                               "data": {
+                                "type": "object",
+                                "properties": {
+                                  "uid": {
+                                    "type": "string",
+                                    "description": "Unique identifier of the compactJWSToken object"
+                                  },
+                                  "token": {
+                                    "type": "string",
+                                    "description": "The JWS token that is used to authenticate the staff member to the app. The token is signed by the app's private key and can be verified by the app's public key it contains information about the staff member, the actor generating the token and the app"
+                                  },
+                                  "expiry_date": {
+                                    "type": "string",
+                                    "description": "The date and time the token will expire",
+                                    "format": "date-time"
+                                  },
+                                  "app_code_name": {
+                                    "type": "string",
+                                    "description": "The code name of the app that the token is generated for"
+                                  }
+                                },
                                 "description": "The generated JWS token or null if failed",
-                                "$ref": "https://vcita.github.io/developers-hub/entities/apps/compactJWSToken.json"
+                                "example": {
+                                  "uid": "eyJ0eXAiOiJKV1QiLA0KIC",
+                                  "token": "eyJ0eXAiOiJKV1QiLA0KICJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFtcGxlLmNvbS9pc19yb290Ijp0cnVlfQ.dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk",
+                                  "expiry_date": "2021-07-20T14:00:00.000Z",
+                                  "app_code_name": "quickbooks"
+                                }
                               },
                               "error": {
                                 "type": "string",
@@ -5328,7 +8945,107 @@
           "widgets": {
             "type": "array",
             "items": {
-              "$ref": "https://vcita.github.io/developers-hub/entities/apps/widget.json"
+              "type": "object",
+              "properties": {
+                "uid": {
+                  "type": "string",
+                  "description": "Unique identifier of the dashboardWidget object"
+                },
+                "app_code_name": {
+                  "type": "string",
+                  "description": "The code name of the app that owns the widget"
+                },
+                "display_name": {
+                  "type": "object",
+                  "description": "The widget display name in different languages"
+                },
+                "permissions": {
+                  "type": "array",
+                  "description": "The permissions required for the widget to show up for a staff member. If it is **null**, no restrictions will be enforced"
+                },
+                "module": {
+                  "type": "string",
+                  "description": "The module (FF) requeired for the widget to show up for a staff member"
+                },
+                "component_data": {
+                  "type": "object",
+                  "description": "a configuration object that is passed to the widget to initialize it. Can vary based on the widget class"
+                },
+                "dimensions": {
+                  "type": "object",
+                  "description": "The dimensions of the widget in grid units",
+                  "properties": {
+                    "min_width": {
+                      "type": "integer",
+                      "description": "the minimum width of the widget in grid units"
+                    },
+                    "min_height": {
+                      "type": "integer",
+                      "description": "the minimum height of the widget in grid units"
+                    },
+                    "height": {
+                      "type": "integer",
+                      "description": "the default height of the widget"
+                    },
+                    "width": {
+                      "type": "integer",
+                      "description": "the default width of the widget"
+                    },
+                    "max_width": {
+                      "type": "integer",
+                      "description": "the maximum width of the widget in grid units"
+                    },
+                    "max_height": {
+                      "type": "integer",
+                      "description": "the maximum height of the widget in grid units"
+                    }
+                  },
+                  "required": [
+                    "min_width",
+                    "min_height",
+                    "max_width",
+                    "max_height"
+                  ]
+                },
+                "created_at": {
+                  "type": "string",
+                  "description": "The time the staffWidgetsBoard was created"
+                },
+                "updated_at": {
+                  "type": "string",
+                  "description": "The time the staffWidgetsBoard was last updated"
+                }
+              },
+              "description": "A widget that can be added to the dashboard to display information or functionality",
+              "example": {
+                "uid": "d290f1ee-6c54-4b01-90e6-d701748f0851",
+                "app_code_name": "myappcode",
+                "display_name": {
+                  "en": "Payments",
+                  "fr": "Paiements"
+                },
+                "permissions": [
+                  "payments_edit",
+                  "payments_read"
+                ],
+                "module": "Payment",
+                "dimensions": {
+                  "max_height": 2,
+                  "min_height": 1,
+                  "height": 2,
+                  "max_width": 3,
+                  "min_width": 1,
+                  "width": 2
+                },
+                "component_data": {
+                  "name": "iFrame",
+                  "config": {
+                    "url": "www.partnerdomain.com/calendar"
+                  }
+                },
+                "created_at": "2021-07-20T14:00:00.000Z",
+                "updated_at": "2021-07-20T14:00:00.000Z"
+              }
             }
           }
         },
@@ -5342,7 +9059,220 @@
           "staffWidgetsBoards": {
             "type": "array",
             "items": {
-              "$ref": "https://vcita.github.io/developers-hub/entities/apps/staffWidgetsBoard.json"
+              "type": "object",
+              "properties": {
+                "uid": {
+                  "type": "string",
+                  "description": "Unique identifier of the staffWidgetsBoard object"
+                },
+                "board_layout_code_name": {
+                  "type": "string",
+                  "description": "A string representing the board layout. Common values include 'MainAndSideBar2Columns', 'MainAndSideBar3Columns', etc."
+                },
+                "type": {
+                  "type": "string",
+                  "description": "The grid frame of the layout, determines the layout frame containing the board. Common values include 'home', 'dashboard', etc."
+                },
+                "sections": {
+                  "description": "An array of dashboard sections. Each section contains a set of properties defining it and a list of widgets that will be populated into the section once it is displayed",
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "code_name": {
+                        "type": "string",
+                        "description": "A code name representing the type of the section"
+                      },
+                      "widgets": {
+                        "description": "An array of widgets which will be populated in the section",
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "description": "Unique identifier of the dashboardWidget object"
+                            },
+                            "app_code_name": {
+                              "type": "string",
+                              "description": "The code name of the app that owns the widget"
+                            },
+                            "display_name": {
+                              "type": "object",
+                              "description": "The widget display name in different languages"
+                            },
+                            "permissions": {
+                              "type": "array",
+                              "description": "The permissions required for the widget to show up for a staff member. If it is **null**, no restrictions will be enforced"
+                            },
+                            "module": {
+                              "type": "string",
+                              "description": "The module (FF) requeired for the widget to show up for a staff member"
+                            },
+                            "component_data": {
+                              "type": "object",
+                              "description": "a configuration object that is passed to the widget to initialize it. Can vary based on the widget class"
+                            },
+                            "dimensions": {
+                              "type": "object",
+                              "description": "The dimensions of the widget in grid units",
+                              "properties": {
+                                "min_width": {
+                                  "type": "integer",
+                                  "description": "the minimum width of the widget in grid units"
+                                },
+                                "min_height": {
+                                  "type": "integer",
+                                  "description": "the minimum height of the widget in grid units"
+                                },
+                                "height": {
+                                  "type": "integer",
+                                  "description": "the default height of the widget"
+                                },
+                                "width": {
+                                  "type": "integer",
+                                  "description": "the default width of the widget"
+                                },
+                                "max_width": {
+                                  "type": "integer",
+                                  "description": "the maximum width of the widget in grid units"
+                                },
+                                "max_height": {
+                                  "type": "integer",
+                                  "description": "the maximum height of the widget in grid units"
+                                }
+                              },
+                              "required": [
+                                "min_width",
+                                "min_height",
+                                "max_width",
+                                "max_height"
+                              ]
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "description": "The time the staffWidgetsBoard was created"
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "description": "The time the staffWidgetsBoard was last updated"
+                            }
+                          },
+                          "description": "A widget that can be added to the dashboard to display information or functionality",
+                          "example": {
+                            "uid": "d290f1ee-6c54-4b01-90e6-d701748f0851",
+                            "app_code_name": "myappcode",
+                            "display_name": {
+                              "en": "Payments",
+                              "fr": "Paiements"
+                            },
+                            "permissions": [
+                              "payments_edit",
+                              "payments_read"
+                            ],
+                            "module": "Payment",
+                            "dimensions": {
+                              "max_height": 2,
+                              "min_height": 1,
+                              "height": 2,
+                              "max_width": 3,
+                              "min_width": 1,
+                              "width": 2
+                            },
+                            "component_data": {
+                              "name": "iFrame",
+                              "config": {
+                                "url": "www.partnerdomain.com/calendar"
+                              }
+                            },
+                            "created_at": "2021-07-20T14:00:00.000Z",
+                            "updated_at": "2021-07-20T14:00:00.000Z"
+                          }
+                        }
+                      },
+                      "created_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "The time the section was created"
+                      },
+                      "updated_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "The time the section was last updated"
+                      }
+                    }
+                  }
+                },
+                "created_at": {
+                  "type": "string",
+                  "description": "The time the staffWidgetsBoard was created"
+                },
+                "updated_at": {
+                  "type": "string",
+                  "description": "The time the staffWidgetsBoard was last updated"
+                }
+              },
+              "example": {
+                "uid": "d290f1ee-6c54-4b01-90e6-d701748f0851",
+                "board_layout": "MainAndSideBar3Columns",
+                "type": "dashboard",
+                "sections": [
+                  {
+                    "code_name": "Main",
+                    "widgets": [
+                      {
+                        "uid": "d290f1ee-6c54-4b01-90e6-d701748f0851",
+                        "app_code_name": "myappcode",
+                        "display_name": {
+                          "en": "Payments",
+                          "fr": "Paiements"
+                        },
+                        "dimensions": {
+                          "max_height": 2,
+                          "min_height": 1,
+                          "height": 2,
+                          "max_width": 3,
+                          "min_width": 1,
+                          "width": 2
+                        },
+                        "component_data": {
+                          "name": "iFrame",
+                          "config": {
+                            "title": "calendar",
+                            "url": "www.partnerdomain.com/calendar"
+                          }
+                        }
+                      },
+                      {
+                        "uid": "d290f1ee-6c54-4b01-90e6-d701748f03434",
+                        "app_code_name": "myappcode2",
+                        "display_name": {
+                          "en": "Clients",
+                          "fr": "Clientèle"
+                        },
+                        "dimensions": {
+                          "max_height": 3,
+                          "min_height": 2,
+                          "height": 3,
+                          "max_width": 4,
+                          "min_width": 1,
+                          "width": 3
+                        },
+                        "component_data": {
+                          "name": "iFrame",
+                          "config": {
+                            "title": "clients",
+                            "url": "www.partnerdomain.com/clients"
+                          }
+                        }
+                      }
+                    ]
+                  }
+                ],
+                "created_at": "2021-06-20T14:00:00.000Z",
+                "updated_at": "2021-07-15T14:00:00.000Z"
+              },
+              "description": "Defines a staff member's dashboard board layout and its widget sections."
             }
           }
         },
@@ -5356,7 +9286,46 @@
           "staff_widgets_boards_templates": {
             "type": "array",
             "items": {
-              "$ref": "https://vcita.github.io/developers-hub/entities/apps/staffWidgetsBoardsTemplate.json"
+              "type": "object",
+              "properties": {
+                "uid": {
+                  "type": "string",
+                  "description": "Unique identifier of the entity"
+                },
+                "owner_type": {
+                  "type": "string",
+                  "description": "The type of template owner, e.g directory, business, etc.",
+                  "enum": [
+                    "directory",
+                    "business"
+                  ]
+                },
+                "owner_uid": {
+                  "type": "string",
+                  "description": "The unique identifier of the template's owner"
+                },
+                "staff_uid": {
+                  "type": "string",
+                  "description": "The unique identifier of the staff member whose template is being cloned"
+                },
+                "created_at": {
+                  "type": "string",
+                  "description": "The timestamp indicating when the template was created, in ISO 8601 format"
+                },
+                "updated_at": {
+                  "type": "string",
+                  "description": "The timestamp indicating the last time the template was updated, in ISO 8601 format"
+                }
+              },
+              "description": "Defines the default widget board template for all members within a directory",
+              "example": {
+                "uid": "d290f1ee-6c54-4b01-90e6-d701748f0851",
+                "owner_type": "directory",
+                "owner_uid": "d290f1ee-6c54-4b01-90e6-d701748f0851",
+                "staff_uid": "d290f1ee-6c54-4b01-90e6-d701748f0851",
+                "created_at": "2021-07-20T14:00:00.000Z",
+                "updated_at": "2021-07-20T14:00:00.000Z"
+              }
             }
           }
         },

--- a/mcp_swagger/assets.json
+++ b/mcp_swagger/assets.json
@@ -6,13 +6,24 @@
     "version": "3.0",
     "x-generated": {
       "sourceFiles": [
+        "files.json",
         "legacy_documents.json"
       ],
       "pathNormalizations": [],
       "pathConflicts": [],
-      "componentConflicts": [],
-      "totalPaths": 7,
-      "totalComponents": 3
+      "componentConflicts": [
+        {
+          "type": "schema",
+          "name": "ErrorResponse",
+          "resolution": "Renamed to ErrorResponse_legacy_documents",
+          "files": [
+            "merged",
+            "legacy_documents.json"
+          ]
+        }
+      ],
+      "totalPaths": 10,
+      "totalComponents": 10
     }
   },
   "servers": [
@@ -22,6 +33,1477 @@
     }
   ],
   "paths": {
+    "/v3/assets/files": {
+      "post": {
+        "operationId": "FilesController_upload",
+        "summary": "Create a new file",
+        "description": "Create a new file for the specified business. The API returns immediately with status='pending'. File processing (virus scan, S3 upload, thumbnail generation) happens asynchronously in the background.\n\nIf a duplicate file is detected via SHA-256 content hash, the existing file is returned immediately with status='uploaded'.\n\nRate limit: 10 uploads per user per 10 minutes. Maximum file size: 100MB.\n\nAvailable for **Staff and Client tokens**.",
+        "tags": [
+          "Files"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/UploadFileRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Duplicate file detected - existing file returned immediately (no processing needed)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Response"
+                    },
+                    {
+                      "properties": {
+                        "data": {
+                          "type": "object",
+                          "description": "Represents a file uploaded to the platform. Files go through an asynchronous processing pipeline including virus scanning, S3 storage, and thumbnail generation. Content deduplication via SHA-256 fingerprinting ensures efficient storage within each business.",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "readOnly": true,
+                              "description": "Unique identifier for the file record (e.g., \"file_123\")."
+                            },
+                            "business_uid": {
+                              "type": "string",
+                              "readOnly": true,
+                              "description": "Unique identifier of the business that owns this file (e.g., \"biz_456\")."
+                            },
+                            "name": {
+                              "type": "string",
+                              "maxLength": 255,
+                              "description": "Original filename including extension (e.g., \"document.pdf\", \"photo.jpg\"). Maximum length is 255 characters."
+                            },
+                            "content_type": {
+                              "type": "string",
+                              "enum": [
+                                "image/jpeg",
+                                "image/png",
+                                "image/gif",
+                                "image/webp",
+                                "image/svg+xml",
+                                "application/pdf",
+                                "application/msword",
+                                "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                                "application/vnd.ms-excel",
+                                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                                "application/vnd.ms-powerpoint",
+                                "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+                                "text/plain",
+                                "text/csv",
+                                "video/mp4",
+                                "video/webm",
+                                "audio/mpeg",
+                                "audio/wav",
+                                "application/zip"
+                              ],
+                              "description": "MIME type of the uploaded file. One of the allowed types: image/jpeg, image/png, image/gif, image/webp, image/svg+xml, application/pdf, application/msword, application/vnd.openxmlformats-officedocument.wordprocessingml.document (.docx), application/vnd.ms-excel, application/vnd.openxmlformats-officedocument.spreadsheetml.sheet (.xlsx), application/vnd.ms-powerpoint, application/vnd.openxmlformats-officedocument.presentationml.presentation (.pptx), text/plain, text/csv, video/mp4, video/webm, audio/mpeg, audio/wav, application/zip (e.g., \"application/pdf\", \"image/jpeg\")."
+                            },
+                            "size_bytes": {
+                              "type": "integer",
+                              "format": "int64",
+                              "description": "File size in bytes. Maximum allowed size is 104857600 bytes (100MB)."
+                            },
+                            "content_hash": {
+                              "type": "string",
+                              "maxLength": 64,
+                              "nullable": true,
+                              "description": "SHA-256 fingerprint (64-character hexadecimal string) used for content deduplication within the same business. Files with identical content_hash skip redundant processing (e.g., \"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\")."
+                            },
+                            "status": {
+                              "type": "string",
+                              "enum": [
+                                "pending",
+                                "scanning",
+                                "scanned",
+                                "uploaded",
+                                "infected",
+                                "failed",
+                                "linked",
+                                "deleted"
+                              ],
+                              "description": "Current processing status of the file. **pending**: Upload received, virus scan queued. **scanning**: Virus scan in progress. **scanned**: Virus scan passed, awaiting S3 upload. **uploaded**: S3 upload complete, thumbnails generated if applicable. **infected**: Malware detected, file marked for deletion. **failed**: Processing error occurred (scan or upload failure). **linked**: File has active entity relations. **deleted**: Soft deleted. The file's S3 objects (original and thumbnails) are removed immediately; the record is retained as soft-deleted and excluded from all reads."
+                            },
+                            "metadata": {
+                              "type": "object",
+                              "nullable": true,
+                              "description": "Optional JSON object containing arbitrary key-value pairs for additional file metadata (e.g., {\"source\": \"chat\", \"uploaded_by_name\": \"John Doe\"})."
+                            },
+                            "url": {
+                              "type": "string",
+                              "format": "uri",
+                              "nullable": true,
+                              "readOnly": true,
+                              "description": "Pre-signed S3 URL for downloading the original file. Available when status is 'uploaded' or 'linked'. Null for pending/failed files (e.g., \"https://s3.amazonaws.com/files-bucket/path/to/original?signature=...\")."
+                            },
+                            "thumbnail_url": {
+                              "type": "string",
+                              "format": "uri",
+                              "nullable": true,
+                              "readOnly": true,
+                              "description": "Pre-signed S3 URL for the 400x400 pixel thumbnail. Available for images and PDFs after successful upload. Null for non-image files or pending uploads (e.g., \"https://s3.amazonaws.com/files-bucket/path/to/thumb_400.jpg?signature=...\")."
+                            },
+                            "thumbnail_small_url": {
+                              "type": "string",
+                              "format": "uri",
+                              "nullable": true,
+                              "readOnly": true,
+                              "description": "Pre-signed S3 URL for the 150x150 pixel thumbnail. Available for images and PDFs after successful upload. Null for non-image files or pending uploads (e.g., \"https://s3.amazonaws.com/files-bucket/path/to/thumb_150.jpg?signature=...\")."
+                            },
+                            "created_by": {
+                              "type": "string",
+                              "enum": [
+                                "staff",
+                                "client"
+                              ],
+                              "readOnly": true,
+                              "description": "Type of actor who created this file. **staff**: Uploaded by a staff member. **client**: Uploaded by a client."
+                            },
+                            "created_by_uid": {
+                              "type": "string",
+                              "readOnly": true,
+                              "description": "Unique identifier of the staff member or client who uploaded this file (e.g., \"staff_789\", \"client_456\")."
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "readOnly": true,
+                              "description": "Timestamp when the file record was created, in ISO 8601 format (e.g., \"2026-01-27T10:30:00Z\")."
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "readOnly": true,
+                              "description": "Timestamp when the file record was last updated, in ISO 8601 format (e.g., \"2026-01-27T11:00:00Z\")."
+                            },
+                            "deleted_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "nullable": true,
+                              "readOnly": true,
+                              "description": "Timestamp when the file was soft deleted, in ISO 8601 format (e.g., \"2026-01-27T12:00:00Z\"). Null if not deleted. On deletion the file's S3 objects (including thumbnails) are removed immediately; the record is retained as soft-deleted."
+                            }
+                          },
+                          "required": [
+                            "uid",
+                            "business_uid",
+                            "name",
+                            "content_type",
+                            "size_bytes",
+                            "status",
+                            "created_by",
+                            "created_by_uid",
+                            "created_at",
+                            "updated_at"
+                          ],
+                          "example": {
+                            "uid": "file_123abc456def",
+                            "business_uid": "biz_789xyz",
+                            "name": "invoice_2026_Q1.pdf",
+                            "content_type": "application/pdf",
+                            "size_bytes": 2048576,
+                            "content_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                            "status": "uploaded",
+                            "metadata": {
+                              "source": "chat",
+                              "conversation_id": "conv_123"
+                            },
+                            "url": "https://s3.amazonaws.com/files-bucket/biz_789xyz/2026/01/27/file_123abc456def/original?signature=abc123...",
+                            "thumbnail_url": "https://s3.amazonaws.com/files-bucket/biz_789xyz/2026/01/27/file_123abc456def/thumb_400.jpg?signature=def456...",
+                            "thumbnail_small_url": "https://s3.amazonaws.com/files-bucket/biz_789xyz/2026/01/27/file_123abc456def/thumb_150.jpg?signature=ghi789...",
+                            "created_by": "staff",
+                            "created_by_uid": "staff_456xyz",
+                            "created_at": "2026-01-27T10:30:00Z",
+                            "updated_at": "2026-01-27T10:30:45Z",
+                            "deleted_at": null
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "File upload initiated successfully (new file, async processing started)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Response"
+                    },
+                    {
+                      "properties": {
+                        "data": {
+                          "type": "object",
+                          "description": "Represents a file uploaded to the platform. Files go through an asynchronous processing pipeline including virus scanning, S3 storage, and thumbnail generation. Content deduplication via SHA-256 fingerprinting ensures efficient storage within each business.",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "readOnly": true,
+                              "description": "Unique identifier for the file record (e.g., \"file_123\")."
+                            },
+                            "business_uid": {
+                              "type": "string",
+                              "readOnly": true,
+                              "description": "Unique identifier of the business that owns this file (e.g., \"biz_456\")."
+                            },
+                            "name": {
+                              "type": "string",
+                              "maxLength": 255,
+                              "description": "Original filename including extension (e.g., \"document.pdf\", \"photo.jpg\"). Maximum length is 255 characters."
+                            },
+                            "content_type": {
+                              "type": "string",
+                              "enum": [
+                                "image/jpeg",
+                                "image/png",
+                                "image/gif",
+                                "image/webp",
+                                "image/svg+xml",
+                                "application/pdf",
+                                "application/msword",
+                                "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                                "application/vnd.ms-excel",
+                                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                                "application/vnd.ms-powerpoint",
+                                "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+                                "text/plain",
+                                "text/csv",
+                                "video/mp4",
+                                "video/webm",
+                                "audio/mpeg",
+                                "audio/wav",
+                                "application/zip"
+                              ],
+                              "description": "MIME type of the uploaded file. One of the allowed types: image/jpeg, image/png, image/gif, image/webp, image/svg+xml, application/pdf, application/msword, application/vnd.openxmlformats-officedocument.wordprocessingml.document (.docx), application/vnd.ms-excel, application/vnd.openxmlformats-officedocument.spreadsheetml.sheet (.xlsx), application/vnd.ms-powerpoint, application/vnd.openxmlformats-officedocument.presentationml.presentation (.pptx), text/plain, text/csv, video/mp4, video/webm, audio/mpeg, audio/wav, application/zip (e.g., \"application/pdf\", \"image/jpeg\")."
+                            },
+                            "size_bytes": {
+                              "type": "integer",
+                              "format": "int64",
+                              "description": "File size in bytes. Maximum allowed size is 104857600 bytes (100MB)."
+                            },
+                            "content_hash": {
+                              "type": "string",
+                              "maxLength": 64,
+                              "nullable": true,
+                              "description": "SHA-256 fingerprint (64-character hexadecimal string) used for content deduplication within the same business. Files with identical content_hash skip redundant processing (e.g., \"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\")."
+                            },
+                            "status": {
+                              "type": "string",
+                              "enum": [
+                                "pending",
+                                "scanning",
+                                "scanned",
+                                "uploaded",
+                                "infected",
+                                "failed",
+                                "linked",
+                                "deleted"
+                              ],
+                              "description": "Current processing status of the file. **pending**: Upload received, virus scan queued. **scanning**: Virus scan in progress. **scanned**: Virus scan passed, awaiting S3 upload. **uploaded**: S3 upload complete, thumbnails generated if applicable. **infected**: Malware detected, file marked for deletion. **failed**: Processing error occurred (scan or upload failure). **linked**: File has active entity relations. **deleted**: Soft deleted. The file's S3 objects (original and thumbnails) are removed immediately; the record is retained as soft-deleted and excluded from all reads."
+                            },
+                            "metadata": {
+                              "type": "object",
+                              "nullable": true,
+                              "description": "Optional JSON object containing arbitrary key-value pairs for additional file metadata (e.g., {\"source\": \"chat\", \"uploaded_by_name\": \"John Doe\"})."
+                            },
+                            "url": {
+                              "type": "string",
+                              "format": "uri",
+                              "nullable": true,
+                              "readOnly": true,
+                              "description": "Pre-signed S3 URL for downloading the original file. Available when status is 'uploaded' or 'linked'. Null for pending/failed files (e.g., \"https://s3.amazonaws.com/files-bucket/path/to/original?signature=...\")."
+                            },
+                            "thumbnail_url": {
+                              "type": "string",
+                              "format": "uri",
+                              "nullable": true,
+                              "readOnly": true,
+                              "description": "Pre-signed S3 URL for the 400x400 pixel thumbnail. Available for images and PDFs after successful upload. Null for non-image files or pending uploads (e.g., \"https://s3.amazonaws.com/files-bucket/path/to/thumb_400.jpg?signature=...\")."
+                            },
+                            "thumbnail_small_url": {
+                              "type": "string",
+                              "format": "uri",
+                              "nullable": true,
+                              "readOnly": true,
+                              "description": "Pre-signed S3 URL for the 150x150 pixel thumbnail. Available for images and PDFs after successful upload. Null for non-image files or pending uploads (e.g., \"https://s3.amazonaws.com/files-bucket/path/to/thumb_150.jpg?signature=...\")."
+                            },
+                            "created_by": {
+                              "type": "string",
+                              "enum": [
+                                "staff",
+                                "client"
+                              ],
+                              "readOnly": true,
+                              "description": "Type of actor who created this file. **staff**: Uploaded by a staff member. **client**: Uploaded by a client."
+                            },
+                            "created_by_uid": {
+                              "type": "string",
+                              "readOnly": true,
+                              "description": "Unique identifier of the staff member or client who uploaded this file (e.g., \"staff_789\", \"client_456\")."
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "readOnly": true,
+                              "description": "Timestamp when the file record was created, in ISO 8601 format (e.g., \"2026-01-27T10:30:00Z\")."
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "readOnly": true,
+                              "description": "Timestamp when the file record was last updated, in ISO 8601 format (e.g., \"2026-01-27T11:00:00Z\")."
+                            },
+                            "deleted_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "nullable": true,
+                              "readOnly": true,
+                              "description": "Timestamp when the file was soft deleted, in ISO 8601 format (e.g., \"2026-01-27T12:00:00Z\"). Null if not deleted. On deletion the file's S3 objects (including thumbnails) are removed immediately; the record is retained as soft-deleted."
+                            }
+                          },
+                          "required": [
+                            "uid",
+                            "business_uid",
+                            "name",
+                            "content_type",
+                            "size_bytes",
+                            "status",
+                            "created_by",
+                            "created_by_uid",
+                            "created_at",
+                            "updated_at"
+                          ],
+                          "example": {
+                            "uid": "file_123abc456def",
+                            "business_uid": "biz_789xyz",
+                            "name": "invoice_2026_Q1.pdf",
+                            "content_type": "application/pdf",
+                            "size_bytes": 2048576,
+                            "content_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                            "status": "uploaded",
+                            "metadata": {
+                              "source": "chat",
+                              "conversation_id": "conv_123"
+                            },
+                            "url": "https://s3.amazonaws.com/files-bucket/biz_789xyz/2026/01/27/file_123abc456def/original?signature=abc123...",
+                            "thumbnail_url": "https://s3.amazonaws.com/files-bucket/biz_789xyz/2026/01/27/file_123abc456def/thumb_400.jpg?signature=def456...",
+                            "thumbnail_small_url": "https://s3.amazonaws.com/files-bucket/biz_789xyz/2026/01/27/file_123abc456def/thumb_150.jpg?signature=ghi789...",
+                            "created_by": "staff",
+                            "created_by_uid": "staff_456xyz",
+                            "created_at": "2026-01-27T10:30:00Z",
+                            "updated_at": "2026-01-27T10:30:45Z",
+                            "deleted_at": null
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request - Invalid file type, name, or size",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - Invalid or missing authentication token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden - Feature disabled for this business",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity - Validation error in request data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests - Rate limit exceeded (10 uploads per 10 minutes)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "Files": []
+          }
+        ]
+      },
+      "get": {
+        "operationId": "FilesController_findAll",
+        "summary": "Get all files",
+        "description": "Retrieves the files you uploaded, optionally filtered by status or a list of file UIDs. Each token only sees files it created itself; files uploaded by other users are not returned. Results include pre-signed URLs for file download and thumbnails when the file is ready. Soft-deleted files are never returned.\n\nAvailable for **Staff and Client tokens**.",
+        "tags": [
+          "Files"
+        ],
+        "parameters": [
+          {
+            "name": "status",
+            "in": "query",
+            "required": false,
+            "description": "Filter by file processing status (e.g., \"uploaded\", \"pending\"). Soft-deleted files are never returned regardless of this filter.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "pending",
+                "scanning",
+                "scanned",
+                "uploaded",
+                "infected",
+                "failed",
+                "linked",
+                "deleted"
+              ]
+            }
+          },
+          {
+            "name": "file_uids",
+            "in": "query",
+            "required": false,
+            "description": "One or more file UIDs to fetch. Repeat the parameter for multiple values (e.g., \"file_123abc\", \"file_456def\").",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "description": "Page number for pagination (default: 1).",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 1
+            }
+          },
+          {
+            "name": "per_page",
+            "in": "query",
+            "required": false,
+            "description": "Number of files per page (default: 20, max: 100).",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 20
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Files retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Response"
+                    },
+                    {
+                      "properties": {
+                        "data": {
+                          "$ref": "#/components/schemas/MultiFileResponse"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request - Invalid query parameters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - Invalid or missing authentication token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "Files": []
+          }
+        ]
+      }
+    },
+    "/v3/assets/files/{uid}": {
+      "get": {
+        "operationId": "FilesController_findOne",
+        "summary": "Get a file",
+        "description": "Retrieves a specific file by its unique identifier. Only the file you uploaded is returned; requesting a file created by another user returns 404.\n\nUsed for status polling after upload to check if processing (scan, storage, thumbnails) is complete. Response includes pre-signed URLs when the file is ready.\n\nAvailable for **Staff and Client tokens**.",
+        "tags": [
+          "Files"
+        ],
+        "parameters": [
+          {
+            "name": "uid",
+            "in": "path",
+            "required": true,
+            "description": "Unique identifier of the file to retrieve (e.g., \"file_123abc\").",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "File retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Response"
+                    },
+                    {
+                      "properties": {
+                        "data": {
+                          "type": "object",
+                          "description": "Represents a file uploaded to the platform. Files go through an asynchronous processing pipeline including virus scanning, S3 storage, and thumbnail generation. Content deduplication via SHA-256 fingerprinting ensures efficient storage within each business.",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "readOnly": true,
+                              "description": "Unique identifier for the file record (e.g., \"file_123\")."
+                            },
+                            "business_uid": {
+                              "type": "string",
+                              "readOnly": true,
+                              "description": "Unique identifier of the business that owns this file (e.g., \"biz_456\")."
+                            },
+                            "name": {
+                              "type": "string",
+                              "maxLength": 255,
+                              "description": "Original filename including extension (e.g., \"document.pdf\", \"photo.jpg\"). Maximum length is 255 characters."
+                            },
+                            "content_type": {
+                              "type": "string",
+                              "enum": [
+                                "image/jpeg",
+                                "image/png",
+                                "image/gif",
+                                "image/webp",
+                                "image/svg+xml",
+                                "application/pdf",
+                                "application/msword",
+                                "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                                "application/vnd.ms-excel",
+                                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                                "application/vnd.ms-powerpoint",
+                                "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+                                "text/plain",
+                                "text/csv",
+                                "video/mp4",
+                                "video/webm",
+                                "audio/mpeg",
+                                "audio/wav",
+                                "application/zip"
+                              ],
+                              "description": "MIME type of the uploaded file. One of the allowed types: image/jpeg, image/png, image/gif, image/webp, image/svg+xml, application/pdf, application/msword, application/vnd.openxmlformats-officedocument.wordprocessingml.document (.docx), application/vnd.ms-excel, application/vnd.openxmlformats-officedocument.spreadsheetml.sheet (.xlsx), application/vnd.ms-powerpoint, application/vnd.openxmlformats-officedocument.presentationml.presentation (.pptx), text/plain, text/csv, video/mp4, video/webm, audio/mpeg, audio/wav, application/zip (e.g., \"application/pdf\", \"image/jpeg\")."
+                            },
+                            "size_bytes": {
+                              "type": "integer",
+                              "format": "int64",
+                              "description": "File size in bytes. Maximum allowed size is 104857600 bytes (100MB)."
+                            },
+                            "content_hash": {
+                              "type": "string",
+                              "maxLength": 64,
+                              "nullable": true,
+                              "description": "SHA-256 fingerprint (64-character hexadecimal string) used for content deduplication within the same business. Files with identical content_hash skip redundant processing (e.g., \"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\")."
+                            },
+                            "status": {
+                              "type": "string",
+                              "enum": [
+                                "pending",
+                                "scanning",
+                                "scanned",
+                                "uploaded",
+                                "infected",
+                                "failed",
+                                "linked",
+                                "deleted"
+                              ],
+                              "description": "Current processing status of the file. **pending**: Upload received, virus scan queued. **scanning**: Virus scan in progress. **scanned**: Virus scan passed, awaiting S3 upload. **uploaded**: S3 upload complete, thumbnails generated if applicable. **infected**: Malware detected, file marked for deletion. **failed**: Processing error occurred (scan or upload failure). **linked**: File has active entity relations. **deleted**: Soft deleted. The file's S3 objects (original and thumbnails) are removed immediately; the record is retained as soft-deleted and excluded from all reads."
+                            },
+                            "metadata": {
+                              "type": "object",
+                              "nullable": true,
+                              "description": "Optional JSON object containing arbitrary key-value pairs for additional file metadata (e.g., {\"source\": \"chat\", \"uploaded_by_name\": \"John Doe\"})."
+                            },
+                            "url": {
+                              "type": "string",
+                              "format": "uri",
+                              "nullable": true,
+                              "readOnly": true,
+                              "description": "Pre-signed S3 URL for downloading the original file. Available when status is 'uploaded' or 'linked'. Null for pending/failed files (e.g., \"https://s3.amazonaws.com/files-bucket/path/to/original?signature=...\")."
+                            },
+                            "thumbnail_url": {
+                              "type": "string",
+                              "format": "uri",
+                              "nullable": true,
+                              "readOnly": true,
+                              "description": "Pre-signed S3 URL for the 400x400 pixel thumbnail. Available for images and PDFs after successful upload. Null for non-image files or pending uploads (e.g., \"https://s3.amazonaws.com/files-bucket/path/to/thumb_400.jpg?signature=...\")."
+                            },
+                            "thumbnail_small_url": {
+                              "type": "string",
+                              "format": "uri",
+                              "nullable": true,
+                              "readOnly": true,
+                              "description": "Pre-signed S3 URL for the 150x150 pixel thumbnail. Available for images and PDFs after successful upload. Null for non-image files or pending uploads (e.g., \"https://s3.amazonaws.com/files-bucket/path/to/thumb_150.jpg?signature=...\")."
+                            },
+                            "created_by": {
+                              "type": "string",
+                              "enum": [
+                                "staff",
+                                "client"
+                              ],
+                              "readOnly": true,
+                              "description": "Type of actor who created this file. **staff**: Uploaded by a staff member. **client**: Uploaded by a client."
+                            },
+                            "created_by_uid": {
+                              "type": "string",
+                              "readOnly": true,
+                              "description": "Unique identifier of the staff member or client who uploaded this file (e.g., \"staff_789\", \"client_456\")."
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "readOnly": true,
+                              "description": "Timestamp when the file record was created, in ISO 8601 format (e.g., \"2026-01-27T10:30:00Z\")."
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "readOnly": true,
+                              "description": "Timestamp when the file record was last updated, in ISO 8601 format (e.g., \"2026-01-27T11:00:00Z\")."
+                            },
+                            "deleted_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "nullable": true,
+                              "readOnly": true,
+                              "description": "Timestamp when the file was soft deleted, in ISO 8601 format (e.g., \"2026-01-27T12:00:00Z\"). Null if not deleted. On deletion the file's S3 objects (including thumbnails) are removed immediately; the record is retained as soft-deleted."
+                            }
+                          },
+                          "required": [
+                            "uid",
+                            "business_uid",
+                            "name",
+                            "content_type",
+                            "size_bytes",
+                            "status",
+                            "created_by",
+                            "created_by_uid",
+                            "created_at",
+                            "updated_at"
+                          ],
+                          "example": {
+                            "uid": "file_123abc456def",
+                            "business_uid": "biz_789xyz",
+                            "name": "invoice_2026_Q1.pdf",
+                            "content_type": "application/pdf",
+                            "size_bytes": 2048576,
+                            "content_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                            "status": "uploaded",
+                            "metadata": {
+                              "source": "chat",
+                              "conversation_id": "conv_123"
+                            },
+                            "url": "https://s3.amazonaws.com/files-bucket/biz_789xyz/2026/01/27/file_123abc456def/original?signature=abc123...",
+                            "thumbnail_url": "https://s3.amazonaws.com/files-bucket/biz_789xyz/2026/01/27/file_123abc456def/thumb_400.jpg?signature=def456...",
+                            "thumbnail_small_url": "https://s3.amazonaws.com/files-bucket/biz_789xyz/2026/01/27/file_123abc456def/thumb_150.jpg?signature=ghi789...",
+                            "created_by": "staff",
+                            "created_by_uid": "staff_456xyz",
+                            "created_at": "2026-01-27T10:30:00Z",
+                            "updated_at": "2026-01-27T10:30:45Z",
+                            "deleted_at": null
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - Invalid or missing authentication token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found - File does not exist, or was uploaded by another user",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "Files": []
+          }
+        ]
+      },
+      "delete": {
+        "operationId": "FilesController_delete",
+        "summary": "Delete a file",
+        "description": "Soft deletes a specific file. The file's S3 objects (original and thumbnails) are removed immediately; the record is retained as soft-deleted and excluded from all reads.\n\nAvailable for **Staff tokens only**.",
+        "tags": [
+          "Files"
+        ],
+        "parameters": [
+          {
+            "name": "uid",
+            "in": "path",
+            "required": true,
+            "description": "Unique identifier of the file to delete (e.g., \"file_123abc\").",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "File deleted successfully (soft delete). The file's S3 objects (original and thumbnails) are removed immediately; the record is retained as soft-deleted. Returns the deleted file entity.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Response"
+                    },
+                    {
+                      "properties": {
+                        "data": {
+                          "type": "object",
+                          "description": "Represents a file uploaded to the platform. Files go through an asynchronous processing pipeline including virus scanning, S3 storage, and thumbnail generation. Content deduplication via SHA-256 fingerprinting ensures efficient storage within each business.",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "readOnly": true,
+                              "description": "Unique identifier for the file record (e.g., \"file_123\")."
+                            },
+                            "business_uid": {
+                              "type": "string",
+                              "readOnly": true,
+                              "description": "Unique identifier of the business that owns this file (e.g., \"biz_456\")."
+                            },
+                            "name": {
+                              "type": "string",
+                              "maxLength": 255,
+                              "description": "Original filename including extension (e.g., \"document.pdf\", \"photo.jpg\"). Maximum length is 255 characters."
+                            },
+                            "content_type": {
+                              "type": "string",
+                              "enum": [
+                                "image/jpeg",
+                                "image/png",
+                                "image/gif",
+                                "image/webp",
+                                "image/svg+xml",
+                                "application/pdf",
+                                "application/msword",
+                                "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                                "application/vnd.ms-excel",
+                                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                                "application/vnd.ms-powerpoint",
+                                "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+                                "text/plain",
+                                "text/csv",
+                                "video/mp4",
+                                "video/webm",
+                                "audio/mpeg",
+                                "audio/wav",
+                                "application/zip"
+                              ],
+                              "description": "MIME type of the uploaded file. One of the allowed types: image/jpeg, image/png, image/gif, image/webp, image/svg+xml, application/pdf, application/msword, application/vnd.openxmlformats-officedocument.wordprocessingml.document (.docx), application/vnd.ms-excel, application/vnd.openxmlformats-officedocument.spreadsheetml.sheet (.xlsx), application/vnd.ms-powerpoint, application/vnd.openxmlformats-officedocument.presentationml.presentation (.pptx), text/plain, text/csv, video/mp4, video/webm, audio/mpeg, audio/wav, application/zip (e.g., \"application/pdf\", \"image/jpeg\")."
+                            },
+                            "size_bytes": {
+                              "type": "integer",
+                              "format": "int64",
+                              "description": "File size in bytes. Maximum allowed size is 104857600 bytes (100MB)."
+                            },
+                            "content_hash": {
+                              "type": "string",
+                              "maxLength": 64,
+                              "nullable": true,
+                              "description": "SHA-256 fingerprint (64-character hexadecimal string) used for content deduplication within the same business. Files with identical content_hash skip redundant processing (e.g., \"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\")."
+                            },
+                            "status": {
+                              "type": "string",
+                              "enum": [
+                                "pending",
+                                "scanning",
+                                "scanned",
+                                "uploaded",
+                                "infected",
+                                "failed",
+                                "linked",
+                                "deleted"
+                              ],
+                              "description": "Current processing status of the file. **pending**: Upload received, virus scan queued. **scanning**: Virus scan in progress. **scanned**: Virus scan passed, awaiting S3 upload. **uploaded**: S3 upload complete, thumbnails generated if applicable. **infected**: Malware detected, file marked for deletion. **failed**: Processing error occurred (scan or upload failure). **linked**: File has active entity relations. **deleted**: Soft deleted. The file's S3 objects (original and thumbnails) are removed immediately; the record is retained as soft-deleted and excluded from all reads."
+                            },
+                            "metadata": {
+                              "type": "object",
+                              "nullable": true,
+                              "description": "Optional JSON object containing arbitrary key-value pairs for additional file metadata (e.g., {\"source\": \"chat\", \"uploaded_by_name\": \"John Doe\"})."
+                            },
+                            "url": {
+                              "type": "string",
+                              "format": "uri",
+                              "nullable": true,
+                              "readOnly": true,
+                              "description": "Pre-signed S3 URL for downloading the original file. Available when status is 'uploaded' or 'linked'. Null for pending/failed files (e.g., \"https://s3.amazonaws.com/files-bucket/path/to/original?signature=...\")."
+                            },
+                            "thumbnail_url": {
+                              "type": "string",
+                              "format": "uri",
+                              "nullable": true,
+                              "readOnly": true,
+                              "description": "Pre-signed S3 URL for the 400x400 pixel thumbnail. Available for images and PDFs after successful upload. Null for non-image files or pending uploads (e.g., \"https://s3.amazonaws.com/files-bucket/path/to/thumb_400.jpg?signature=...\")."
+                            },
+                            "thumbnail_small_url": {
+                              "type": "string",
+                              "format": "uri",
+                              "nullable": true,
+                              "readOnly": true,
+                              "description": "Pre-signed S3 URL for the 150x150 pixel thumbnail. Available for images and PDFs after successful upload. Null for non-image files or pending uploads (e.g., \"https://s3.amazonaws.com/files-bucket/path/to/thumb_150.jpg?signature=...\")."
+                            },
+                            "created_by": {
+                              "type": "string",
+                              "enum": [
+                                "staff",
+                                "client"
+                              ],
+                              "readOnly": true,
+                              "description": "Type of actor who created this file. **staff**: Uploaded by a staff member. **client**: Uploaded by a client."
+                            },
+                            "created_by_uid": {
+                              "type": "string",
+                              "readOnly": true,
+                              "description": "Unique identifier of the staff member or client who uploaded this file (e.g., \"staff_789\", \"client_456\")."
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "readOnly": true,
+                              "description": "Timestamp when the file record was created, in ISO 8601 format (e.g., \"2026-01-27T10:30:00Z\")."
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "readOnly": true,
+                              "description": "Timestamp when the file record was last updated, in ISO 8601 format (e.g., \"2026-01-27T11:00:00Z\")."
+                            },
+                            "deleted_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "nullable": true,
+                              "readOnly": true,
+                              "description": "Timestamp when the file was soft deleted, in ISO 8601 format (e.g., \"2026-01-27T12:00:00Z\"). Null if not deleted. On deletion the file's S3 objects (including thumbnails) are removed immediately; the record is retained as soft-deleted."
+                            }
+                          },
+                          "required": [
+                            "uid",
+                            "business_uid",
+                            "name",
+                            "content_type",
+                            "size_bytes",
+                            "status",
+                            "created_by",
+                            "created_by_uid",
+                            "created_at",
+                            "updated_at"
+                          ],
+                          "example": {
+                            "uid": "file_123abc456def",
+                            "business_uid": "biz_789xyz",
+                            "name": "invoice_2026_Q1.pdf",
+                            "content_type": "application/pdf",
+                            "size_bytes": 2048576,
+                            "content_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                            "status": "uploaded",
+                            "metadata": {
+                              "source": "chat",
+                              "conversation_id": "conv_123"
+                            },
+                            "url": "https://s3.amazonaws.com/files-bucket/biz_789xyz/2026/01/27/file_123abc456def/original?signature=abc123...",
+                            "thumbnail_url": "https://s3.amazonaws.com/files-bucket/biz_789xyz/2026/01/27/file_123abc456def/thumb_400.jpg?signature=def456...",
+                            "thumbnail_small_url": "https://s3.amazonaws.com/files-bucket/biz_789xyz/2026/01/27/file_123abc456def/thumb_150.jpg?signature=ghi789...",
+                            "created_by": "staff",
+                            "created_by_uid": "staff_456xyz",
+                            "created_at": "2026-01-27T10:30:00Z",
+                            "updated_at": "2026-01-27T10:30:45Z",
+                            "deleted_at": null
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - Invalid or missing authentication token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden - Insufficient permissions to delete this file",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found - File does not exist",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity - Validation error in request data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "Files": []
+          }
+        ]
+      }
+    },
+    "/v3/assets/file_relations": {
+      "post": {
+        "operationId": "FileRelationsController_create",
+        "summary": "Create a file relation",
+        "description": "Links an existing file to a business entity (e.g., an invoice, message, or appointment). The referenced file must already exist and be in a usable state ('scanned', 'uploaded', or 'linked'). Once a file has at least one active relation its status becomes 'linked', protecting it from cleanup.\n\nFor **Client tokens**, the client_uid is derived from the token and any value supplied in the body is ignored. For **Staff tokens**, client_uid may be provided to associate the relation with a specific client.\n\nAvailable for **Staff and Client tokens**.",
+        "tags": [
+          "File Relations"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateFileRelationRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Relation created successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Response"
+                    },
+                    {
+                      "properties": {
+                        "data": {
+                          "type": "object",
+                          "description": "Represents a relationship between a file and a business entity (e.g., invoice, message, appointment). This allows files to be attached to various entities across the platform. When a file has at least one active relation, its status becomes 'linked' and it is protected from cleanup jobs.",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "readOnly": true,
+                              "description": "Unique identifier for the file-entity relation record (e.g., \"rel_123abc\")."
+                            },
+                            "file_uid": {
+                              "type": "string",
+                              "description": "Unique identifier of the file being linked (e.g., \"file_456def\"). Must reference an existing file with status 'scanned', 'uploaded', or 'linked'."
+                            },
+                            "entity_type": {
+                              "type": "string",
+                              "enum": [
+                                "message",
+                                "invoice",
+                                "payment",
+                                "appointment",
+                                "estimate"
+                              ],
+                              "description": "Type of entity the file is attached to. **message**: Email message. **invoice**: Invoice document. **payment**: Payment record. **appointment**: Scheduled appointment. **estimate**: Estimate/quote document."
+                            },
+                            "entity_uid": {
+                              "type": "string",
+                              "description": "Unique identifier of the entity the file is attached to (e.g., \"inv_789xyz\" for an invoice, \"msg_123abc\" for a message)."
+                            },
+                            "business_uid": {
+                              "type": "string",
+                              "readOnly": true,
+                              "description": "Unique identifier of the business that owns both the file and the entity (e.g., \"biz_456xyz\"). Inherited from the file record."
+                            },
+                            "client_uid": {
+                              "type": "string",
+                              "nullable": true,
+                              "description": "Unique identifier of the client associated with this relation, if applicable (e.g., \"client_789abc\"). Used for client-specific files like uploaded documents or images. Null for business-level files."
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "readOnly": true,
+                              "description": "Timestamp when the relation was created, in ISO 8601 format (e.g., \"2026-01-27T10:35:00Z\")."
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "readOnly": true,
+                              "description": "Timestamp when the relation was last updated, in ISO 8601 format (e.g., \"2026-01-27T10:35:30Z\")."
+                            },
+                            "deleted_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "nullable": true,
+                              "readOnly": true,
+                              "description": "Timestamp when the relation was soft deleted, in ISO 8601 format (e.g., \"2026-01-27T12:00:00Z\"). Null if the relation is still active. When all relations for a file are deleted, the file may become eligible for cleanup."
+                            },
+                            "file": {
+                              "type": "object",
+                              "readOnly": true,
+                              "nullable": true,
+                              "description": "Details of the linked file, included when relations are fetched by entity. Omitted on relation creation.",
+                              "properties": {
+                                "name": {
+                                  "type": "string",
+                                  "description": "Original filename including extension (e.g., \"invoice_2026_Q1.pdf\")."
+                                },
+                                "status": {
+                                  "type": "string",
+                                  "enum": [
+                                    "pending",
+                                    "scanning",
+                                    "scanned",
+                                    "uploaded",
+                                    "infected",
+                                    "failed",
+                                    "linked",
+                                    "deleted"
+                                  ],
+                                  "description": "Current processing status of the linked file."
+                                },
+                                "content_type": {
+                                  "type": "string",
+                                  "description": "MIME type of the linked file (e.g., \"application/pdf\", \"image/jpeg\")."
+                                },
+                                "size": {
+                                  "type": "integer",
+                                  "format": "int64",
+                                  "description": "File size in bytes (e.g., 2048576)."
+                                },
+                                "url": {
+                                  "type": "string",
+                                  "format": "uri",
+                                  "nullable": true,
+                                  "description": "Pre-signed S3 URL for downloading the original file. Null for pending/infected files."
+                                },
+                                "thumbnail_url": {
+                                  "type": "string",
+                                  "format": "uri",
+                                  "nullable": true,
+                                  "description": "Pre-signed S3 URL for the 400x400 pixel thumbnail. Null for non-image files or pending uploads."
+                                },
+                                "thumbnail_small_url": {
+                                  "type": "string",
+                                  "format": "uri",
+                                  "nullable": true,
+                                  "description": "Pre-signed S3 URL for the 150x150 pixel thumbnail. Null for non-image files or pending uploads."
+                                },
+                                "metadata": {
+                                  "type": "object",
+                                  "nullable": true,
+                                  "description": "Optional JSON object containing arbitrary key-value pairs for additional file metadata."
+                                },
+                                "created_at": {
+                                  "type": "string",
+                                  "format": "date-time",
+                                  "description": "Timestamp when the file record was created, in ISO 8601 format."
+                                },
+                                "updated_at": {
+                                  "type": "string",
+                                  "format": "date-time",
+                                  "description": "Timestamp when the file record was last updated, in ISO 8601 format."
+                                }
+                              }
+                            }
+                          },
+                          "required": [
+                            "uid",
+                            "file_uid",
+                            "entity_type",
+                            "entity_uid",
+                            "business_uid",
+                            "created_at",
+                            "updated_at"
+                          ],
+                          "example": {
+                            "uid": "rel_abc123def456",
+                            "file_uid": "file_789xyz",
+                            "entity_type": "invoice",
+                            "entity_uid": "inv_456abc",
+                            "business_uid": "biz_123xyz",
+                            "client_uid": "client_789def",
+                            "created_at": "2026-01-27T10:35:00Z",
+                            "updated_at": "2026-01-27T10:35:00Z",
+                            "deleted_at": null,
+                            "file": {
+                              "name": "invoice_2026_Q1.pdf",
+                              "status": "linked",
+                              "content_type": "application/pdf",
+                              "size": 2048576,
+                              "url": "https://s3.amazonaws.com/files-bucket/biz_123xyz/2026/01/27/file_789xyz/original?signature=abc123...",
+                              "thumbnail_url": "https://s3.amazonaws.com/files-bucket/biz_123xyz/2026/01/27/file_789xyz/thumb_400.jpg?signature=def456...",
+                              "thumbnail_small_url": "https://s3.amazonaws.com/files-bucket/biz_123xyz/2026/01/27/file_789xyz/thumb_150.jpg?signature=ghi789...",
+                              "metadata": {
+                                "source": "chat"
+                              },
+                              "created_at": "2026-01-27T10:30:00Z",
+                              "updated_at": "2026-01-27T10:30:45Z"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request - File is not ready or is in an unusable state",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - Invalid or missing authentication token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found - File does not exist",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict - A relation between this file and entity already exists",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity - Validation error in request data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "Files": []
+          }
+        ]
+      },
+      "get": {
+        "operationId": "FileRelationsController_findByEntity",
+        "summary": "Get file relations by entity",
+        "description": "Retrieves the file relations for a given entity, each including the linked file's details. Results are paginated.\n\nStaff access is scoped to the linked entity: a staff sees relations for any entity they can access, regardless of who uploaded the file. Client access is scoped to the client's own relations.\n\nAvailable for **Staff and Client tokens**.",
+        "tags": [
+          "File Relations"
+        ],
+        "parameters": [
+          {
+            "name": "entity_type",
+            "in": "query",
+            "required": true,
+            "description": "Type of entity to fetch relations for (e.g., \"invoice\", \"message\", \"appointment\").",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "message",
+                "invoice",
+                "payment",
+                "appointment",
+                "estimate"
+              ]
+            }
+          },
+          {
+            "name": "entity_uid",
+            "in": "query",
+            "required": true,
+            "description": "Unique identifier of the entity to fetch relations for (e.g., \"inv_123abc\").",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "description": "Page number for pagination (default: 1).",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 1
+            }
+          },
+          {
+            "name": "per_page",
+            "in": "query",
+            "required": false,
+            "description": "Number of relations per page (default: 20).",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 20
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Relations retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Response"
+                    },
+                    {
+                      "properties": {
+                        "data": {
+                          "$ref": "#/components/schemas/FileRelationsResponse"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - Invalid or missing authentication token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden - Insufficient permissions to access relations for this entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "Files": []
+          }
+        ]
+      },
+      "delete": {
+        "operationId": "FileRelationsController_deleteByEntity",
+        "summary": "Delete all entity files",
+        "description": "Soft deletes every file relation for the given entity and returns the number of relations deleted. Files left with no remaining active relations may become eligible for cleanup.\n\nAvailable for **Staff and Client tokens**.",
+        "tags": [
+          "File Relations"
+        ],
+        "parameters": [
+          {
+            "name": "entity_type",
+            "in": "query",
+            "required": true,
+            "description": "Type of entity whose relations should be deleted (e.g., \"invoice\", \"message\", \"appointment\").",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "message",
+                "invoice",
+                "payment",
+                "appointment",
+                "estimate"
+              ]
+            }
+          },
+          {
+            "name": "entity_uid",
+            "in": "query",
+            "required": true,
+            "description": "Unique identifier of the entity whose relations should be deleted (e.g., \"inv_123abc\").",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Relations deleted successfully (soft delete). Returns the number of relations removed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Response"
+                    },
+                    {
+                      "properties": {
+                        "data": {
+                          "$ref": "#/components/schemas/DeleteFileRelationsResponse"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - Invalid or missing authentication token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden - Insufficient permissions to delete relations for this entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "Files": []
+          }
+        ]
+      }
+    },
     "/client_api/v1/portals/{business_uid}/contact/get_form": {
       "get": {
         "tags": [
@@ -786,6 +2268,480 @@
   },
   "components": {
     "schemas": {
+      "Response": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "data": {
+            "type": "object"
+          }
+        },
+        "required": [
+          "success",
+          "data"
+        ]
+      },
+      "UploadFileRequest": {
+        "type": "object",
+        "properties": {
+          "file": {
+            "type": "string",
+            "format": "binary",
+            "description": "The file binary content to upload. Maximum size: 100MB."
+          },
+          "name": {
+            "type": "string",
+            "maxLength": 255,
+            "description": "Optional filename override. If not provided, the original filename from the uploaded file is used. Maximum length: 255 characters (e.g., \"document.pdf\", \"photo.jpg\")."
+          },
+          "metadata": {
+            "type": "object",
+            "description": "Optional JSON object containing arbitrary key-value pairs for additional file metadata (e.g., {\"source\": \"chat\", \"conversation_id\": \"conv_123\"})."
+          }
+        },
+        "required": [
+          "file"
+        ]
+      },
+      "MultiFileResponse": {
+        "type": "object",
+        "properties": {
+          "files": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "description": "Represents a file uploaded to the platform. Files go through an asynchronous processing pipeline including virus scanning, S3 storage, and thumbnail generation. Content deduplication via SHA-256 fingerprinting ensures efficient storage within each business.",
+              "properties": {
+                "uid": {
+                  "type": "string",
+                  "readOnly": true,
+                  "description": "Unique identifier for the file record (e.g., \"file_123\")."
+                },
+                "business_uid": {
+                  "type": "string",
+                  "readOnly": true,
+                  "description": "Unique identifier of the business that owns this file (e.g., \"biz_456\")."
+                },
+                "name": {
+                  "type": "string",
+                  "maxLength": 255,
+                  "description": "Original filename including extension (e.g., \"document.pdf\", \"photo.jpg\"). Maximum length is 255 characters."
+                },
+                "content_type": {
+                  "type": "string",
+                  "enum": [
+                    "image/jpeg",
+                    "image/png",
+                    "image/gif",
+                    "image/webp",
+                    "image/svg+xml",
+                    "application/pdf",
+                    "application/msword",
+                    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                    "application/vnd.ms-excel",
+                    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                    "application/vnd.ms-powerpoint",
+                    "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+                    "text/plain",
+                    "text/csv",
+                    "video/mp4",
+                    "video/webm",
+                    "audio/mpeg",
+                    "audio/wav",
+                    "application/zip"
+                  ],
+                  "description": "MIME type of the uploaded file. One of the allowed types: image/jpeg, image/png, image/gif, image/webp, image/svg+xml, application/pdf, application/msword, application/vnd.openxmlformats-officedocument.wordprocessingml.document (.docx), application/vnd.ms-excel, application/vnd.openxmlformats-officedocument.spreadsheetml.sheet (.xlsx), application/vnd.ms-powerpoint, application/vnd.openxmlformats-officedocument.presentationml.presentation (.pptx), text/plain, text/csv, video/mp4, video/webm, audio/mpeg, audio/wav, application/zip (e.g., \"application/pdf\", \"image/jpeg\")."
+                },
+                "size_bytes": {
+                  "type": "integer",
+                  "format": "int64",
+                  "description": "File size in bytes. Maximum allowed size is 104857600 bytes (100MB)."
+                },
+                "content_hash": {
+                  "type": "string",
+                  "maxLength": 64,
+                  "nullable": true,
+                  "description": "SHA-256 fingerprint (64-character hexadecimal string) used for content deduplication within the same business. Files with identical content_hash skip redundant processing (e.g., \"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\")."
+                },
+                "status": {
+                  "type": "string",
+                  "enum": [
+                    "pending",
+                    "scanning",
+                    "scanned",
+                    "uploaded",
+                    "infected",
+                    "failed",
+                    "linked",
+                    "deleted"
+                  ],
+                  "description": "Current processing status of the file. **pending**: Upload received, virus scan queued. **scanning**: Virus scan in progress. **scanned**: Virus scan passed, awaiting S3 upload. **uploaded**: S3 upload complete, thumbnails generated if applicable. **infected**: Malware detected, file marked for deletion. **failed**: Processing error occurred (scan or upload failure). **linked**: File has active entity relations. **deleted**: Soft deleted. The file's S3 objects (original and thumbnails) are removed immediately; the record is retained as soft-deleted and excluded from all reads."
+                },
+                "metadata": {
+                  "type": "object",
+                  "nullable": true,
+                  "description": "Optional JSON object containing arbitrary key-value pairs for additional file metadata (e.g., {\"source\": \"chat\", \"uploaded_by_name\": \"John Doe\"})."
+                },
+                "url": {
+                  "type": "string",
+                  "format": "uri",
+                  "nullable": true,
+                  "readOnly": true,
+                  "description": "Pre-signed S3 URL for downloading the original file. Available when status is 'uploaded' or 'linked'. Null for pending/failed files (e.g., \"https://s3.amazonaws.com/files-bucket/path/to/original?signature=...\")."
+                },
+                "thumbnail_url": {
+                  "type": "string",
+                  "format": "uri",
+                  "nullable": true,
+                  "readOnly": true,
+                  "description": "Pre-signed S3 URL for the 400x400 pixel thumbnail. Available for images and PDFs after successful upload. Null for non-image files or pending uploads (e.g., \"https://s3.amazonaws.com/files-bucket/path/to/thumb_400.jpg?signature=...\")."
+                },
+                "thumbnail_small_url": {
+                  "type": "string",
+                  "format": "uri",
+                  "nullable": true,
+                  "readOnly": true,
+                  "description": "Pre-signed S3 URL for the 150x150 pixel thumbnail. Available for images and PDFs after successful upload. Null for non-image files or pending uploads (e.g., \"https://s3.amazonaws.com/files-bucket/path/to/thumb_150.jpg?signature=...\")."
+                },
+                "created_by": {
+                  "type": "string",
+                  "enum": [
+                    "staff",
+                    "client"
+                  ],
+                  "readOnly": true,
+                  "description": "Type of actor who created this file. **staff**: Uploaded by a staff member. **client**: Uploaded by a client."
+                },
+                "created_by_uid": {
+                  "type": "string",
+                  "readOnly": true,
+                  "description": "Unique identifier of the staff member or client who uploaded this file (e.g., \"staff_789\", \"client_456\")."
+                },
+                "created_at": {
+                  "type": "string",
+                  "format": "date-time",
+                  "readOnly": true,
+                  "description": "Timestamp when the file record was created, in ISO 8601 format (e.g., \"2026-01-27T10:30:00Z\")."
+                },
+                "updated_at": {
+                  "type": "string",
+                  "format": "date-time",
+                  "readOnly": true,
+                  "description": "Timestamp when the file record was last updated, in ISO 8601 format (e.g., \"2026-01-27T11:00:00Z\")."
+                },
+                "deleted_at": {
+                  "type": "string",
+                  "format": "date-time",
+                  "nullable": true,
+                  "readOnly": true,
+                  "description": "Timestamp when the file was soft deleted, in ISO 8601 format (e.g., \"2026-01-27T12:00:00Z\"). Null if not deleted. On deletion the file's S3 objects (including thumbnails) are removed immediately; the record is retained as soft-deleted."
+                }
+              },
+              "required": [
+                "uid",
+                "business_uid",
+                "name",
+                "content_type",
+                "size_bytes",
+                "status",
+                "created_by",
+                "created_by_uid",
+                "created_at",
+                "updated_at"
+              ],
+              "example": {
+                "uid": "file_123abc456def",
+                "business_uid": "biz_789xyz",
+                "name": "invoice_2026_Q1.pdf",
+                "content_type": "application/pdf",
+                "size_bytes": 2048576,
+                "content_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "status": "uploaded",
+                "metadata": {
+                  "source": "chat",
+                  "conversation_id": "conv_123"
+                },
+                "url": "https://s3.amazonaws.com/files-bucket/biz_789xyz/2026/01/27/file_123abc456def/original?signature=abc123...",
+                "thumbnail_url": "https://s3.amazonaws.com/files-bucket/biz_789xyz/2026/01/27/file_123abc456def/thumb_400.jpg?signature=def456...",
+                "thumbnail_small_url": "https://s3.amazonaws.com/files-bucket/biz_789xyz/2026/01/27/file_123abc456def/thumb_150.jpg?signature=ghi789...",
+                "created_by": "staff",
+                "created_by_uid": "staff_456xyz",
+                "created_at": "2026-01-27T10:30:00Z",
+                "updated_at": "2026-01-27T10:30:45Z",
+                "deleted_at": null
+              }
+            }
+          },
+          "pagination": {
+            "type": "object",
+            "properties": {
+              "page": {
+                "type": "integer"
+              },
+              "per_page": {
+                "type": "integer"
+              },
+              "total": {
+                "type": "integer"
+              },
+              "total_pages": {
+                "type": "integer"
+              }
+            }
+          }
+        },
+        "required": [
+          "files"
+        ]
+      },
+      "CreateFileRelationRequest": {
+        "type": "object",
+        "properties": {
+          "file_uid": {
+            "type": "string",
+            "description": "Unique identifier of the file to link (e.g., \"file_123abc\"). Must reference an existing file in a usable state ('scanned', 'uploaded', or 'linked')."
+          },
+          "entity_type": {
+            "type": "string",
+            "enum": [
+              "message",
+              "invoice",
+              "payment",
+              "appointment",
+              "estimate"
+            ],
+            "description": "Type of entity the file is linked to (e.g., \"message\", \"invoice\")."
+          },
+          "entity_uid": {
+            "type": "string",
+            "description": "Unique identifier of the entity the file is linked to (e.g., \"inv_123abc\")."
+          },
+          "client_uid": {
+            "type": "string",
+            "description": "Optional client UID to associate with the relation (e.g., \"client_789abc\"). Ignored for Client tokens, where it is derived from the token."
+          }
+        },
+        "required": [
+          "file_uid",
+          "entity_type",
+          "entity_uid"
+        ]
+      },
+      "FileRelationsResponse": {
+        "type": "object",
+        "properties": {
+          "file_relations": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "description": "Represents a relationship between a file and a business entity (e.g., invoice, message, appointment). This allows files to be attached to various entities across the platform. When a file has at least one active relation, its status becomes 'linked' and it is protected from cleanup jobs.",
+              "properties": {
+                "uid": {
+                  "type": "string",
+                  "readOnly": true,
+                  "description": "Unique identifier for the file-entity relation record (e.g., \"rel_123abc\")."
+                },
+                "file_uid": {
+                  "type": "string",
+                  "description": "Unique identifier of the file being linked (e.g., \"file_456def\"). Must reference an existing file with status 'scanned', 'uploaded', or 'linked'."
+                },
+                "entity_type": {
+                  "type": "string",
+                  "enum": [
+                    "message",
+                    "invoice",
+                    "payment",
+                    "appointment",
+                    "estimate"
+                  ],
+                  "description": "Type of entity the file is attached to. **message**: Email message. **invoice**: Invoice document. **payment**: Payment record. **appointment**: Scheduled appointment. **estimate**: Estimate/quote document."
+                },
+                "entity_uid": {
+                  "type": "string",
+                  "description": "Unique identifier of the entity the file is attached to (e.g., \"inv_789xyz\" for an invoice, \"msg_123abc\" for a message)."
+                },
+                "business_uid": {
+                  "type": "string",
+                  "readOnly": true,
+                  "description": "Unique identifier of the business that owns both the file and the entity (e.g., \"biz_456xyz\"). Inherited from the file record."
+                },
+                "client_uid": {
+                  "type": "string",
+                  "nullable": true,
+                  "description": "Unique identifier of the client associated with this relation, if applicable (e.g., \"client_789abc\"). Used for client-specific files like uploaded documents or images. Null for business-level files."
+                },
+                "created_at": {
+                  "type": "string",
+                  "format": "date-time",
+                  "readOnly": true,
+                  "description": "Timestamp when the relation was created, in ISO 8601 format (e.g., \"2026-01-27T10:35:00Z\")."
+                },
+                "updated_at": {
+                  "type": "string",
+                  "format": "date-time",
+                  "readOnly": true,
+                  "description": "Timestamp when the relation was last updated, in ISO 8601 format (e.g., \"2026-01-27T10:35:30Z\")."
+                },
+                "deleted_at": {
+                  "type": "string",
+                  "format": "date-time",
+                  "nullable": true,
+                  "readOnly": true,
+                  "description": "Timestamp when the relation was soft deleted, in ISO 8601 format (e.g., \"2026-01-27T12:00:00Z\"). Null if the relation is still active. When all relations for a file are deleted, the file may become eligible for cleanup."
+                },
+                "file": {
+                  "type": "object",
+                  "readOnly": true,
+                  "nullable": true,
+                  "description": "Details of the linked file, included when relations are fetched by entity. Omitted on relation creation.",
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "description": "Original filename including extension (e.g., \"invoice_2026_Q1.pdf\")."
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "pending",
+                        "scanning",
+                        "scanned",
+                        "uploaded",
+                        "infected",
+                        "failed",
+                        "linked",
+                        "deleted"
+                      ],
+                      "description": "Current processing status of the linked file."
+                    },
+                    "content_type": {
+                      "type": "string",
+                      "description": "MIME type of the linked file (e.g., \"application/pdf\", \"image/jpeg\")."
+                    },
+                    "size": {
+                      "type": "integer",
+                      "format": "int64",
+                      "description": "File size in bytes (e.g., 2048576)."
+                    },
+                    "url": {
+                      "type": "string",
+                      "format": "uri",
+                      "nullable": true,
+                      "description": "Pre-signed S3 URL for downloading the original file. Null for pending/infected files."
+                    },
+                    "thumbnail_url": {
+                      "type": "string",
+                      "format": "uri",
+                      "nullable": true,
+                      "description": "Pre-signed S3 URL for the 400x400 pixel thumbnail. Null for non-image files or pending uploads."
+                    },
+                    "thumbnail_small_url": {
+                      "type": "string",
+                      "format": "uri",
+                      "nullable": true,
+                      "description": "Pre-signed S3 URL for the 150x150 pixel thumbnail. Null for non-image files or pending uploads."
+                    },
+                    "metadata": {
+                      "type": "object",
+                      "nullable": true,
+                      "description": "Optional JSON object containing arbitrary key-value pairs for additional file metadata."
+                    },
+                    "created_at": {
+                      "type": "string",
+                      "format": "date-time",
+                      "description": "Timestamp when the file record was created, in ISO 8601 format."
+                    },
+                    "updated_at": {
+                      "type": "string",
+                      "format": "date-time",
+                      "description": "Timestamp when the file record was last updated, in ISO 8601 format."
+                    }
+                  }
+                }
+              },
+              "required": [
+                "uid",
+                "file_uid",
+                "entity_type",
+                "entity_uid",
+                "business_uid",
+                "created_at",
+                "updated_at"
+              ],
+              "example": {
+                "uid": "rel_abc123def456",
+                "file_uid": "file_789xyz",
+                "entity_type": "invoice",
+                "entity_uid": "inv_456abc",
+                "business_uid": "biz_123xyz",
+                "client_uid": "client_789def",
+                "created_at": "2026-01-27T10:35:00Z",
+                "updated_at": "2026-01-27T10:35:00Z",
+                "deleted_at": null,
+                "file": {
+                  "name": "invoice_2026_Q1.pdf",
+                  "status": "linked",
+                  "content_type": "application/pdf",
+                  "size": 2048576,
+                  "url": "https://s3.amazonaws.com/files-bucket/biz_123xyz/2026/01/27/file_789xyz/original?signature=abc123...",
+                  "thumbnail_url": "https://s3.amazonaws.com/files-bucket/biz_123xyz/2026/01/27/file_789xyz/thumb_400.jpg?signature=def456...",
+                  "thumbnail_small_url": "https://s3.amazonaws.com/files-bucket/biz_123xyz/2026/01/27/file_789xyz/thumb_150.jpg?signature=ghi789...",
+                  "metadata": {
+                    "source": "chat"
+                  },
+                  "created_at": "2026-01-27T10:30:00Z",
+                  "updated_at": "2026-01-27T10:30:45Z"
+                }
+              }
+            },
+            "description": "Array of file relations, each including the linked file's details"
+          }
+        },
+        "required": [
+          "file_relations"
+        ]
+      },
+      "DeleteFileRelationsResponse": {
+        "type": "object",
+        "properties": {
+          "deleted_count": {
+            "type": "integer",
+            "description": "Number of file relations that were soft deleted (e.g., 3)."
+          }
+        },
+        "required": [
+          "deleted_count"
+        ]
+      },
+      "ErrorResponse": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "errors": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "field": {
+                  "type": "string",
+                  "description": "The name of the field that had an error (for validation errors) (e.g., \"name\", \"file\")."
+                },
+                "code": {
+                  "type": "string",
+                  "description": "The error code (for validation errors) (e.g., \"FILE_REQUIRED\", \"VALIDATION_ERROR\")."
+                },
+                "description": {
+                  "type": "string",
+                  "description": "A description of the error (for validation errors) (e.g., \"File is required\")."
+                }
+              }
+            }
+          }
+        }
+      },
       "DocuformsSearchResponse": {
         "type": "object",
         "description": "Response for docuforms (documents/forms) search.",
@@ -855,7 +2811,7 @@
           }
         }
       },
-      "ErrorResponse": {
+      "ErrorResponse_legacy_documents": {
         "type": "object",
         "properties": {
           "success": {
@@ -874,6 +2830,10 @@
         "scheme": "bearer",
         "bearerFormat": "JWT",
         "description": "Provide a valid bearer token in the Authorization header. Example: 'Authorization: Bearer {app_token}'"
+      },
+      "Files": {
+        "type": "http",
+        "scheme": "bearer"
       }
     }
   },

--- a/mcp_swagger/clients.json
+++ b/mcp_swagger/clients.json
@@ -4252,12 +4252,110 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/clients/clientSettings.json"
+                          "type": "object",
+                          "properties": {
+                            "client_uid": {
+                              "type": "string",
+                              "readOnly": true,
+                              "description": "The unique identifier (UID) of the client."
+                            },
+                            "client_id": {
+                              "type": [
+                                "integer",
+                                "null"
+                              ],
+                              "readOnly": true,
+                              "description": "The numeric client ID (internal identifier)."
+                            },
+                            "opt_out_transactional_sms": {
+                              "type": "boolean",
+                              "description": "The opt out status of the client for transactional SMS messages."
+                            },
+                            "preferred_language": {
+                              "type": "string",
+                              "description": "The client's preferred language code (e.g., \"en\", \"he\", \"es\"). Can be null if not set."
+                            },
+                            "effective_language": {
+                              "type": "string",
+                              "readOnly": true,
+                              "description": "The effective language used for the client, taking into account business defaults if preferred_language is not set."
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "readOnly": true,
+                              "description": "The date and time when the client settings were created, in ISO 8601 format."
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "readOnly": true,
+                              "description": "The date and time when the client settings were last updated, in ISO 8601 format."
+                            }
+                          },
+                          "required": [
+                            "client_uid",
+                            "created_at",
+                            "updated_at"
+                          ],
+                          "example": {
+                            "client_uid": "d290f1ee-6c54-4b01-90e6-d701748f0851",
+                            "client_id": 12345678,
+                            "opt_out_transactional_sms": true,
+                            "preferred_language": "en",
+                            "effective_language": "en",
+                            "created_at": "2021-07-20T14:00:00Z",
+                            "updated_at": "2021-07-20T14:00:00Z"
+                          },
+                          "description": "Client-level settings such as communication preferences and opt-outs."
                         }
                       }
                     }
@@ -4318,12 +4416,110 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/clients/clientSettings.json"
+                          "type": "object",
+                          "properties": {
+                            "client_uid": {
+                              "type": "string",
+                              "readOnly": true,
+                              "description": "The unique identifier (UID) of the client."
+                            },
+                            "client_id": {
+                              "type": [
+                                "integer",
+                                "null"
+                              ],
+                              "readOnly": true,
+                              "description": "The numeric client ID (internal identifier)."
+                            },
+                            "opt_out_transactional_sms": {
+                              "type": "boolean",
+                              "description": "The opt out status of the client for transactional SMS messages."
+                            },
+                            "preferred_language": {
+                              "type": "string",
+                              "description": "The client's preferred language code (e.g., \"en\", \"he\", \"es\"). Can be null if not set."
+                            },
+                            "effective_language": {
+                              "type": "string",
+                              "readOnly": true,
+                              "description": "The effective language used for the client, taking into account business defaults if preferred_language is not set."
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "readOnly": true,
+                              "description": "The date and time when the client settings were created, in ISO 8601 format."
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "readOnly": true,
+                              "description": "The date and time when the client settings were last updated, in ISO 8601 format."
+                            }
+                          },
+                          "required": [
+                            "client_uid",
+                            "created_at",
+                            "updated_at"
+                          ],
+                          "example": {
+                            "client_uid": "d290f1ee-6c54-4b01-90e6-d701748f0851",
+                            "client_id": 12345678,
+                            "opt_out_transactional_sms": true,
+                            "preferred_language": "en",
+                            "effective_language": "en",
+                            "created_at": "2021-07-20T14:00:00Z",
+                            "updated_at": "2021-07-20T14:00:00Z"
+                          },
+                          "description": "Client-level settings such as communication preferences and opt-outs."
                         }
                       }
                     }
@@ -4377,7 +4573,50 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
@@ -4398,8 +4637,62 @@
                                     "description": "Indicates if the operation succeeded for this client"
                                   },
                                   "data": {
-                                    "description": "Client settings data (only present when success is true)",
-                                    "$ref": "https://vcita.github.io/developers-hub/entities/clients/clientSettings.json"
+                                    "type": "object",
+                                    "properties": {
+                                      "client_uid": {
+                                        "type": "string",
+                                        "readOnly": true,
+                                        "description": "The unique identifier (UID) of the client."
+                                      },
+                                      "client_id": {
+                                        "type": [
+                                          "integer",
+                                          "null"
+                                        ],
+                                        "readOnly": true,
+                                        "description": "The numeric client ID (internal identifier)."
+                                      },
+                                      "opt_out_transactional_sms": {
+                                        "type": "boolean",
+                                        "description": "The opt out status of the client for transactional SMS messages."
+                                      },
+                                      "preferred_language": {
+                                        "type": "string",
+                                        "description": "The client's preferred language code (e.g., \"en\", \"he\", \"es\"). Can be null if not set."
+                                      },
+                                      "effective_language": {
+                                        "type": "string",
+                                        "readOnly": true,
+                                        "description": "The effective language used for the client, taking into account business defaults if preferred_language is not set."
+                                      },
+                                      "created_at": {
+                                        "type": "string",
+                                        "format": "date-time",
+                                        "readOnly": true,
+                                        "description": "The date and time when the client settings were created, in ISO 8601 format."
+                                      },
+                                      "updated_at": {
+                                        "type": "string",
+                                        "format": "date-time",
+                                        "readOnly": true,
+                                        "description": "The date and time when the client settings were last updated, in ISO 8601 format."
+                                      }
+                                    },
+                                    "required": [
+                                      "client_uid",
+                                      "created_at",
+                                      "updated_at"
+                                    ],
+                                    "example": {
+                                      "client_uid": "d290f1ee-6c54-4b01-90e6-d701748f0851",
+                                      "client_id": 12345678,
+                                      "opt_out_transactional_sms": true,
+                                      "preferred_language": "en",
+                                      "effective_language": "en",
+                                      "created_at": "2021-07-20T14:00:00Z",
+                                      "updated_at": "2021-07-20T14:00:00Z"
+                                    },
+                                    "description": "Client settings data (only present when success is true)"
                                   },
                                   "errors": {
                                     "type": "array",
@@ -4605,7 +4898,50 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
@@ -4730,12 +5066,186 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/clients/client_note.json"
+                          "$schema": "https://json-schema.org/draft/2020-12/schema",
+                          "title": "ClientNote",
+                          "description": "Represents a note belonging to a client matter. Notes can optionally be associated with other entities like documents, payments, or meetings through entity_uid and entity_type fields.",
+                          "type": "object",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "description": "Unique identifier for the note record"
+                            },
+                            "business_uid": {
+                              "type": "string",
+                              "description": "Unique identifier of the business that owns this note"
+                            },
+                            "matter_uid": {
+                              "type": "string",
+                              "description": "Unique identifier of the client matter this note belongs to"
+                            },
+                            "content": {
+                              "type": "string",
+                              "description": "The HTML or text content of the note. May contain HTML markup for rich text formatting (e.g., \"<div>some note here</div>\"). Can be empty. At least one of title or content must be provided."
+                            },
+                            "title": {
+                              "type": "string",
+                              "description": "Title for the note. Provides a brief heading or subject line for the note content. At least one of title or content must be provided."
+                            },
+                            "staff_uid": {
+                              "type": "string",
+                              "description": "Unique identifier of the staff member who created this note"
+                            },
+                            "entity_uid": {
+                              "type": "string",
+                              "description": "Unique identifier of the entity this note is associated with (e.g., document, payment, meeting). Null if the note is not linked to any specific entity."
+                            },
+                            "entity_type": {
+                              "type": "string",
+                              "enum": [
+                                "document",
+                                "payment",
+                                "meeting"
+                              ],
+                              "description": "Type of entity this note is associated with. Possible values: document (note linked to a document), payment (note linked to a payment), meeting (note linked to a meeting). Null if the note is not linked to any specific entity."
+                            },
+                            "entity_title": {
+                              "type": "string",
+                              "description": "Title of the associated entity. Provides the display name of the linked document, payment, or meeting without requiring an additional API call. Null if the note is not linked to any specific entity."
+                            },
+                            "summary": {
+                              "type": "string",
+                              "description": "AI-generated summary of the note content. Null if summary has not been generated yet (status: null, in_progress, skipped, or failed). Present and up-to-date when status is generated."
+                            },
+                            "summary_status": {
+                              "type": "string",
+                              "enum": [
+                                "in_progress",
+                                "generated",
+                                "skipped",
+                                "failed"
+                              ],
+                              "description": "Status of the AI summary generation process. Possible values: in_progress (summary is currently being generated, wait before retrying), generated (summary completed successfully and is up-to-date), skipped (summary generation was not performed - user requested skip, content too short, or AI rejected), failed (error during generation). Null indicates a legacy note created before this feature or a note that hasn't been evaluated for summary generation yet."
+                            },
+                            "capabilities": {
+                              "type": "object",
+                              "description": "The requesting staff member's capabilities on this note, computed server-side. Output-only; clients should render UI (read-only state, hidden actions) from these flags rather than re-deriving permission rules. Extensible — additional action capabilities may be added over time without breaking existing clients.",
+                              "properties": {
+                                "update": {
+                                  "type": "boolean",
+                                  "description": "Whether the requesting staff member may edit this note. When false, an update request is rejected with HTTP 403. Derived from the note edit rules: note author, organization-wide activity access, marketing permissions, or staff on the related entity."
+                                },
+                                "delete": {
+                                  "type": "boolean",
+                                  "description": "Whether the requesting staff member may delete this note. When false, a delete request is rejected with HTTP 403. Uses the same rules as update."
+                                }
+                              }
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "description": "The date and time when the note was created, in ISO 8601 format"
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "description": "The date and time when the note was last updated, in ISO 8601 format"
+                            }
+                          },
+                          "readOnly": [
+                            "uid",
+                            "business_uid",
+                            "staff_uid",
+                            "entity_uid",
+                            "entity_type",
+                            "entity_title",
+                            "summary",
+                            "summary_status",
+                            "capabilities",
+                            "created_at",
+                            "updated_at"
+                          ],
+                          "required": [
+                            "matter_uid"
+                          ],
+                          "anyOf": [
+                            {
+                              "required": [
+                                "title"
+                              ]
+                            },
+                            {
+                              "required": [
+                                "content"
+                              ]
+                            }
+                          ],
+                          "example": {
+                            "uid": "197om8659kkgq6pm",
+                            "business_uid": "d290f1ee26c54",
+                            "matter_uid": "you37bj7mnbv372g",
+                            "content": "<div>some note here</div>",
+                            "title": "Follow-up discussion",
+                            "staff_uid": "ctxr1h6y69d46vaj",
+                            "entity_uid": "25p7fdsyg887ttn9",
+                            "entity_type": "meeting",
+                            "entity_title": "Quick one",
+                            "summary": "Brief discussion about scheduling matters",
+                            "summary_status": "generated",
+                            "capabilities": {
+                              "update": true,
+                              "delete": true
+                            },
+                            "created_at": "2026-04-01T07:00:23Z",
+                            "updated_at": "2026-04-01T07:00:23Z"
+                          }
                         }
                       }
                     }
@@ -4838,12 +5348,186 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/clients/client_note.json"
+                          "$schema": "https://json-schema.org/draft/2020-12/schema",
+                          "title": "ClientNote",
+                          "description": "Represents a note belonging to a client matter. Notes can optionally be associated with other entities like documents, payments, or meetings through entity_uid and entity_type fields.",
+                          "type": "object",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "description": "Unique identifier for the note record"
+                            },
+                            "business_uid": {
+                              "type": "string",
+                              "description": "Unique identifier of the business that owns this note"
+                            },
+                            "matter_uid": {
+                              "type": "string",
+                              "description": "Unique identifier of the client matter this note belongs to"
+                            },
+                            "content": {
+                              "type": "string",
+                              "description": "The HTML or text content of the note. May contain HTML markup for rich text formatting (e.g., \"<div>some note here</div>\"). Can be empty. At least one of title or content must be provided."
+                            },
+                            "title": {
+                              "type": "string",
+                              "description": "Title for the note. Provides a brief heading or subject line for the note content. At least one of title or content must be provided."
+                            },
+                            "staff_uid": {
+                              "type": "string",
+                              "description": "Unique identifier of the staff member who created this note"
+                            },
+                            "entity_uid": {
+                              "type": "string",
+                              "description": "Unique identifier of the entity this note is associated with (e.g., document, payment, meeting). Null if the note is not linked to any specific entity."
+                            },
+                            "entity_type": {
+                              "type": "string",
+                              "enum": [
+                                "document",
+                                "payment",
+                                "meeting"
+                              ],
+                              "description": "Type of entity this note is associated with. Possible values: document (note linked to a document), payment (note linked to a payment), meeting (note linked to a meeting). Null if the note is not linked to any specific entity."
+                            },
+                            "entity_title": {
+                              "type": "string",
+                              "description": "Title of the associated entity. Provides the display name of the linked document, payment, or meeting without requiring an additional API call. Null if the note is not linked to any specific entity."
+                            },
+                            "summary": {
+                              "type": "string",
+                              "description": "AI-generated summary of the note content. Null if summary has not been generated yet (status: null, in_progress, skipped, or failed). Present and up-to-date when status is generated."
+                            },
+                            "summary_status": {
+                              "type": "string",
+                              "enum": [
+                                "in_progress",
+                                "generated",
+                                "skipped",
+                                "failed"
+                              ],
+                              "description": "Status of the AI summary generation process. Possible values: in_progress (summary is currently being generated, wait before retrying), generated (summary completed successfully and is up-to-date), skipped (summary generation was not performed - user requested skip, content too short, or AI rejected), failed (error during generation). Null indicates a legacy note created before this feature or a note that hasn't been evaluated for summary generation yet."
+                            },
+                            "capabilities": {
+                              "type": "object",
+                              "description": "The requesting staff member's capabilities on this note, computed server-side. Output-only; clients should render UI (read-only state, hidden actions) from these flags rather than re-deriving permission rules. Extensible — additional action capabilities may be added over time without breaking existing clients.",
+                              "properties": {
+                                "update": {
+                                  "type": "boolean",
+                                  "description": "Whether the requesting staff member may edit this note. When false, an update request is rejected with HTTP 403. Derived from the note edit rules: note author, organization-wide activity access, marketing permissions, or staff on the related entity."
+                                },
+                                "delete": {
+                                  "type": "boolean",
+                                  "description": "Whether the requesting staff member may delete this note. When false, a delete request is rejected with HTTP 403. Uses the same rules as update."
+                                }
+                              }
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "description": "The date and time when the note was created, in ISO 8601 format"
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "description": "The date and time when the note was last updated, in ISO 8601 format"
+                            }
+                          },
+                          "readOnly": [
+                            "uid",
+                            "business_uid",
+                            "staff_uid",
+                            "entity_uid",
+                            "entity_type",
+                            "entity_title",
+                            "summary",
+                            "summary_status",
+                            "capabilities",
+                            "created_at",
+                            "updated_at"
+                          ],
+                          "required": [
+                            "matter_uid"
+                          ],
+                          "anyOf": [
+                            {
+                              "required": [
+                                "title"
+                              ]
+                            },
+                            {
+                              "required": [
+                                "content"
+                              ]
+                            }
+                          ],
+                          "example": {
+                            "uid": "197om8659kkgq6pm",
+                            "business_uid": "d290f1ee26c54",
+                            "matter_uid": "you37bj7mnbv372g",
+                            "content": "<div>some note here</div>",
+                            "title": "Follow-up discussion",
+                            "staff_uid": "ctxr1h6y69d46vaj",
+                            "entity_uid": "25p7fdsyg887ttn9",
+                            "entity_type": "meeting",
+                            "entity_title": "Quick one",
+                            "summary": "Brief discussion about scheduling matters",
+                            "summary_status": "generated",
+                            "capabilities": {
+                              "update": true,
+                              "delete": true
+                            },
+                            "created_at": "2026-04-01T07:00:23Z",
+                            "updated_at": "2026-04-01T07:00:23Z"
+                          }
                         }
                       }
                     }
@@ -4936,12 +5620,186 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/clients/client_note.json"
+                          "$schema": "https://json-schema.org/draft/2020-12/schema",
+                          "title": "ClientNote",
+                          "description": "Represents a note belonging to a client matter. Notes can optionally be associated with other entities like documents, payments, or meetings through entity_uid and entity_type fields.",
+                          "type": "object",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "description": "Unique identifier for the note record"
+                            },
+                            "business_uid": {
+                              "type": "string",
+                              "description": "Unique identifier of the business that owns this note"
+                            },
+                            "matter_uid": {
+                              "type": "string",
+                              "description": "Unique identifier of the client matter this note belongs to"
+                            },
+                            "content": {
+                              "type": "string",
+                              "description": "The HTML or text content of the note. May contain HTML markup for rich text formatting (e.g., \"<div>some note here</div>\"). Can be empty. At least one of title or content must be provided."
+                            },
+                            "title": {
+                              "type": "string",
+                              "description": "Title for the note. Provides a brief heading or subject line for the note content. At least one of title or content must be provided."
+                            },
+                            "staff_uid": {
+                              "type": "string",
+                              "description": "Unique identifier of the staff member who created this note"
+                            },
+                            "entity_uid": {
+                              "type": "string",
+                              "description": "Unique identifier of the entity this note is associated with (e.g., document, payment, meeting). Null if the note is not linked to any specific entity."
+                            },
+                            "entity_type": {
+                              "type": "string",
+                              "enum": [
+                                "document",
+                                "payment",
+                                "meeting"
+                              ],
+                              "description": "Type of entity this note is associated with. Possible values: document (note linked to a document), payment (note linked to a payment), meeting (note linked to a meeting). Null if the note is not linked to any specific entity."
+                            },
+                            "entity_title": {
+                              "type": "string",
+                              "description": "Title of the associated entity. Provides the display name of the linked document, payment, or meeting without requiring an additional API call. Null if the note is not linked to any specific entity."
+                            },
+                            "summary": {
+                              "type": "string",
+                              "description": "AI-generated summary of the note content. Null if summary has not been generated yet (status: null, in_progress, skipped, or failed). Present and up-to-date when status is generated."
+                            },
+                            "summary_status": {
+                              "type": "string",
+                              "enum": [
+                                "in_progress",
+                                "generated",
+                                "skipped",
+                                "failed"
+                              ],
+                              "description": "Status of the AI summary generation process. Possible values: in_progress (summary is currently being generated, wait before retrying), generated (summary completed successfully and is up-to-date), skipped (summary generation was not performed - user requested skip, content too short, or AI rejected), failed (error during generation). Null indicates a legacy note created before this feature or a note that hasn't been evaluated for summary generation yet."
+                            },
+                            "capabilities": {
+                              "type": "object",
+                              "description": "The requesting staff member's capabilities on this note, computed server-side. Output-only; clients should render UI (read-only state, hidden actions) from these flags rather than re-deriving permission rules. Extensible — additional action capabilities may be added over time without breaking existing clients.",
+                              "properties": {
+                                "update": {
+                                  "type": "boolean",
+                                  "description": "Whether the requesting staff member may edit this note. When false, an update request is rejected with HTTP 403. Derived from the note edit rules: note author, organization-wide activity access, marketing permissions, or staff on the related entity."
+                                },
+                                "delete": {
+                                  "type": "boolean",
+                                  "description": "Whether the requesting staff member may delete this note. When false, a delete request is rejected with HTTP 403. Uses the same rules as update."
+                                }
+                              }
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "description": "The date and time when the note was created, in ISO 8601 format"
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "description": "The date and time when the note was last updated, in ISO 8601 format"
+                            }
+                          },
+                          "readOnly": [
+                            "uid",
+                            "business_uid",
+                            "staff_uid",
+                            "entity_uid",
+                            "entity_type",
+                            "entity_title",
+                            "summary",
+                            "summary_status",
+                            "capabilities",
+                            "created_at",
+                            "updated_at"
+                          ],
+                          "required": [
+                            "matter_uid"
+                          ],
+                          "anyOf": [
+                            {
+                              "required": [
+                                "title"
+                              ]
+                            },
+                            {
+                              "required": [
+                                "content"
+                              ]
+                            }
+                          ],
+                          "example": {
+                            "uid": "197om8659kkgq6pm",
+                            "business_uid": "d290f1ee26c54",
+                            "matter_uid": "you37bj7mnbv372g",
+                            "content": "<div>some note here</div>",
+                            "title": "Follow-up discussion",
+                            "staff_uid": "ctxr1h6y69d46vaj",
+                            "entity_uid": "25p7fdsyg887ttn9",
+                            "entity_type": "meeting",
+                            "entity_title": "Quick one",
+                            "summary": "Brief discussion about scheduling matters",
+                            "summary_status": "generated",
+                            "capabilities": {
+                              "update": true,
+                              "delete": true
+                            },
+                            "created_at": "2026-04-01T07:00:23Z",
+                            "updated_at": "2026-04-01T07:00:23Z"
+                          }
                         }
                       }
                     }
@@ -5032,7 +5890,50 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     }
                   ]
                 }
@@ -8618,7 +9519,62 @@
             "description": "List of Client Settings",
             "type": "array",
             "items": {
-              "$ref": "https://vcita.github.io/developers-hub/entities/clients/clientSettings.json"
+              "type": "object",
+              "properties": {
+                "client_uid": {
+                  "type": "string",
+                  "readOnly": true,
+                  "description": "The unique identifier (UID) of the client."
+                },
+                "client_id": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ],
+                  "readOnly": true,
+                  "description": "The numeric client ID (internal identifier)."
+                },
+                "opt_out_transactional_sms": {
+                  "type": "boolean",
+                  "description": "The opt out status of the client for transactional SMS messages."
+                },
+                "preferred_language": {
+                  "type": "string",
+                  "description": "The client's preferred language code (e.g., \"en\", \"he\", \"es\"). Can be null if not set."
+                },
+                "effective_language": {
+                  "type": "string",
+                  "readOnly": true,
+                  "description": "The effective language used for the client, taking into account business defaults if preferred_language is not set."
+                },
+                "created_at": {
+                  "type": "string",
+                  "format": "date-time",
+                  "readOnly": true,
+                  "description": "The date and time when the client settings were created, in ISO 8601 format."
+                },
+                "updated_at": {
+                  "type": "string",
+                  "format": "date-time",
+                  "readOnly": true,
+                  "description": "The date and time when the client settings were last updated, in ISO 8601 format."
+                }
+              },
+              "required": [
+                "client_uid",
+                "created_at",
+                "updated_at"
+              ],
+              "example": {
+                "client_uid": "d290f1ee-6c54-4b01-90e6-d701748f0851",
+                "client_id": 12345678,
+                "opt_out_transactional_sms": true,
+                "preferred_language": "en",
+                "effective_language": "en",
+                "created_at": "2021-07-20T14:00:00Z",
+                "updated_at": "2021-07-20T14:00:00Z"
+              },
+              "description": "Client-level settings such as communication preferences and opt-outs."
             }
           }
         }
@@ -8731,7 +9687,138 @@
             "type": "array",
             "description": "List of client notes",
             "items": {
-              "$ref": "https://vcita.github.io/developers-hub/entities/clients/client_note.json"
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "title": "ClientNote",
+              "description": "Represents a note belonging to a client matter. Notes can optionally be associated with other entities like documents, payments, or meetings through entity_uid and entity_type fields.",
+              "type": "object",
+              "properties": {
+                "uid": {
+                  "type": "string",
+                  "description": "Unique identifier for the note record"
+                },
+                "business_uid": {
+                  "type": "string",
+                  "description": "Unique identifier of the business that owns this note"
+                },
+                "matter_uid": {
+                  "type": "string",
+                  "description": "Unique identifier of the client matter this note belongs to"
+                },
+                "content": {
+                  "type": "string",
+                  "description": "The HTML or text content of the note. May contain HTML markup for rich text formatting (e.g., \"<div>some note here</div>\"). Can be empty. At least one of title or content must be provided."
+                },
+                "title": {
+                  "type": "string",
+                  "description": "Title for the note. Provides a brief heading or subject line for the note content. At least one of title or content must be provided."
+                },
+                "staff_uid": {
+                  "type": "string",
+                  "description": "Unique identifier of the staff member who created this note"
+                },
+                "entity_uid": {
+                  "type": "string",
+                  "description": "Unique identifier of the entity this note is associated with (e.g., document, payment, meeting). Null if the note is not linked to any specific entity."
+                },
+                "entity_type": {
+                  "type": "string",
+                  "enum": [
+                    "document",
+                    "payment",
+                    "meeting"
+                  ],
+                  "description": "Type of entity this note is associated with. Possible values: document (note linked to a document), payment (note linked to a payment), meeting (note linked to a meeting). Null if the note is not linked to any specific entity."
+                },
+                "entity_title": {
+                  "type": "string",
+                  "description": "Title of the associated entity. Provides the display name of the linked document, payment, or meeting without requiring an additional API call. Null if the note is not linked to any specific entity."
+                },
+                "summary": {
+                  "type": "string",
+                  "description": "AI-generated summary of the note content. Null if summary has not been generated yet (status: null, in_progress, skipped, or failed). Present and up-to-date when status is generated."
+                },
+                "summary_status": {
+                  "type": "string",
+                  "enum": [
+                    "in_progress",
+                    "generated",
+                    "skipped",
+                    "failed"
+                  ],
+                  "description": "Status of the AI summary generation process. Possible values: in_progress (summary is currently being generated, wait before retrying), generated (summary completed successfully and is up-to-date), skipped (summary generation was not performed - user requested skip, content too short, or AI rejected), failed (error during generation). Null indicates a legacy note created before this feature or a note that hasn't been evaluated for summary generation yet."
+                },
+                "capabilities": {
+                  "type": "object",
+                  "description": "The requesting staff member's capabilities on this note, computed server-side. Output-only; clients should render UI (read-only state, hidden actions) from these flags rather than re-deriving permission rules. Extensible — additional action capabilities may be added over time without breaking existing clients.",
+                  "properties": {
+                    "update": {
+                      "type": "boolean",
+                      "description": "Whether the requesting staff member may edit this note. When false, an update request is rejected with HTTP 403. Derived from the note edit rules: note author, organization-wide activity access, marketing permissions, or staff on the related entity."
+                    },
+                    "delete": {
+                      "type": "boolean",
+                      "description": "Whether the requesting staff member may delete this note. When false, a delete request is rejected with HTTP 403. Uses the same rules as update."
+                    }
+                  }
+                },
+                "created_at": {
+                  "type": "string",
+                  "format": "date-time",
+                  "description": "The date and time when the note was created, in ISO 8601 format"
+                },
+                "updated_at": {
+                  "type": "string",
+                  "format": "date-time",
+                  "description": "The date and time when the note was last updated, in ISO 8601 format"
+                }
+              },
+              "readOnly": [
+                "uid",
+                "business_uid",
+                "staff_uid",
+                "entity_uid",
+                "entity_type",
+                "entity_title",
+                "summary",
+                "summary_status",
+                "capabilities",
+                "created_at",
+                "updated_at"
+              ],
+              "required": [
+                "matter_uid"
+              ],
+              "anyOf": [
+                {
+                  "required": [
+                    "title"
+                  ]
+                },
+                {
+                  "required": [
+                    "content"
+                  ]
+                }
+              ],
+              "example": {
+                "uid": "197om8659kkgq6pm",
+                "business_uid": "d290f1ee26c54",
+                "matter_uid": "you37bj7mnbv372g",
+                "content": "<div>some note here</div>",
+                "title": "Follow-up discussion",
+                "staff_uid": "ctxr1h6y69d46vaj",
+                "entity_uid": "25p7fdsyg887ttn9",
+                "entity_type": "meeting",
+                "entity_title": "Quick one",
+                "summary": "Brief discussion about scheduling matters",
+                "summary_status": "generated",
+                "capabilities": {
+                  "update": true,
+                  "delete": true
+                },
+                "created_at": "2026-04-01T07:00:23Z",
+                "updated_at": "2026-04-01T07:00:23Z"
+              }
             }
           }
         }

--- a/mcp_swagger/communication.json
+++ b/mcp_swagger/communication.json
@@ -1562,7 +1562,50 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
@@ -1573,7 +1616,186 @@
                               "type": "array",
                               "description": "List of activity message records matching the query filters.",
                               "items": {
-                                "$ref": "https://vcita.github.io/developers-hub/entities/communication/activityMessage.json"
+                                "type": "object",
+                                "description": "Represents an activity message associated with a business-client interaction. Activity messages are created automatically by the system for various activity types (e.g., meetings, invoices, payments) or manually via the invite activity type. Each message captures the communication context including direction, channels, and activity-specific metadata.",
+                                "properties": {
+                                  "uid": {
+                                    "type": "string",
+                                    "readOnly": true,
+                                    "description": "Unique identifier for the activity message record."
+                                  },
+                                  "business_uid": {
+                                    "type": "string",
+                                    "readOnly": true,
+                                    "description": "Unique identifier of the business associated with this activity message."
+                                  },
+                                  "staff_uid": {
+                                    "type": "string",
+                                    "description": "Unique identifier of the staff member associated with this activity message."
+                                  },
+                                  "client_uid": {
+                                    "type": "string",
+                                    "description": "Unique identifier of the client this activity message is associated with."
+                                  },
+                                  "activity_type": {
+                                    "type": "string",
+                                    "enum": [
+                                      "meeting",
+                                      "appointment_series",
+                                      "invoice",
+                                      "estimate",
+                                      "payment",
+                                      "payment_status",
+                                      "payment_card",
+                                      "card_request",
+                                      "scheduled_payments_rule",
+                                      "payout",
+                                      "announcement",
+                                      "invite",
+                                      "event",
+                                      "event_series",
+                                      "event_instance",
+                                      "waitlist",
+                                      "linked_booking",
+                                      "client_booking_package",
+                                      "product_order",
+                                      "review",
+                                      "document",
+                                      "voice_call",
+                                      "assignment"
+                                    ],
+                                    "description": "The type of activity this message is associated with. Determines the category of the underlying business event (e.g., \"meeting\" for scheduled appointments, \"invoice\" for billing documents, \"invite\" for manual client invitations to schedule)."
+                                  },
+                                  "activity_action": {
+                                    "type": "string",
+                                    "description": "The specific action or status related to the activity type (e.g., \"scheduled\" for a meeting that was booked, \"created\" for a newly generated invoice). For \"invite\" activity_type, supported actions are \"schedule\", \"pay\", \"share_document\", and \"client_portal\". Values vary depending on the activity_type."
+                                  },
+                                  "direction": {
+                                    "type": "string",
+                                    "enum": [
+                                      "pivot_to_client",
+                                      "client_to_pivot",
+                                      "to_pivot",
+                                      "to_client"
+                                    ],
+                                    "description": "The direction of the activity message. Possible values: \"pivot_to_client\" — message sent from the business to the client; \"client_to_pivot\" — message sent from the client to the business; \"to_pivot\" — system notification delivered to the business side; \"to_client\" — system notification delivered to the client side."
+                                  },
+                                  "channels": {
+                                    "type": "array",
+                                    "description": "The communication channels through which the message was sent or should be sent.",
+                                    "items": {
+                                      "type": "string",
+                                      "enum": [
+                                        "email",
+                                        "sms"
+                                      ]
+                                    }
+                                  },
+                                  "message_text": {
+                                    "type": "object",
+                                    "description": "The textual content of the activity message.",
+                                    "properties": {
+                                      "body": {
+                                        "type": "string",
+                                        "description": "The main content of the message. For SMS messages, the maximum length is 550 characters. For email messages, the maximum length is 50,000 characters."
+                                      },
+                                      "subject": {
+                                        "type": "string",
+                                        "description": "A concise summary or title of the message content. For invite activity types, this is a user-provided subject. For other activity types, it is automatically derived from the activity (e.g., appointment title, invoice number)."
+                                      }
+                                    }
+                                  },
+                                  "cta_button_text": {
+                                    "type": "string",
+                                    "description": "The text displayed on the call-to-action button in the email message (e.g., \"Schedule now\", \"View Invoice\", \"View Appointment\"). Automatically derived for system-generated activity messages."
+                                  },
+                                  "link_url_params": {
+                                    "type": "object",
+                                    "description": "URL parameters appended to the action button link in emails or the SMS link. Useful for tracking campaign attribution (e.g., UTM parameters).",
+                                    "properties": {
+                                      "utm_source": {
+                                        "type": "string",
+                                        "description": "Identifies the source of traffic (e.g., \"website\", \"search_engine\", \"social_media\")."
+                                      },
+                                      "utm_campaign": {
+                                        "type": "string",
+                                        "description": "Identifies the specific marketing campaign (e.g., \"spring_sale\", \"product_launch\")."
+                                      }
+                                    }
+                                  },
+                                  "meeting_data": {
+                                    "type": "object",
+                                    "description": "Additional metadata about the associated meeting. Only present when activity_type is \"meeting\".",
+                                    "properties": {
+                                      "service_uid": {
+                                        "type": "string",
+                                        "description": "Unique identifier of the service associated with the meeting."
+                                      },
+                                      "service_name": {
+                                        "type": "string",
+                                        "description": "Display name of the service associated with the meeting (e.g., \"Initial Consultation\", \"Follow-up Session\")."
+                                      },
+                                      "start_time": {
+                                        "type": "string",
+                                        "format": "date-time",
+                                        "description": "The scheduled start time of the meeting in ISO 8601 format (e.g., \"2026-03-15T14:00:00Z\")."
+                                      },
+                                      "duration": {
+                                        "type": "integer",
+                                        "description": "Duration of the meeting in minutes (e.g., 30, 60)."
+                                      },
+                                      "interaction_type": {
+                                        "type": "string",
+                                        "description": "The type of interaction for the meeting (e.g., \"in_person\", \"video\", \"phone\")."
+                                      }
+                                    }
+                                  },
+                                  "created_at": {
+                                    "type": "string",
+                                    "format": "date-time",
+                                    "readOnly": true,
+                                    "description": "The date and time when the activity message was created, in ISO 8601 format."
+                                  },
+                                  "updated_at": {
+                                    "type": "string",
+                                    "format": "date-time",
+                                    "readOnly": true,
+                                    "description": "The date and time when the activity message was last updated, in ISO 8601 format."
+                                  }
+                                },
+                                "required": [
+                                  "client_uid",
+                                  "activity_type",
+                                  "activity_action",
+                                  "channels"
+                                ],
+                                "example": {
+                                  "uid": "msg_a1b2c3d4e5f6",
+                                  "business_uid": "d290f1ee26c54",
+                                  "staff_uid": "5ya4gbwm2c3qoic8",
+                                  "client_uid": "0c4ac9717ab26f56",
+                                  "activity_type": "meeting",
+                                  "activity_action": "scheduled",
+                                  "direction": "business_to_client",
+                                  "channels": [
+                                    "email"
+                                  ],
+                                  "message_text": {
+                                    "body": "Your appointment has been scheduled.",
+                                    "subject": "Initial Consultation"
+                                  },
+                                  "cta_button_text": "View Appointment",
+                                  "link_url_params": null,
+                                  "meeting_data": {
+                                    "service_uid": "svc_x7y8z9",
+                                    "service_name": "Initial Consultation",
+                                    "start_time": "2026-03-15T14:00:00Z",
+                                    "duration": 60,
+                                    "interaction_type": "video"
+                                  },
+                                  "created_at": "2026-03-10T09:00:00Z",
+                                  "updated_at": "2026-03-10T09:00:00Z"
+                                }
                               }
                             },
                             "page": {
@@ -1830,12 +2052,234 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/communication/activityMessage.json"
+                          "type": "object",
+                          "description": "Represents an activity message associated with a business-client interaction. Activity messages are created automatically by the system for various activity types (e.g., meetings, invoices, payments) or manually via the invite activity type. Each message captures the communication context including direction, channels, and activity-specific metadata.",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "readOnly": true,
+                              "description": "Unique identifier for the activity message record."
+                            },
+                            "business_uid": {
+                              "type": "string",
+                              "readOnly": true,
+                              "description": "Unique identifier of the business associated with this activity message."
+                            },
+                            "staff_uid": {
+                              "type": "string",
+                              "description": "Unique identifier of the staff member associated with this activity message."
+                            },
+                            "client_uid": {
+                              "type": "string",
+                              "description": "Unique identifier of the client this activity message is associated with."
+                            },
+                            "activity_type": {
+                              "type": "string",
+                              "enum": [
+                                "meeting",
+                                "appointment_series",
+                                "invoice",
+                                "estimate",
+                                "payment",
+                                "payment_status",
+                                "payment_card",
+                                "card_request",
+                                "scheduled_payments_rule",
+                                "payout",
+                                "announcement",
+                                "invite",
+                                "event",
+                                "event_series",
+                                "event_instance",
+                                "waitlist",
+                                "linked_booking",
+                                "client_booking_package",
+                                "product_order",
+                                "review",
+                                "document",
+                                "voice_call",
+                                "assignment"
+                              ],
+                              "description": "The type of activity this message is associated with. Determines the category of the underlying business event (e.g., \"meeting\" for scheduled appointments, \"invoice\" for billing documents, \"invite\" for manual client invitations to schedule)."
+                            },
+                            "activity_action": {
+                              "type": "string",
+                              "description": "The specific action or status related to the activity type (e.g., \"scheduled\" for a meeting that was booked, \"created\" for a newly generated invoice). For \"invite\" activity_type, supported actions are \"schedule\", \"pay\", \"share_document\", and \"client_portal\". Values vary depending on the activity_type."
+                            },
+                            "direction": {
+                              "type": "string",
+                              "enum": [
+                                "pivot_to_client",
+                                "client_to_pivot",
+                                "to_pivot",
+                                "to_client"
+                              ],
+                              "description": "The direction of the activity message. Possible values: \"pivot_to_client\" — message sent from the business to the client; \"client_to_pivot\" — message sent from the client to the business; \"to_pivot\" — system notification delivered to the business side; \"to_client\" — system notification delivered to the client side."
+                            },
+                            "channels": {
+                              "type": "array",
+                              "description": "The communication channels through which the message was sent or should be sent.",
+                              "items": {
+                                "type": "string",
+                                "enum": [
+                                  "email",
+                                  "sms"
+                                ]
+                              }
+                            },
+                            "message_text": {
+                              "type": "object",
+                              "description": "The textual content of the activity message.",
+                              "properties": {
+                                "body": {
+                                  "type": "string",
+                                  "description": "The main content of the message. For SMS messages, the maximum length is 550 characters. For email messages, the maximum length is 50,000 characters."
+                                },
+                                "subject": {
+                                  "type": "string",
+                                  "description": "A concise summary or title of the message content. For invite activity types, this is a user-provided subject. For other activity types, it is automatically derived from the activity (e.g., appointment title, invoice number)."
+                                }
+                              }
+                            },
+                            "cta_button_text": {
+                              "type": "string",
+                              "description": "The text displayed on the call-to-action button in the email message (e.g., \"Schedule now\", \"View Invoice\", \"View Appointment\"). Automatically derived for system-generated activity messages."
+                            },
+                            "link_url_params": {
+                              "type": "object",
+                              "description": "URL parameters appended to the action button link in emails or the SMS link. Useful for tracking campaign attribution (e.g., UTM parameters).",
+                              "properties": {
+                                "utm_source": {
+                                  "type": "string",
+                                  "description": "Identifies the source of traffic (e.g., \"website\", \"search_engine\", \"social_media\")."
+                                },
+                                "utm_campaign": {
+                                  "type": "string",
+                                  "description": "Identifies the specific marketing campaign (e.g., \"spring_sale\", \"product_launch\")."
+                                }
+                              }
+                            },
+                            "meeting_data": {
+                              "type": "object",
+                              "description": "Additional metadata about the associated meeting. Only present when activity_type is \"meeting\".",
+                              "properties": {
+                                "service_uid": {
+                                  "type": "string",
+                                  "description": "Unique identifier of the service associated with the meeting."
+                                },
+                                "service_name": {
+                                  "type": "string",
+                                  "description": "Display name of the service associated with the meeting (e.g., \"Initial Consultation\", \"Follow-up Session\")."
+                                },
+                                "start_time": {
+                                  "type": "string",
+                                  "format": "date-time",
+                                  "description": "The scheduled start time of the meeting in ISO 8601 format (e.g., \"2026-03-15T14:00:00Z\")."
+                                },
+                                "duration": {
+                                  "type": "integer",
+                                  "description": "Duration of the meeting in minutes (e.g., 30, 60)."
+                                },
+                                "interaction_type": {
+                                  "type": "string",
+                                  "description": "The type of interaction for the meeting (e.g., \"in_person\", \"video\", \"phone\")."
+                                }
+                              }
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "readOnly": true,
+                              "description": "The date and time when the activity message was created, in ISO 8601 format."
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "readOnly": true,
+                              "description": "The date and time when the activity message was last updated, in ISO 8601 format."
+                            }
+                          },
+                          "required": [
+                            "client_uid",
+                            "activity_type",
+                            "activity_action",
+                            "channels"
+                          ],
+                          "example": {
+                            "uid": "msg_a1b2c3d4e5f6",
+                            "business_uid": "d290f1ee26c54",
+                            "staff_uid": "5ya4gbwm2c3qoic8",
+                            "client_uid": "0c4ac9717ab26f56",
+                            "activity_type": "meeting",
+                            "activity_action": "scheduled",
+                            "direction": "business_to_client",
+                            "channels": [
+                              "email"
+                            ],
+                            "message_text": {
+                              "body": "Your appointment has been scheduled.",
+                              "subject": "Initial Consultation"
+                            },
+                            "cta_button_text": "View Appointment",
+                            "link_url_params": null,
+                            "meeting_data": {
+                              "service_uid": "svc_x7y8z9",
+                              "service_name": "Initial Consultation",
+                              "start_time": "2026-03-15T14:00:00Z",
+                              "duration": 60,
+                              "interaction_type": "video"
+                            },
+                            "created_at": "2026-03-10T09:00:00Z",
+                            "updated_at": "2026-03-10T09:00:00Z"
+                          }
                         }
                       }
                     }
@@ -1971,7 +2415,123 @@
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/communication/voiceCallSetting.json"
+                          "type": "object",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "description": "The unique identifier of the VoiceCallSetting entity (e.g., \"56ah3478b56c\")"
+                            },
+                            "business_uid": {
+                              "type": "string",
+                              "description": "The unique identifier of the business (e.g., \"d290f1ee-6c54-4b01-90e6-d701748f0851\")"
+                            },
+                            "staff_uid": {
+                              "type": "string",
+                              "description": "The unique identifier of the staff receiving the forwarded call (e.g., \"5ya4gbwm2c3qic8\")"
+                            },
+                            "forward_number": {
+                              "type": "string",
+                              "description": "The phone number of the staff receiving the forwarded call (e.g., \"180348567634\")"
+                            },
+                            "dedicated_number": {
+                              "type": "string",
+                              "description": "The dedicated number of the business receiving calls from clients (e.g., \"12845783457\")"
+                            },
+                            "forwarding_enabled": {
+                              "type": "boolean",
+                              "description": "Indicates if voice call forwarding is enabled (e.g., true)"
+                            },
+                            "call_forwarding_policy": {
+                              "type": "string",
+                              "enum": [
+                                "ALWAYS",
+                                "WORK_HOURS",
+                                "NEVER"
+                              ],
+                              "description": "Specifies the conditions under which calls are forwarded based on staff availability (e.g., \"WORK_HOURS\")"
+                            },
+                            "call_timeout_sec": {
+                              "type": "number",
+                              "description": "Call ringing timeout in seconds (e.g., 20)"
+                            },
+                            "publish_number": {
+                              "type": "boolean",
+                              "description": "Indicates if the dedicated number should be published as the business's phone number (e.g., true)"
+                            },
+                            "voice_scripts": {
+                              "type": "object",
+                              "nullable": true,
+                              "description": "Configuration of voice messages played to callers during different stages of a voice call. Each key is a message name, value is an object with message (string) and enabled (boolean)."
+                            },
+                            "external_app_name": {
+                              "type": "string",
+                              "description": "The name of the external application managing the voice call (e.g., \"my.pa\")"
+                            },
+                            "app_status": {
+                              "type": "string",
+                              "enum": [
+                                "INSTALLED",
+                                "UNINSTALLED",
+                                "PAYMENT_ISSUE"
+                              ],
+                              "description": "The status of the app (e.g., \"INSTALLED\")"
+                            },
+                            "feature": {
+                              "type": "string",
+                              "enum": [
+                                "VOICE",
+                                "SMS",
+                                "VOICE_SMS"
+                              ],
+                              "nullable": true,
+                              "description": "The feature type for this setting (e.g., \"VOICE\")"
+                            },
+                            "transcript_enabled": {
+                              "type": "boolean",
+                              "description": "Whether automatic transcript processing is enabled for voice calls in this business (e.g., true)"
+                            }
+                          },
+                          "required": [
+                            "uid",
+                            "business_uid",
+                            "forwarding_enabled",
+                            "external_app_name",
+                            "app_status"
+                          ],
+                          "example": {
+                            "uid": "56ah3478b56c",
+                            "business_uid": "d290f1ee-6c54-4b01-90e6-d701748f0851",
+                            "staff_uid": "5ya4gbwm2c3qic8",
+                            "forward_number": "180348567634",
+                            "dedicated_number": "12845783457",
+                            "forwarding_enabled": true,
+                            "call_forwarding_policy": "WORK_HOURS",
+                            "call_timeout_sec": 20,
+                            "publish_number": true,
+                            "voice_scripts": {
+                              "greeting_message": {
+                                "message": "Hi, The call will be forwarded soon, please wait.",
+                                "enabled": true
+                              },
+                              "missed_call_message": {
+                                "message": "Sorry, please try again later.",
+                                "enabled": false
+                              },
+                              "voicemail_message": {
+                                "message": "Sorry, the staff is not available right now. Please leave a message after the beep.",
+                                "enabled": false
+                              },
+                              "recording_call_message": {
+                                "message": "Please note that this is a voice recording, please press 1 to continue.",
+                                "enabled": false
+                              }
+                            },
+                            "external_app_name": "my.pa",
+                            "app_status": "INSTALLED",
+                            "feature": "VOICE",
+                            "transcript_enabled": true
+                          },
+                          "description": "Defines voice call settings for a staff member/business, including forwarding, policies, and scripts."
                         }
                       }
                     }
@@ -2095,7 +2655,123 @@
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/communication/voiceCallSetting.json"
+                          "type": "object",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "description": "The unique identifier of the VoiceCallSetting entity (e.g., \"56ah3478b56c\")"
+                            },
+                            "business_uid": {
+                              "type": "string",
+                              "description": "The unique identifier of the business (e.g., \"d290f1ee-6c54-4b01-90e6-d701748f0851\")"
+                            },
+                            "staff_uid": {
+                              "type": "string",
+                              "description": "The unique identifier of the staff receiving the forwarded call (e.g., \"5ya4gbwm2c3qic8\")"
+                            },
+                            "forward_number": {
+                              "type": "string",
+                              "description": "The phone number of the staff receiving the forwarded call (e.g., \"180348567634\")"
+                            },
+                            "dedicated_number": {
+                              "type": "string",
+                              "description": "The dedicated number of the business receiving calls from clients (e.g., \"12845783457\")"
+                            },
+                            "forwarding_enabled": {
+                              "type": "boolean",
+                              "description": "Indicates if voice call forwarding is enabled (e.g., true)"
+                            },
+                            "call_forwarding_policy": {
+                              "type": "string",
+                              "enum": [
+                                "ALWAYS",
+                                "WORK_HOURS",
+                                "NEVER"
+                              ],
+                              "description": "Specifies the conditions under which calls are forwarded based on staff availability (e.g., \"WORK_HOURS\")"
+                            },
+                            "call_timeout_sec": {
+                              "type": "number",
+                              "description": "Call ringing timeout in seconds (e.g., 20)"
+                            },
+                            "publish_number": {
+                              "type": "boolean",
+                              "description": "Indicates if the dedicated number should be published as the business's phone number (e.g., true)"
+                            },
+                            "voice_scripts": {
+                              "type": "object",
+                              "nullable": true,
+                              "description": "Configuration of voice messages played to callers during different stages of a voice call. Each key is a message name, value is an object with message (string) and enabled (boolean)."
+                            },
+                            "external_app_name": {
+                              "type": "string",
+                              "description": "The name of the external application managing the voice call (e.g., \"my.pa\")"
+                            },
+                            "app_status": {
+                              "type": "string",
+                              "enum": [
+                                "INSTALLED",
+                                "UNINSTALLED",
+                                "PAYMENT_ISSUE"
+                              ],
+                              "description": "The status of the app (e.g., \"INSTALLED\")"
+                            },
+                            "feature": {
+                              "type": "string",
+                              "enum": [
+                                "VOICE",
+                                "SMS",
+                                "VOICE_SMS"
+                              ],
+                              "nullable": true,
+                              "description": "The feature type for this setting (e.g., \"VOICE\")"
+                            },
+                            "transcript_enabled": {
+                              "type": "boolean",
+                              "description": "Whether automatic transcript processing is enabled for voice calls in this business (e.g., true)"
+                            }
+                          },
+                          "required": [
+                            "uid",
+                            "business_uid",
+                            "forwarding_enabled",
+                            "external_app_name",
+                            "app_status"
+                          ],
+                          "example": {
+                            "uid": "56ah3478b56c",
+                            "business_uid": "d290f1ee-6c54-4b01-90e6-d701748f0851",
+                            "staff_uid": "5ya4gbwm2c3qic8",
+                            "forward_number": "180348567634",
+                            "dedicated_number": "12845783457",
+                            "forwarding_enabled": true,
+                            "call_forwarding_policy": "WORK_HOURS",
+                            "call_timeout_sec": 20,
+                            "publish_number": true,
+                            "voice_scripts": {
+                              "greeting_message": {
+                                "message": "Hi, The call will be forwarded soon, please wait.",
+                                "enabled": true
+                              },
+                              "missed_call_message": {
+                                "message": "Sorry, please try again later.",
+                                "enabled": false
+                              },
+                              "voicemail_message": {
+                                "message": "Sorry, the staff is not available right now. Please leave a message after the beep.",
+                                "enabled": false
+                              },
+                              "recording_call_message": {
+                                "message": "Please note that this is a voice recording, please press 1 to continue.",
+                                "enabled": false
+                              }
+                            },
+                            "external_app_name": "my.pa",
+                            "app_status": "INSTALLED",
+                            "feature": "VOICE",
+                            "transcript_enabled": true
+                          },
+                          "description": "Defines voice call settings for a staff member/business, including forwarding, policies, and scripts."
                         }
                       }
                     }
@@ -2150,7 +2826,123 @@
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/communication/voiceCallSetting.json"
+                          "type": "object",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "description": "The unique identifier of the VoiceCallSetting entity (e.g., \"56ah3478b56c\")"
+                            },
+                            "business_uid": {
+                              "type": "string",
+                              "description": "The unique identifier of the business (e.g., \"d290f1ee-6c54-4b01-90e6-d701748f0851\")"
+                            },
+                            "staff_uid": {
+                              "type": "string",
+                              "description": "The unique identifier of the staff receiving the forwarded call (e.g., \"5ya4gbwm2c3qic8\")"
+                            },
+                            "forward_number": {
+                              "type": "string",
+                              "description": "The phone number of the staff receiving the forwarded call (e.g., \"180348567634\")"
+                            },
+                            "dedicated_number": {
+                              "type": "string",
+                              "description": "The dedicated number of the business receiving calls from clients (e.g., \"12845783457\")"
+                            },
+                            "forwarding_enabled": {
+                              "type": "boolean",
+                              "description": "Indicates if voice call forwarding is enabled (e.g., true)"
+                            },
+                            "call_forwarding_policy": {
+                              "type": "string",
+                              "enum": [
+                                "ALWAYS",
+                                "WORK_HOURS",
+                                "NEVER"
+                              ],
+                              "description": "Specifies the conditions under which calls are forwarded based on staff availability (e.g., \"WORK_HOURS\")"
+                            },
+                            "call_timeout_sec": {
+                              "type": "number",
+                              "description": "Call ringing timeout in seconds (e.g., 20)"
+                            },
+                            "publish_number": {
+                              "type": "boolean",
+                              "description": "Indicates if the dedicated number should be published as the business's phone number (e.g., true)"
+                            },
+                            "voice_scripts": {
+                              "type": "object",
+                              "nullable": true,
+                              "description": "Configuration of voice messages played to callers during different stages of a voice call. Each key is a message name, value is an object with message (string) and enabled (boolean)."
+                            },
+                            "external_app_name": {
+                              "type": "string",
+                              "description": "The name of the external application managing the voice call (e.g., \"my.pa\")"
+                            },
+                            "app_status": {
+                              "type": "string",
+                              "enum": [
+                                "INSTALLED",
+                                "UNINSTALLED",
+                                "PAYMENT_ISSUE"
+                              ],
+                              "description": "The status of the app (e.g., \"INSTALLED\")"
+                            },
+                            "feature": {
+                              "type": "string",
+                              "enum": [
+                                "VOICE",
+                                "SMS",
+                                "VOICE_SMS"
+                              ],
+                              "nullable": true,
+                              "description": "The feature type for this setting (e.g., \"VOICE\")"
+                            },
+                            "transcript_enabled": {
+                              "type": "boolean",
+                              "description": "Whether automatic transcript processing is enabled for voice calls in this business (e.g., true)"
+                            }
+                          },
+                          "required": [
+                            "uid",
+                            "business_uid",
+                            "forwarding_enabled",
+                            "external_app_name",
+                            "app_status"
+                          ],
+                          "example": {
+                            "uid": "56ah3478b56c",
+                            "business_uid": "d290f1ee-6c54-4b01-90e6-d701748f0851",
+                            "staff_uid": "5ya4gbwm2c3qic8",
+                            "forward_number": "180348567634",
+                            "dedicated_number": "12845783457",
+                            "forwarding_enabled": true,
+                            "call_forwarding_policy": "WORK_HOURS",
+                            "call_timeout_sec": 20,
+                            "publish_number": true,
+                            "voice_scripts": {
+                              "greeting_message": {
+                                "message": "Hi, The call will be forwarded soon, please wait.",
+                                "enabled": true
+                              },
+                              "missed_call_message": {
+                                "message": "Sorry, please try again later.",
+                                "enabled": false
+                              },
+                              "voicemail_message": {
+                                "message": "Sorry, the staff is not available right now. Please leave a message after the beep.",
+                                "enabled": false
+                              },
+                              "recording_call_message": {
+                                "message": "Please note that this is a voice recording, please press 1 to continue.",
+                                "enabled": false
+                              }
+                            },
+                            "external_app_name": "my.pa",
+                            "app_status": "INSTALLED",
+                            "feature": "VOICE",
+                            "transcript_enabled": true
+                          },
+                          "description": "Defines voice call settings for a staff member/business, including forwarding, policies, and scripts."
                         }
                       }
                     }
@@ -2280,7 +3072,182 @@
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/communication/voiceCall.json"
+                          "type": "object",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "description": "Unique identifier of the VoiceCall object"
+                            },
+                            "duration": {
+                              "type": "integer",
+                              "description": "Duration of the call in seconds"
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "description": "The time the call was created"
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "description": "The time the call was last updated"
+                            },
+                            "status": {
+                              "type": "string",
+                              "enum": [
+                                "INCOMING_CALL",
+                                "ANSWERED_BY_STAFF",
+                                "MISSED",
+                                "ANSWERED_BY_CALLS_PROVIDER",
+                                "MISSED_CALL_HANDLED",
+                                "VOICEMAIL"
+                              ],
+                              "description": "The status of the call (e.g., \"ANSWERED_BY_STAFF\")"
+                            },
+                            "direction": {
+                              "type": "string",
+                              "enum": [
+                                "INBOUND",
+                                "OUTBOUND"
+                              ],
+                              "description": "The direction of the call. INBOUND for incoming calls to the business, OUTBOUND for outgoing calls from the business. Values are uppercase (e.g., \"INBOUND\")."
+                            },
+                            "staff_uid": {
+                              "type": "string",
+                              "description": "Unique identifier of the staff member who answered the call"
+                            },
+                            "client_uid": {
+                              "type": "string",
+                              "description": "Unique identifier of the client who made the call"
+                            },
+                            "from_number": {
+                              "type": "string",
+                              "description": "The phone number the call was made from"
+                            },
+                            "to_number": {
+                              "type": "string",
+                              "description": "The phone number the call was made to"
+                            },
+                            "call_summary": {
+                              "type": "string",
+                              "description": "Text summary of the call"
+                            },
+                            "recording": {
+                              "type": "object",
+                              "properties": {
+                                "uid": {
+                                  "type": "string",
+                                  "description": "Unique identifier of the recording entity (e.g., \"rec-abc123xyz\")"
+                                },
+                                "recordingUrl": {
+                                  "type": "string",
+                                  "description": "Pre-signed URL to access the recording file (e.g., \"https://example.com/recordings/presigned-url\")"
+                                },
+                                "size": {
+                                  "type": "number",
+                                  "description": "The size of the recording in bytes (e.g., 1048576)"
+                                },
+                                "duration": {
+                                  "type": "number",
+                                  "description": "The duration of the recording in seconds (e.g., 300)"
+                                },
+                                "recording_played": {
+                                  "type": "boolean",
+                                  "description": "Whether the call recording has been played (e.g., false)"
+                                },
+                                "recording_type": {
+                                  "type": "string",
+                                  "description": "The type of the recording",
+                                  "enum": [
+                                    "CALL",
+                                    "VOICEMAIL"
+                                  ]
+                                }
+                              },
+                              "required": [
+                                "uid",
+                                "size",
+                                "duration",
+                                "recording_type"
+                              ],
+                              "example": {
+                                "uid": "rec-abc123xyz",
+                                "recordingUrl": "https://example.com/recordings/presigned-url",
+                                "size": 1048576,
+                                "duration": 300,
+                                "recording_played": false,
+                                "recording_type": "CALL"
+                              },
+                              "description": "The call recording details"
+                            },
+                            "external_app_url": {
+                              "type": "string",
+                              "description": "Link to an application page with additional details about the call (e.g., \"https://example.com/call-details\")"
+                            },
+                            "external_app_name": {
+                              "type": "string",
+                              "description": "The name of the external application that originated or manages the call (e.g., \"my.pa\")"
+                            },
+                            "source_id": {
+                              "type": "string",
+                              "description": "A unique source identifier for the call from the provider system (e.g., \"call-src-001\")"
+                            },
+                            "external_uuid": {
+                              "type": "string",
+                              "description": "An external unique identifier for the call conversation from the provider system (e.g., \"ext-call-001\")"
+                            },
+                            "handled_by_staff_uid": {
+                              "type": "string",
+                              "description": "The unique identifier of the staff who handled the call"
+                            },
+                            "handled_at": {
+                              "type": "string",
+                              "description": "The date and time when the call was handled",
+                              "format": "date-time"
+                            },
+                            "deleted_at": {
+                              "type": "string",
+                              "description": "Time the call was deleted - is null if the call is not deleted"
+                            },
+                            "transcript_status": {
+                              "type": "string",
+                              "nullable": true,
+                              "enum": [
+                                "IN_PROGRESS",
+                                "DONE",
+                                "FAILED"
+                              ],
+                              "description": "Processing status of the associated transcript. IN_PROGRESS means the transcript is being generated, DONE means it is ready, FAILED means generation failed (e.g., \"DONE\")"
+                            }
+                          },
+                          "example": {
+                            "uid": "d290f1ee-6c54-4b01-90e6-d701748f0851",
+                            "created_at": "2021-07-20T14:00:00.000Z",
+                            "updated_at": "2021-07-20T14:00:00.000Z",
+                            "duration": 120,
+                            "status": "ANSWERED_BY_STAFF",
+                            "direction": "INBOUND",
+                            "staff_uid": "d290f1ee-6c54-4b01-90e6-d701748f0851",
+                            "client_uid": "d290f1ee-6c54-4b01-90e6-d701748f0851",
+                            "from_number": "183466347342",
+                            "to_number": "183466347342",
+                            "call_summary": "Client called to ask about their account balance",
+                            "recording": {
+                              "uid": "rec-abc123xyz",
+                              "recordingUrl": "https://example.com/recordings/presigned-url",
+                              "size": 1048576,
+                              "duration": 300,
+                              "recording_played": false,
+                              "recording_type": "CALL"
+                            },
+                            "external_app_url": "https://example.com/call-details",
+                            "external_app_name": "my.pa",
+                            "source_id": "call-src-001",
+                            "external_uuid": "ext-call-001",
+                            "handled_by_staff_uid": "d290f1ee-6c54-4b01-90e6-d701748f0851",
+                            "handled_at": "2021-07-20T14:00:00.000Z",
+                            "deleted_at": null,
+                            "transcript_status": "DONE"
+                          },
+                          "description": "Represents a phone call record, including participants, status, recording and audit timestamps."
                         }
                       }
                     }
@@ -2328,7 +3295,182 @@
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/communication/voiceCall.json"
+                          "type": "object",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "description": "Unique identifier of the VoiceCall object"
+                            },
+                            "duration": {
+                              "type": "integer",
+                              "description": "Duration of the call in seconds"
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "description": "The time the call was created"
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "description": "The time the call was last updated"
+                            },
+                            "status": {
+                              "type": "string",
+                              "enum": [
+                                "INCOMING_CALL",
+                                "ANSWERED_BY_STAFF",
+                                "MISSED",
+                                "ANSWERED_BY_CALLS_PROVIDER",
+                                "MISSED_CALL_HANDLED",
+                                "VOICEMAIL"
+                              ],
+                              "description": "The status of the call (e.g., \"ANSWERED_BY_STAFF\")"
+                            },
+                            "direction": {
+                              "type": "string",
+                              "enum": [
+                                "INBOUND",
+                                "OUTBOUND"
+                              ],
+                              "description": "The direction of the call. INBOUND for incoming calls to the business, OUTBOUND for outgoing calls from the business. Values are uppercase (e.g., \"INBOUND\")."
+                            },
+                            "staff_uid": {
+                              "type": "string",
+                              "description": "Unique identifier of the staff member who answered the call"
+                            },
+                            "client_uid": {
+                              "type": "string",
+                              "description": "Unique identifier of the client who made the call"
+                            },
+                            "from_number": {
+                              "type": "string",
+                              "description": "The phone number the call was made from"
+                            },
+                            "to_number": {
+                              "type": "string",
+                              "description": "The phone number the call was made to"
+                            },
+                            "call_summary": {
+                              "type": "string",
+                              "description": "Text summary of the call"
+                            },
+                            "recording": {
+                              "type": "object",
+                              "properties": {
+                                "uid": {
+                                  "type": "string",
+                                  "description": "Unique identifier of the recording entity (e.g., \"rec-abc123xyz\")"
+                                },
+                                "recordingUrl": {
+                                  "type": "string",
+                                  "description": "Pre-signed URL to access the recording file (e.g., \"https://example.com/recordings/presigned-url\")"
+                                },
+                                "size": {
+                                  "type": "number",
+                                  "description": "The size of the recording in bytes (e.g., 1048576)"
+                                },
+                                "duration": {
+                                  "type": "number",
+                                  "description": "The duration of the recording in seconds (e.g., 300)"
+                                },
+                                "recording_played": {
+                                  "type": "boolean",
+                                  "description": "Whether the call recording has been played (e.g., false)"
+                                },
+                                "recording_type": {
+                                  "type": "string",
+                                  "description": "The type of the recording",
+                                  "enum": [
+                                    "CALL",
+                                    "VOICEMAIL"
+                                  ]
+                                }
+                              },
+                              "required": [
+                                "uid",
+                                "size",
+                                "duration",
+                                "recording_type"
+                              ],
+                              "example": {
+                                "uid": "rec-abc123xyz",
+                                "recordingUrl": "https://example.com/recordings/presigned-url",
+                                "size": 1048576,
+                                "duration": 300,
+                                "recording_played": false,
+                                "recording_type": "CALL"
+                              },
+                              "description": "The call recording details"
+                            },
+                            "external_app_url": {
+                              "type": "string",
+                              "description": "Link to an application page with additional details about the call (e.g., \"https://example.com/call-details\")"
+                            },
+                            "external_app_name": {
+                              "type": "string",
+                              "description": "The name of the external application that originated or manages the call (e.g., \"my.pa\")"
+                            },
+                            "source_id": {
+                              "type": "string",
+                              "description": "A unique source identifier for the call from the provider system (e.g., \"call-src-001\")"
+                            },
+                            "external_uuid": {
+                              "type": "string",
+                              "description": "An external unique identifier for the call conversation from the provider system (e.g., \"ext-call-001\")"
+                            },
+                            "handled_by_staff_uid": {
+                              "type": "string",
+                              "description": "The unique identifier of the staff who handled the call"
+                            },
+                            "handled_at": {
+                              "type": "string",
+                              "description": "The date and time when the call was handled",
+                              "format": "date-time"
+                            },
+                            "deleted_at": {
+                              "type": "string",
+                              "description": "Time the call was deleted - is null if the call is not deleted"
+                            },
+                            "transcript_status": {
+                              "type": "string",
+                              "nullable": true,
+                              "enum": [
+                                "IN_PROGRESS",
+                                "DONE",
+                                "FAILED"
+                              ],
+                              "description": "Processing status of the associated transcript. IN_PROGRESS means the transcript is being generated, DONE means it is ready, FAILED means generation failed (e.g., \"DONE\")"
+                            }
+                          },
+                          "example": {
+                            "uid": "d290f1ee-6c54-4b01-90e6-d701748f0851",
+                            "created_at": "2021-07-20T14:00:00.000Z",
+                            "updated_at": "2021-07-20T14:00:00.000Z",
+                            "duration": 120,
+                            "status": "ANSWERED_BY_STAFF",
+                            "direction": "INBOUND",
+                            "staff_uid": "d290f1ee-6c54-4b01-90e6-d701748f0851",
+                            "client_uid": "d290f1ee-6c54-4b01-90e6-d701748f0851",
+                            "from_number": "183466347342",
+                            "to_number": "183466347342",
+                            "call_summary": "Client called to ask about their account balance",
+                            "recording": {
+                              "uid": "rec-abc123xyz",
+                              "recordingUrl": "https://example.com/recordings/presigned-url",
+                              "size": 1048576,
+                              "duration": 300,
+                              "recording_played": false,
+                              "recording_type": "CALL"
+                            },
+                            "external_app_url": "https://example.com/call-details",
+                            "external_app_name": "my.pa",
+                            "source_id": "call-src-001",
+                            "external_uuid": "ext-call-001",
+                            "handled_by_staff_uid": "d290f1ee-6c54-4b01-90e6-d701748f0851",
+                            "handled_at": "2021-07-20T14:00:00.000Z",
+                            "deleted_at": null,
+                            "transcript_status": "DONE"
+                          },
+                          "description": "Represents a phone call record, including participants, status, recording and audit timestamps."
                         }
                       }
                     }
@@ -2384,7 +3526,182 @@
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/communication/voiceCall.json"
+                          "type": "object",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "description": "Unique identifier of the VoiceCall object"
+                            },
+                            "duration": {
+                              "type": "integer",
+                              "description": "Duration of the call in seconds"
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "description": "The time the call was created"
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "description": "The time the call was last updated"
+                            },
+                            "status": {
+                              "type": "string",
+                              "enum": [
+                                "INCOMING_CALL",
+                                "ANSWERED_BY_STAFF",
+                                "MISSED",
+                                "ANSWERED_BY_CALLS_PROVIDER",
+                                "MISSED_CALL_HANDLED",
+                                "VOICEMAIL"
+                              ],
+                              "description": "The status of the call (e.g., \"ANSWERED_BY_STAFF\")"
+                            },
+                            "direction": {
+                              "type": "string",
+                              "enum": [
+                                "INBOUND",
+                                "OUTBOUND"
+                              ],
+                              "description": "The direction of the call. INBOUND for incoming calls to the business, OUTBOUND for outgoing calls from the business. Values are uppercase (e.g., \"INBOUND\")."
+                            },
+                            "staff_uid": {
+                              "type": "string",
+                              "description": "Unique identifier of the staff member who answered the call"
+                            },
+                            "client_uid": {
+                              "type": "string",
+                              "description": "Unique identifier of the client who made the call"
+                            },
+                            "from_number": {
+                              "type": "string",
+                              "description": "The phone number the call was made from"
+                            },
+                            "to_number": {
+                              "type": "string",
+                              "description": "The phone number the call was made to"
+                            },
+                            "call_summary": {
+                              "type": "string",
+                              "description": "Text summary of the call"
+                            },
+                            "recording": {
+                              "type": "object",
+                              "properties": {
+                                "uid": {
+                                  "type": "string",
+                                  "description": "Unique identifier of the recording entity (e.g., \"rec-abc123xyz\")"
+                                },
+                                "recordingUrl": {
+                                  "type": "string",
+                                  "description": "Pre-signed URL to access the recording file (e.g., \"https://example.com/recordings/presigned-url\")"
+                                },
+                                "size": {
+                                  "type": "number",
+                                  "description": "The size of the recording in bytes (e.g., 1048576)"
+                                },
+                                "duration": {
+                                  "type": "number",
+                                  "description": "The duration of the recording in seconds (e.g., 300)"
+                                },
+                                "recording_played": {
+                                  "type": "boolean",
+                                  "description": "Whether the call recording has been played (e.g., false)"
+                                },
+                                "recording_type": {
+                                  "type": "string",
+                                  "description": "The type of the recording",
+                                  "enum": [
+                                    "CALL",
+                                    "VOICEMAIL"
+                                  ]
+                                }
+                              },
+                              "required": [
+                                "uid",
+                                "size",
+                                "duration",
+                                "recording_type"
+                              ],
+                              "example": {
+                                "uid": "rec-abc123xyz",
+                                "recordingUrl": "https://example.com/recordings/presigned-url",
+                                "size": 1048576,
+                                "duration": 300,
+                                "recording_played": false,
+                                "recording_type": "CALL"
+                              },
+                              "description": "The call recording details"
+                            },
+                            "external_app_url": {
+                              "type": "string",
+                              "description": "Link to an application page with additional details about the call (e.g., \"https://example.com/call-details\")"
+                            },
+                            "external_app_name": {
+                              "type": "string",
+                              "description": "The name of the external application that originated or manages the call (e.g., \"my.pa\")"
+                            },
+                            "source_id": {
+                              "type": "string",
+                              "description": "A unique source identifier for the call from the provider system (e.g., \"call-src-001\")"
+                            },
+                            "external_uuid": {
+                              "type": "string",
+                              "description": "An external unique identifier for the call conversation from the provider system (e.g., \"ext-call-001\")"
+                            },
+                            "handled_by_staff_uid": {
+                              "type": "string",
+                              "description": "The unique identifier of the staff who handled the call"
+                            },
+                            "handled_at": {
+                              "type": "string",
+                              "description": "The date and time when the call was handled",
+                              "format": "date-time"
+                            },
+                            "deleted_at": {
+                              "type": "string",
+                              "description": "Time the call was deleted - is null if the call is not deleted"
+                            },
+                            "transcript_status": {
+                              "type": "string",
+                              "nullable": true,
+                              "enum": [
+                                "IN_PROGRESS",
+                                "DONE",
+                                "FAILED"
+                              ],
+                              "description": "Processing status of the associated transcript. IN_PROGRESS means the transcript is being generated, DONE means it is ready, FAILED means generation failed (e.g., \"DONE\")"
+                            }
+                          },
+                          "example": {
+                            "uid": "d290f1ee-6c54-4b01-90e6-d701748f0851",
+                            "created_at": "2021-07-20T14:00:00.000Z",
+                            "updated_at": "2021-07-20T14:00:00.000Z",
+                            "duration": 120,
+                            "status": "ANSWERED_BY_STAFF",
+                            "direction": "INBOUND",
+                            "staff_uid": "d290f1ee-6c54-4b01-90e6-d701748f0851",
+                            "client_uid": "d290f1ee-6c54-4b01-90e6-d701748f0851",
+                            "from_number": "183466347342",
+                            "to_number": "183466347342",
+                            "call_summary": "Client called to ask about their account balance",
+                            "recording": {
+                              "uid": "rec-abc123xyz",
+                              "recordingUrl": "https://example.com/recordings/presigned-url",
+                              "size": 1048576,
+                              "duration": 300,
+                              "recording_played": false,
+                              "recording_type": "CALL"
+                            },
+                            "external_app_url": "https://example.com/call-details",
+                            "external_app_name": "my.pa",
+                            "source_id": "call-src-001",
+                            "external_uuid": "ext-call-001",
+                            "handled_by_staff_uid": "d290f1ee-6c54-4b01-90e6-d701748f0851",
+                            "handled_at": "2021-07-20T14:00:00.000Z",
+                            "deleted_at": null,
+                            "transcript_status": "DONE"
+                          },
+                          "description": "Represents a phone call record, including participants, status, recording and audit timestamps."
                         }
                       }
                     }
@@ -2434,7 +3751,75 @@
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/communication/voiceCallTranscript.json"
+                          "type": "object",
+                          "properties": {
+                            "transcript_uid": {
+                              "type": "string",
+                              "description": "Unique identifier of the transcript entity (e.g., \"a1b2c3d4-5678-90ab-cdef-1234567890ab\")"
+                            },
+                            "status": {
+                              "type": "string",
+                              "enum": [
+                                "IN_PROGRESS",
+                                "DONE",
+                                "FAILED"
+                              ],
+                              "description": "Processing status of the transcript. IN_PROGRESS means generation is underway, DONE means it is ready, FAILED means generation failed (e.g., \"DONE\")"
+                            },
+                            "transcript": {
+                              "type": "array",
+                              "nullable": true,
+                              "description": "Array of transcript entries, present only when status is DONE",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "timestamp": {
+                                    "type": "number",
+                                    "description": "Timestamp in seconds from start of audio (e.g., 12.5)"
+                                  },
+                                  "speaker_role": {
+                                    "type": "string",
+                                    "description": "Role of the speaker in the conversation (e.g., \"client\", \"staff\")"
+                                  },
+                                  "text": {
+                                    "type": "string",
+                                    "description": "Transcribed text for this segment (e.g., \"Hello, how can I help you?\")"
+                                  }
+                                },
+                                "required": [
+                                  "timestamp",
+                                  "speaker_role",
+                                  "text"
+                                ]
+                              }
+                            }
+                          },
+                          "required": [
+                            "transcript_uid",
+                            "status"
+                          ],
+                          "example": {
+                            "transcript_uid": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
+                            "status": "DONE",
+                            "transcript": [
+                              {
+                                "timestamp": 0,
+                                "speaker_role": "staff",
+                                "text": "Hello, thank you for calling. How can I help you today?"
+                              },
+                              {
+                                "timestamp": 3.2,
+                                "speaker_role": "client",
+                                "text": "Hi, I'd like to schedule an appointment for next week."
+                              },
+                              {
+                                "timestamp": 7.8,
+                                "speaker_role": "staff",
+                                "text": "Sure, let me check available slots for you."
+                              }
+                            ]
+                          },
+                          "description": "Represents the transcript of a voice call, including processing status and individual speaker entries."
                         }
                       }
                     }
@@ -2494,7 +3879,182 @@
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/communication/voiceCall.json"
+                          "type": "object",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "description": "Unique identifier of the VoiceCall object"
+                            },
+                            "duration": {
+                              "type": "integer",
+                              "description": "Duration of the call in seconds"
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "description": "The time the call was created"
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "description": "The time the call was last updated"
+                            },
+                            "status": {
+                              "type": "string",
+                              "enum": [
+                                "INCOMING_CALL",
+                                "ANSWERED_BY_STAFF",
+                                "MISSED",
+                                "ANSWERED_BY_CALLS_PROVIDER",
+                                "MISSED_CALL_HANDLED",
+                                "VOICEMAIL"
+                              ],
+                              "description": "The status of the call (e.g., \"ANSWERED_BY_STAFF\")"
+                            },
+                            "direction": {
+                              "type": "string",
+                              "enum": [
+                                "INBOUND",
+                                "OUTBOUND"
+                              ],
+                              "description": "The direction of the call. INBOUND for incoming calls to the business, OUTBOUND for outgoing calls from the business. Values are uppercase (e.g., \"INBOUND\")."
+                            },
+                            "staff_uid": {
+                              "type": "string",
+                              "description": "Unique identifier of the staff member who answered the call"
+                            },
+                            "client_uid": {
+                              "type": "string",
+                              "description": "Unique identifier of the client who made the call"
+                            },
+                            "from_number": {
+                              "type": "string",
+                              "description": "The phone number the call was made from"
+                            },
+                            "to_number": {
+                              "type": "string",
+                              "description": "The phone number the call was made to"
+                            },
+                            "call_summary": {
+                              "type": "string",
+                              "description": "Text summary of the call"
+                            },
+                            "recording": {
+                              "type": "object",
+                              "properties": {
+                                "uid": {
+                                  "type": "string",
+                                  "description": "Unique identifier of the recording entity (e.g., \"rec-abc123xyz\")"
+                                },
+                                "recordingUrl": {
+                                  "type": "string",
+                                  "description": "Pre-signed URL to access the recording file (e.g., \"https://example.com/recordings/presigned-url\")"
+                                },
+                                "size": {
+                                  "type": "number",
+                                  "description": "The size of the recording in bytes (e.g., 1048576)"
+                                },
+                                "duration": {
+                                  "type": "number",
+                                  "description": "The duration of the recording in seconds (e.g., 300)"
+                                },
+                                "recording_played": {
+                                  "type": "boolean",
+                                  "description": "Whether the call recording has been played (e.g., false)"
+                                },
+                                "recording_type": {
+                                  "type": "string",
+                                  "description": "The type of the recording",
+                                  "enum": [
+                                    "CALL",
+                                    "VOICEMAIL"
+                                  ]
+                                }
+                              },
+                              "required": [
+                                "uid",
+                                "size",
+                                "duration",
+                                "recording_type"
+                              ],
+                              "example": {
+                                "uid": "rec-abc123xyz",
+                                "recordingUrl": "https://example.com/recordings/presigned-url",
+                                "size": 1048576,
+                                "duration": 300,
+                                "recording_played": false,
+                                "recording_type": "CALL"
+                              },
+                              "description": "The call recording details"
+                            },
+                            "external_app_url": {
+                              "type": "string",
+                              "description": "Link to an application page with additional details about the call (e.g., \"https://example.com/call-details\")"
+                            },
+                            "external_app_name": {
+                              "type": "string",
+                              "description": "The name of the external application that originated or manages the call (e.g., \"my.pa\")"
+                            },
+                            "source_id": {
+                              "type": "string",
+                              "description": "A unique source identifier for the call from the provider system (e.g., \"call-src-001\")"
+                            },
+                            "external_uuid": {
+                              "type": "string",
+                              "description": "An external unique identifier for the call conversation from the provider system (e.g., \"ext-call-001\")"
+                            },
+                            "handled_by_staff_uid": {
+                              "type": "string",
+                              "description": "The unique identifier of the staff who handled the call"
+                            },
+                            "handled_at": {
+                              "type": "string",
+                              "description": "The date and time when the call was handled",
+                              "format": "date-time"
+                            },
+                            "deleted_at": {
+                              "type": "string",
+                              "description": "Time the call was deleted - is null if the call is not deleted"
+                            },
+                            "transcript_status": {
+                              "type": "string",
+                              "nullable": true,
+                              "enum": [
+                                "IN_PROGRESS",
+                                "DONE",
+                                "FAILED"
+                              ],
+                              "description": "Processing status of the associated transcript. IN_PROGRESS means the transcript is being generated, DONE means it is ready, FAILED means generation failed (e.g., \"DONE\")"
+                            }
+                          },
+                          "example": {
+                            "uid": "d290f1ee-6c54-4b01-90e6-d701748f0851",
+                            "created_at": "2021-07-20T14:00:00.000Z",
+                            "updated_at": "2021-07-20T14:00:00.000Z",
+                            "duration": 120,
+                            "status": "ANSWERED_BY_STAFF",
+                            "direction": "INBOUND",
+                            "staff_uid": "d290f1ee-6c54-4b01-90e6-d701748f0851",
+                            "client_uid": "d290f1ee-6c54-4b01-90e6-d701748f0851",
+                            "from_number": "183466347342",
+                            "to_number": "183466347342",
+                            "call_summary": "Client called to ask about their account balance",
+                            "recording": {
+                              "uid": "rec-abc123xyz",
+                              "recordingUrl": "https://example.com/recordings/presigned-url",
+                              "size": 1048576,
+                              "duration": 300,
+                              "recording_played": false,
+                              "recording_type": "CALL"
+                            },
+                            "external_app_url": "https://example.com/call-details",
+                            "external_app_name": "my.pa",
+                            "source_id": "call-src-001",
+                            "external_uuid": "ext-call-001",
+                            "handled_by_staff_uid": "d290f1ee-6c54-4b01-90e6-d701748f0851",
+                            "handled_at": "2021-07-20T14:00:00.000Z",
+                            "deleted_at": null,
+                            "transcript_status": "DONE"
+                          },
+                          "description": "Represents a phone call record, including participants, status, recording and audit timestamps."
                         }
                       }
                     }
@@ -2541,7 +4101,182 @@
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/communication/voiceCall.json"
+                          "type": "object",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "description": "Unique identifier of the VoiceCall object"
+                            },
+                            "duration": {
+                              "type": "integer",
+                              "description": "Duration of the call in seconds"
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "description": "The time the call was created"
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "description": "The time the call was last updated"
+                            },
+                            "status": {
+                              "type": "string",
+                              "enum": [
+                                "INCOMING_CALL",
+                                "ANSWERED_BY_STAFF",
+                                "MISSED",
+                                "ANSWERED_BY_CALLS_PROVIDER",
+                                "MISSED_CALL_HANDLED",
+                                "VOICEMAIL"
+                              ],
+                              "description": "The status of the call (e.g., \"ANSWERED_BY_STAFF\")"
+                            },
+                            "direction": {
+                              "type": "string",
+                              "enum": [
+                                "INBOUND",
+                                "OUTBOUND"
+                              ],
+                              "description": "The direction of the call. INBOUND for incoming calls to the business, OUTBOUND for outgoing calls from the business. Values are uppercase (e.g., \"INBOUND\")."
+                            },
+                            "staff_uid": {
+                              "type": "string",
+                              "description": "Unique identifier of the staff member who answered the call"
+                            },
+                            "client_uid": {
+                              "type": "string",
+                              "description": "Unique identifier of the client who made the call"
+                            },
+                            "from_number": {
+                              "type": "string",
+                              "description": "The phone number the call was made from"
+                            },
+                            "to_number": {
+                              "type": "string",
+                              "description": "The phone number the call was made to"
+                            },
+                            "call_summary": {
+                              "type": "string",
+                              "description": "Text summary of the call"
+                            },
+                            "recording": {
+                              "type": "object",
+                              "properties": {
+                                "uid": {
+                                  "type": "string",
+                                  "description": "Unique identifier of the recording entity (e.g., \"rec-abc123xyz\")"
+                                },
+                                "recordingUrl": {
+                                  "type": "string",
+                                  "description": "Pre-signed URL to access the recording file (e.g., \"https://example.com/recordings/presigned-url\")"
+                                },
+                                "size": {
+                                  "type": "number",
+                                  "description": "The size of the recording in bytes (e.g., 1048576)"
+                                },
+                                "duration": {
+                                  "type": "number",
+                                  "description": "The duration of the recording in seconds (e.g., 300)"
+                                },
+                                "recording_played": {
+                                  "type": "boolean",
+                                  "description": "Whether the call recording has been played (e.g., false)"
+                                },
+                                "recording_type": {
+                                  "type": "string",
+                                  "description": "The type of the recording",
+                                  "enum": [
+                                    "CALL",
+                                    "VOICEMAIL"
+                                  ]
+                                }
+                              },
+                              "required": [
+                                "uid",
+                                "size",
+                                "duration",
+                                "recording_type"
+                              ],
+                              "example": {
+                                "uid": "rec-abc123xyz",
+                                "recordingUrl": "https://example.com/recordings/presigned-url",
+                                "size": 1048576,
+                                "duration": 300,
+                                "recording_played": false,
+                                "recording_type": "CALL"
+                              },
+                              "description": "The call recording details"
+                            },
+                            "external_app_url": {
+                              "type": "string",
+                              "description": "Link to an application page with additional details about the call (e.g., \"https://example.com/call-details\")"
+                            },
+                            "external_app_name": {
+                              "type": "string",
+                              "description": "The name of the external application that originated or manages the call (e.g., \"my.pa\")"
+                            },
+                            "source_id": {
+                              "type": "string",
+                              "description": "A unique source identifier for the call from the provider system (e.g., \"call-src-001\")"
+                            },
+                            "external_uuid": {
+                              "type": "string",
+                              "description": "An external unique identifier for the call conversation from the provider system (e.g., \"ext-call-001\")"
+                            },
+                            "handled_by_staff_uid": {
+                              "type": "string",
+                              "description": "The unique identifier of the staff who handled the call"
+                            },
+                            "handled_at": {
+                              "type": "string",
+                              "description": "The date and time when the call was handled",
+                              "format": "date-time"
+                            },
+                            "deleted_at": {
+                              "type": "string",
+                              "description": "Time the call was deleted - is null if the call is not deleted"
+                            },
+                            "transcript_status": {
+                              "type": "string",
+                              "nullable": true,
+                              "enum": [
+                                "IN_PROGRESS",
+                                "DONE",
+                                "FAILED"
+                              ],
+                              "description": "Processing status of the associated transcript. IN_PROGRESS means the transcript is being generated, DONE means it is ready, FAILED means generation failed (e.g., \"DONE\")"
+                            }
+                          },
+                          "example": {
+                            "uid": "d290f1ee-6c54-4b01-90e6-d701748f0851",
+                            "created_at": "2021-07-20T14:00:00.000Z",
+                            "updated_at": "2021-07-20T14:00:00.000Z",
+                            "duration": 120,
+                            "status": "ANSWERED_BY_STAFF",
+                            "direction": "INBOUND",
+                            "staff_uid": "d290f1ee-6c54-4b01-90e6-d701748f0851",
+                            "client_uid": "d290f1ee-6c54-4b01-90e6-d701748f0851",
+                            "from_number": "183466347342",
+                            "to_number": "183466347342",
+                            "call_summary": "Client called to ask about their account balance",
+                            "recording": {
+                              "uid": "rec-abc123xyz",
+                              "recordingUrl": "https://example.com/recordings/presigned-url",
+                              "size": 1048576,
+                              "duration": 300,
+                              "recording_played": false,
+                              "recording_type": "CALL"
+                            },
+                            "external_app_url": "https://example.com/call-details",
+                            "external_app_name": "my.pa",
+                            "source_id": "call-src-001",
+                            "external_uuid": "ext-call-001",
+                            "handled_by_staff_uid": "d290f1ee-6c54-4b01-90e6-d701748f0851",
+                            "handled_at": "2021-07-20T14:00:00.000Z",
+                            "deleted_at": null,
+                            "transcript_status": "DONE"
+                          },
+                          "description": "Represents a phone call record, including participants, status, recording and audit timestamps."
                         }
                       }
                     }
@@ -2951,7 +4686,50 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
@@ -2962,7 +4740,484 @@
                               "description": "List of NotificationTemplates",
                               "type": "array",
                               "items": {
-                                "$ref": "https://vcita.github.io/developers-hub/entities/communication/notificationTemplate.json"
+                                "title": "NotificationTemplate",
+                                "description": "Metadata definition for notification templates and delivery settings.",
+                                "type": "object",
+                                "properties": {
+                                  "uid": {
+                                    "type": "string",
+                                    "description": "Unique identifier for the entity instance."
+                                  },
+                                  "code_name": {
+                                    "type": "string",
+                                    "description": "Unique identifier name for the notification"
+                                  },
+                                  "title": {
+                                    "description": "The display name of the notification template that appears in the staff portal notification settings. This is what users see when browsing available notification options (e.g., \"Payment Received Notification\"). Should contain at least one English locale entry when creating a template.",
+                                    "$ref": "#/definitions/localizedTextList"
+                                  },
+                                  "description": {
+                                    "description": "A brief explanation that appears in the staff portal notification settings to help them understand what this notification is for and when it will be triggered. Should contain at least one English locale entry when creating a template.",
+                                    "$ref": "#/definitions/localizedTextList"
+                                  },
+                                  "category": {
+                                    "type": "string",
+                                    "description": "The functional category this notification belongs to (e.g., \"payments\", \"booking\", \"documents\").",
+                                    "enum": [
+                                      "payments",
+                                      "clients",
+                                      "calendar",
+                                      "booking",
+                                      "marketing",
+                                      "teamchat",
+                                      "scheduling",
+                                      "advertising",
+                                      "group_events",
+                                      "documents",
+                                      "messages",
+                                      "reviews",
+                                      "social",
+                                      "account"
+                                    ]
+                                  },
+                                  "configurable_by_staff": {
+                                    "type": "boolean",
+                                    "description": "Boolean flag that determines whether staff members can customize or modify this notification template through the staff portal."
+                                  },
+                                  "delivery_channel": {
+                                    "type": "array",
+                                    "description": "List of delivery channels for the notification.",
+                                    "items": {
+                                      "type": "string",
+                                      "enum": [
+                                        "push",
+                                        "pane",
+                                        "email",
+                                        "sms"
+                                      ]
+                                    },
+                                    "minItems": 1
+                                  },
+                                  "trigger_type": {
+                                    "type": "string",
+                                    "description": "Type of trigger for the notification.",
+                                    "enum": [
+                                      "system",
+                                      "client"
+                                    ]
+                                  },
+                                  "content": {
+                                    "type": "object",
+                                    "description": "Notification content for 'email', 'staff_portal', and/or 'sms'. Not all content sections are required - only the channels that are relevant to the notification need to be populated.",
+                                    "properties": {
+                                      "staff_portal": {
+                                        "type": "object",
+                                        "description": "Staff portal notification content. This section is optional and may be omitted or contain empty arrays for templates not intended for staff portal delivery.",
+                                        "properties": {
+                                          "title": {
+                                            "description": "Title for staff portal notification. May be an empty array if not configured.",
+                                            "$ref": "#/definitions/localizedTextList"
+                                          },
+                                          "message_body": {
+                                            "description": "Message body for staff portal notification. May be an empty array if not configured.",
+                                            "$ref": "#/definitions/localizedTextList"
+                                          },
+                                          "deep_link": {
+                                            "type": "string",
+                                            "description": "Optional deep link URL for notification action."
+                                          }
+                                        }
+                                      },
+                                      "email": {
+                                        "type": "object",
+                                        "description": "Email notification content. This section is optional and may contain empty arrays for templates not intended for email delivery.",
+                                        "properties": {
+                                          "subject": {
+                                            "description": "Email subject line. May be an empty array if not configured.",
+                                            "$ref": "#/definitions/localizedTextList"
+                                          },
+                                          "top_image": {
+                                            "type": "object",
+                                            "description": "Image at the top of the email.",
+                                            "properties": {
+                                              "url": {
+                                                "type": "string",
+                                                "description": "Image URL."
+                                              },
+                                              "width": {
+                                                "type": "integer",
+                                                "description": "Image width in pixels."
+                                              },
+                                              "alt": {
+                                                "description": "Alternative text for the image.",
+                                                "$ref": "#/definitions/localizedTextList"
+                                              }
+                                            }
+                                          },
+                                          "main_title": {
+                                            "description": "Header or introduction text for the email. May be an empty array if not configured.",
+                                            "$ref": "#/definitions/localizedTextList"
+                                          },
+                                          "main_text": {
+                                            "description": "Main content of the email. May be an empty array if not configured.",
+                                            "$ref": "#/definitions/localizedTextList"
+                                          },
+                                          "middle_image": {
+                                            "type": "object",
+                                            "description": "Image in the middle of the email.",
+                                            "properties": {
+                                              "url": {
+                                                "type": "string",
+                                                "description": "Image URL."
+                                              },
+                                              "width": {
+                                                "type": "integer",
+                                                "description": "Image width in pixels."
+                                              },
+                                              "alt": {
+                                                "description": "Alternative text for the image.",
+                                                "$ref": "#/definitions/localizedTextList"
+                                              }
+                                            }
+                                          },
+                                          "middle_text": {
+                                            "description": "Middle content of the email.",
+                                            "$ref": "#/definitions/localizedTextList"
+                                          },
+                                          "footer_text": {
+                                            "description": "Footer or closing text for the email.",
+                                            "$ref": "#/definitions/localizedTextList"
+                                          },
+                                          "primary_cta_button": {
+                                            "type": "object",
+                                            "description": "Call-to-action button details.",
+                                            "properties": {
+                                              "text": {
+                                                "description": "Button text.",
+                                                "$ref": "#/definitions/localizedTextList"
+                                              },
+                                              "url": {
+                                                "type": "string",
+                                                "description": "Button URL."
+                                              },
+                                              "alt": {
+                                                "description": "Alternative text for the button.",
+                                                "$ref": "#/definitions/localizedTextList"
+                                              }
+                                            }
+                                          },
+                                          "secondary_cta_button": {
+                                            "type": "object",
+                                            "description": "Secondary call-to-action button details.",
+                                            "properties": {
+                                              "text": {
+                                                "description": "Button text.",
+                                                "$ref": "#/definitions/localizedTextList"
+                                              },
+                                              "url": {
+                                                "type": "string",
+                                                "description": "Button URL."
+                                              },
+                                              "alt": {
+                                                "description": "Alternative text for the button.",
+                                                "$ref": "#/definitions/localizedTextList"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "sms": {
+                                        "type": "object",
+                                        "description": "SMS notification content. This section is optional and may contain empty arrays for templates not intended for SMS delivery.",
+                                        "properties": {
+                                          "message_body": {
+                                            "description": "Message body for SMS notification. May be an empty array if not configured.",
+                                            "$ref": "#/definitions/localizedTextList"
+                                          },
+                                          "deep_link": {
+                                            "type": "string",
+                                            "description": "Optional deep link URL for SMS notification action."
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "created_at": {
+                                    "type": "string",
+                                    "format": "date-time",
+                                    "description": "ISO8601 timestamp of when the entity was created."
+                                  },
+                                  "updated_at": {
+                                    "type": "string",
+                                    "format": "date-time",
+                                    "description": "ISO8601 timestamp of the last update to the entity."
+                                  }
+                                },
+                                "required": [
+                                  "uid",
+                                  "code_name",
+                                  "title",
+                                  "description",
+                                  "category",
+                                  "configurable_by_staff",
+                                  "delivery_channel",
+                                  "trigger_type",
+                                  "content",
+                                  "created_at",
+                                  "updated_at"
+                                ],
+                                "definitions": {
+                                  "localizedTextList": {
+                                    "type": "array",
+                                    "description": "List of localized strings. Each item is a locale-value pair: locale is a locale (from enum), value is a string. Each language can appear only once.",
+                                    "uniqueItems": true,
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "locale": {
+                                          "type": "string",
+                                          "enum": [
+                                            "en",
+                                            "fr",
+                                            "de",
+                                            "it",
+                                            "pl",
+                                            "pt",
+                                            "es",
+                                            "nl",
+                                            "he",
+                                            "sl",
+                                            "en_gb"
+                                          ]
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "locale",
+                                        "value"
+                                      ]
+                                    }
+                                  }
+                                },
+                                "example": {
+                                  "uid": "notif-001",
+                                  "code_name": "welcome_new_user",
+                                  "title": [
+                                    {
+                                      "locale": "en",
+                                      "value": "Welcome Notification"
+                                    },
+                                    {
+                                      "locale": "fr",
+                                      "value": "Notification de bienvenue"
+                                    },
+                                    {
+                                      "locale": "de",
+                                      "value": "Willkommensbenachrichtigung"
+                                    }
+                                  ],
+                                  "description": [
+                                    {
+                                      "locale": "en",
+                                      "value": "Sent to new users upon registration."
+                                    },
+                                    {
+                                      "locale": "fr",
+                                      "value": "Envoyé aux nouveaux utilisateurs lors de l'inscription."
+                                    },
+                                    {
+                                      "locale": "es",
+                                      "value": "Enviado a los nuevos usuarios al registrarse."
+                                    }
+                                  ],
+                                  "category": "account",
+                                  "configurable_by_staff": true,
+                                  "delivery_channel": [
+                                    "push",
+                                    "email"
+                                  ],
+                                  "trigger_type": "system",
+                                  "content": {
+                                    "staff_portal": {
+                                      "title": [
+                                        {
+                                          "locale": "en",
+                                          "value": "Welcome!"
+                                        },
+                                        {
+                                          "locale": "fr",
+                                          "value": "Bienvenue!"
+                                        },
+                                        {
+                                          "locale": "es",
+                                          "value": "¡Bienvenido!"
+                                        }
+                                      ],
+                                      "message_body": [
+                                        {
+                                          "locale": "en",
+                                          "value": "Thanks for joining us!"
+                                        },
+                                        {
+                                          "locale": "fr",
+                                          "value": "Merci de nous avoir rejoints!"
+                                        }
+                                      ],
+                                      "deep_link": "https://example.com/welcome"
+                                    },
+                                    "email": {
+                                      "subject": [
+                                        {
+                                          "locale": "en",
+                                          "value": "Welcome to Our Service"
+                                        },
+                                        {
+                                          "locale": "fr",
+                                          "value": "Bienvenue à notre service"
+                                        },
+                                        {
+                                          "locale": "de",
+                                          "value": "Willkommen bei unserem Service"
+                                        }
+                                      ],
+                                      "top_image": {
+                                        "url": "https://example.com/banner.png",
+                                        "width": 600,
+                                        "alt": [
+                                          {
+                                            "locale": "en",
+                                            "value": "Welcome banner"
+                                          },
+                                          {
+                                            "locale": "fr",
+                                            "value": "Bannière de bienvenue"
+                                          }
+                                        ]
+                                      },
+                                      "main_title": [
+                                        {
+                                          "locale": "en",
+                                          "value": "Hello and Welcome!"
+                                        },
+                                        {
+                                          "locale": "fr",
+                                          "value": "Bonjour et bienvenue!"
+                                        }
+                                      ],
+                                      "main_text": [
+                                        {
+                                          "locale": "en",
+                                          "value": "We're excited to have you on board."
+                                        },
+                                        {
+                                          "locale": "es",
+                                          "value": "Estamos emocionados de tenerte con nosotros."
+                                        }
+                                      ],
+                                      "middle_image": {
+                                        "url": "https://example.com/mid.png",
+                                        "width": 400,
+                                        "alt": [
+                                          {
+                                            "locale": "en",
+                                            "value": "Mid section image"
+                                          },
+                                          {
+                                            "locale": "es",
+                                            "value": "Imagen de la sección media"
+                                          }
+                                        ]
+                                      },
+                                      "middle_text": [
+                                        {
+                                          "locale": "en",
+                                          "value": "Here are some tips to get started."
+                                        },
+                                        {
+                                          "locale": "fr",
+                                          "value": "Voici quelques conseils pour commencer."
+                                        }
+                                      ],
+                                      "footer_text": [
+                                        {
+                                          "locale": "en",
+                                          "value": "Best regards, The Team"
+                                        },
+                                        {
+                                          "locale": "de",
+                                          "value": "Mit freundlichen Grüßen, Das Team"
+                                        }
+                                      ],
+                                      "primary_cta_button": {
+                                        "text": [
+                                          {
+                                            "locale": "en",
+                                            "value": "Get Started"
+                                          },
+                                          {
+                                            "locale": "fr",
+                                            "value": "Commencer"
+                                          }
+                                        ],
+                                        "url": "https://example.com/start",
+                                        "alt": [
+                                          {
+                                            "locale": "en",
+                                            "value": "Start now"
+                                          },
+                                          {
+                                            "locale": "fr",
+                                            "value": "Commencez maintenant"
+                                          }
+                                        ]
+                                      },
+                                      "secondary_cta_button": {
+                                        "text": [
+                                          {
+                                            "locale": "en",
+                                            "value": "Contact Support"
+                                          },
+                                          {
+                                            "locale": "es",
+                                            "value": "Contactar Soporte"
+                                          }
+                                        ],
+                                        "url": "https://example.com/support",
+                                        "alt": [
+                                          {
+                                            "locale": "en",
+                                            "value": "Support"
+                                          },
+                                          {
+                                            "locale": "es",
+                                            "value": "Soporte"
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "sms": {
+                                      "message_body": [
+                                        {
+                                          "locale": "en",
+                                          "value": "Welcome! Thanks for joining us. Get started:"
+                                        },
+                                        {
+                                          "locale": "fr",
+                                          "value": "Bienvenue! Merci de nous avoir rejoints. Commencez:"
+                                        },
+                                        {
+                                          "locale": "es",
+                                          "value": "¡Bienvenido! Gracias por unirte. Comienza:"
+                                        }
+                                      ],
+                                      "deep_link": "https://example.com/welcome"
+                                    }
+                                  },
+                                  "created_at": "2024-06-01T12:00:00Z",
+                                  "updated_at": "2024-06-01T12:00:00Z"
+                                }
                               }
                             }
                           }
@@ -2996,22 +5251,176 @@
                 "type": "object",
                 "properties": {
                   "code_name": {
-                    "$ref": "https://vcita.github.io/developers-hub/entities/communication/notificationTemplate.json#/properties/code_name"
+                    "type": "string",
+                    "description": "Unique identifier name for the notification"
                   },
                   "title": {
-                    "$ref": "https://vcita.github.io/developers-hub/entities/communication/notificationTemplate.json#/properties/title"
+                    "description": "The display name of the notification template that appears in the staff portal notification settings. This is what users see when browsing available notification options (e.g., \"Payment Received Notification\"). Should contain at least one English locale entry when creating a template.",
+                    "$ref": "#/definitions/localizedTextList"
                   },
                   "description": {
-                    "$ref": "https://vcita.github.io/developers-hub/entities/communication/notificationTemplate.json#/properties/description"
+                    "description": "A brief explanation that appears in the staff portal notification settings to help them understand what this notification is for and when it will be triggered. Should contain at least one English locale entry when creating a template.",
+                    "$ref": "#/definitions/localizedTextList"
                   },
                   "category": {
-                    "$ref": "https://vcita.github.io/developers-hub/entities/communication/notificationTemplate.json#/properties/category"
+                    "type": "string",
+                    "description": "The functional category this notification belongs to (e.g., \"payments\", \"booking\", \"documents\").",
+                    "enum": [
+                      "payments",
+                      "clients",
+                      "calendar",
+                      "booking",
+                      "marketing",
+                      "teamchat",
+                      "scheduling",
+                      "advertising",
+                      "group_events",
+                      "documents",
+                      "messages",
+                      "reviews",
+                      "social",
+                      "account"
+                    ]
                   },
                   "configurable_by_staff": {
-                    "$ref": "https://vcita.github.io/developers-hub/entities/communication/notificationTemplate.json#/properties/configurable_by_staff"
+                    "type": "boolean",
+                    "description": "Boolean flag that determines whether staff members can customize or modify this notification template through the staff portal."
                   },
                   "content": {
-                    "$ref": "https://vcita.github.io/developers-hub/entities/communication/notificationTemplate.json#/properties/content"
+                    "type": "object",
+                    "description": "Notification content for 'email', 'staff_portal', and/or 'sms'. Not all content sections are required - only the channels that are relevant to the notification need to be populated.",
+                    "properties": {
+                      "staff_portal": {
+                        "type": "object",
+                        "description": "Staff portal notification content. This section is optional and may be omitted or contain empty arrays for templates not intended for staff portal delivery.",
+                        "properties": {
+                          "title": {
+                            "description": "Title for staff portal notification. May be an empty array if not configured.",
+                            "$ref": "#/definitions/localizedTextList"
+                          },
+                          "message_body": {
+                            "description": "Message body for staff portal notification. May be an empty array if not configured.",
+                            "$ref": "#/definitions/localizedTextList"
+                          },
+                          "deep_link": {
+                            "type": "string",
+                            "description": "Optional deep link URL for notification action."
+                          }
+                        }
+                      },
+                      "email": {
+                        "type": "object",
+                        "description": "Email notification content. This section is optional and may contain empty arrays for templates not intended for email delivery.",
+                        "properties": {
+                          "subject": {
+                            "description": "Email subject line. May be an empty array if not configured.",
+                            "$ref": "#/definitions/localizedTextList"
+                          },
+                          "top_image": {
+                            "type": "object",
+                            "description": "Image at the top of the email.",
+                            "properties": {
+                              "url": {
+                                "type": "string",
+                                "description": "Image URL."
+                              },
+                              "width": {
+                                "type": "integer",
+                                "description": "Image width in pixels."
+                              },
+                              "alt": {
+                                "description": "Alternative text for the image.",
+                                "$ref": "#/definitions/localizedTextList"
+                              }
+                            }
+                          },
+                          "main_title": {
+                            "description": "Header or introduction text for the email. May be an empty array if not configured.",
+                            "$ref": "#/definitions/localizedTextList"
+                          },
+                          "main_text": {
+                            "description": "Main content of the email. May be an empty array if not configured.",
+                            "$ref": "#/definitions/localizedTextList"
+                          },
+                          "middle_image": {
+                            "type": "object",
+                            "description": "Image in the middle of the email.",
+                            "properties": {
+                              "url": {
+                                "type": "string",
+                                "description": "Image URL."
+                              },
+                              "width": {
+                                "type": "integer",
+                                "description": "Image width in pixels."
+                              },
+                              "alt": {
+                                "description": "Alternative text for the image.",
+                                "$ref": "#/definitions/localizedTextList"
+                              }
+                            }
+                          },
+                          "middle_text": {
+                            "description": "Middle content of the email.",
+                            "$ref": "#/definitions/localizedTextList"
+                          },
+                          "footer_text": {
+                            "description": "Footer or closing text for the email.",
+                            "$ref": "#/definitions/localizedTextList"
+                          },
+                          "primary_cta_button": {
+                            "type": "object",
+                            "description": "Call-to-action button details.",
+                            "properties": {
+                              "text": {
+                                "description": "Button text.",
+                                "$ref": "#/definitions/localizedTextList"
+                              },
+                              "url": {
+                                "type": "string",
+                                "description": "Button URL."
+                              },
+                              "alt": {
+                                "description": "Alternative text for the button.",
+                                "$ref": "#/definitions/localizedTextList"
+                              }
+                            }
+                          },
+                          "secondary_cta_button": {
+                            "type": "object",
+                            "description": "Secondary call-to-action button details.",
+                            "properties": {
+                              "text": {
+                                "description": "Button text.",
+                                "$ref": "#/definitions/localizedTextList"
+                              },
+                              "url": {
+                                "type": "string",
+                                "description": "Button URL."
+                              },
+                              "alt": {
+                                "description": "Alternative text for the button.",
+                                "$ref": "#/definitions/localizedTextList"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "sms": {
+                        "type": "object",
+                        "description": "SMS notification content. This section is optional and may contain empty arrays for templates not intended for SMS delivery.",
+                        "properties": {
+                          "message_body": {
+                            "description": "Message body for SMS notification. May be an empty array if not configured.",
+                            "$ref": "#/definitions/localizedTextList"
+                          },
+                          "deep_link": {
+                            "type": "string",
+                            "description": "Optional deep link URL for SMS notification action."
+                          }
+                        }
+                      }
+                    }
                   }
                 },
                 "required": [
@@ -3034,12 +5443,532 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/communication/notificationTemplate.json"
+                          "title": "NotificationTemplate",
+                          "description": "Metadata definition for notification templates and delivery settings.",
+                          "type": "object",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "description": "Unique identifier for the entity instance."
+                            },
+                            "code_name": {
+                              "type": "string",
+                              "description": "Unique identifier name for the notification"
+                            },
+                            "title": {
+                              "description": "The display name of the notification template that appears in the staff portal notification settings. This is what users see when browsing available notification options (e.g., \"Payment Received Notification\"). Should contain at least one English locale entry when creating a template.",
+                              "$ref": "#/definitions/localizedTextList"
+                            },
+                            "description": {
+                              "description": "A brief explanation that appears in the staff portal notification settings to help them understand what this notification is for and when it will be triggered. Should contain at least one English locale entry when creating a template.",
+                              "$ref": "#/definitions/localizedTextList"
+                            },
+                            "category": {
+                              "type": "string",
+                              "description": "The functional category this notification belongs to (e.g., \"payments\", \"booking\", \"documents\").",
+                              "enum": [
+                                "payments",
+                                "clients",
+                                "calendar",
+                                "booking",
+                                "marketing",
+                                "teamchat",
+                                "scheduling",
+                                "advertising",
+                                "group_events",
+                                "documents",
+                                "messages",
+                                "reviews",
+                                "social",
+                                "account"
+                              ]
+                            },
+                            "configurable_by_staff": {
+                              "type": "boolean",
+                              "description": "Boolean flag that determines whether staff members can customize or modify this notification template through the staff portal."
+                            },
+                            "delivery_channel": {
+                              "type": "array",
+                              "description": "List of delivery channels for the notification.",
+                              "items": {
+                                "type": "string",
+                                "enum": [
+                                  "push",
+                                  "pane",
+                                  "email",
+                                  "sms"
+                                ]
+                              },
+                              "minItems": 1
+                            },
+                            "trigger_type": {
+                              "type": "string",
+                              "description": "Type of trigger for the notification.",
+                              "enum": [
+                                "system",
+                                "client"
+                              ]
+                            },
+                            "content": {
+                              "type": "object",
+                              "description": "Notification content for 'email', 'staff_portal', and/or 'sms'. Not all content sections are required - only the channels that are relevant to the notification need to be populated.",
+                              "properties": {
+                                "staff_portal": {
+                                  "type": "object",
+                                  "description": "Staff portal notification content. This section is optional and may be omitted or contain empty arrays for templates not intended for staff portal delivery.",
+                                  "properties": {
+                                    "title": {
+                                      "description": "Title for staff portal notification. May be an empty array if not configured.",
+                                      "$ref": "#/definitions/localizedTextList"
+                                    },
+                                    "message_body": {
+                                      "description": "Message body for staff portal notification. May be an empty array if not configured.",
+                                      "$ref": "#/definitions/localizedTextList"
+                                    },
+                                    "deep_link": {
+                                      "type": "string",
+                                      "description": "Optional deep link URL for notification action."
+                                    }
+                                  }
+                                },
+                                "email": {
+                                  "type": "object",
+                                  "description": "Email notification content. This section is optional and may contain empty arrays for templates not intended for email delivery.",
+                                  "properties": {
+                                    "subject": {
+                                      "description": "Email subject line. May be an empty array if not configured.",
+                                      "$ref": "#/definitions/localizedTextList"
+                                    },
+                                    "top_image": {
+                                      "type": "object",
+                                      "description": "Image at the top of the email.",
+                                      "properties": {
+                                        "url": {
+                                          "type": "string",
+                                          "description": "Image URL."
+                                        },
+                                        "width": {
+                                          "type": "integer",
+                                          "description": "Image width in pixels."
+                                        },
+                                        "alt": {
+                                          "description": "Alternative text for the image.",
+                                          "$ref": "#/definitions/localizedTextList"
+                                        }
+                                      }
+                                    },
+                                    "main_title": {
+                                      "description": "Header or introduction text for the email. May be an empty array if not configured.",
+                                      "$ref": "#/definitions/localizedTextList"
+                                    },
+                                    "main_text": {
+                                      "description": "Main content of the email. May be an empty array if not configured.",
+                                      "$ref": "#/definitions/localizedTextList"
+                                    },
+                                    "middle_image": {
+                                      "type": "object",
+                                      "description": "Image in the middle of the email.",
+                                      "properties": {
+                                        "url": {
+                                          "type": "string",
+                                          "description": "Image URL."
+                                        },
+                                        "width": {
+                                          "type": "integer",
+                                          "description": "Image width in pixels."
+                                        },
+                                        "alt": {
+                                          "description": "Alternative text for the image.",
+                                          "$ref": "#/definitions/localizedTextList"
+                                        }
+                                      }
+                                    },
+                                    "middle_text": {
+                                      "description": "Middle content of the email.",
+                                      "$ref": "#/definitions/localizedTextList"
+                                    },
+                                    "footer_text": {
+                                      "description": "Footer or closing text for the email.",
+                                      "$ref": "#/definitions/localizedTextList"
+                                    },
+                                    "primary_cta_button": {
+                                      "type": "object",
+                                      "description": "Call-to-action button details.",
+                                      "properties": {
+                                        "text": {
+                                          "description": "Button text.",
+                                          "$ref": "#/definitions/localizedTextList"
+                                        },
+                                        "url": {
+                                          "type": "string",
+                                          "description": "Button URL."
+                                        },
+                                        "alt": {
+                                          "description": "Alternative text for the button.",
+                                          "$ref": "#/definitions/localizedTextList"
+                                        }
+                                      }
+                                    },
+                                    "secondary_cta_button": {
+                                      "type": "object",
+                                      "description": "Secondary call-to-action button details.",
+                                      "properties": {
+                                        "text": {
+                                          "description": "Button text.",
+                                          "$ref": "#/definitions/localizedTextList"
+                                        },
+                                        "url": {
+                                          "type": "string",
+                                          "description": "Button URL."
+                                        },
+                                        "alt": {
+                                          "description": "Alternative text for the button.",
+                                          "$ref": "#/definitions/localizedTextList"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "sms": {
+                                  "type": "object",
+                                  "description": "SMS notification content. This section is optional and may contain empty arrays for templates not intended for SMS delivery.",
+                                  "properties": {
+                                    "message_body": {
+                                      "description": "Message body for SMS notification. May be an empty array if not configured.",
+                                      "$ref": "#/definitions/localizedTextList"
+                                    },
+                                    "deep_link": {
+                                      "type": "string",
+                                      "description": "Optional deep link URL for SMS notification action."
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "description": "ISO8601 timestamp of when the entity was created."
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "description": "ISO8601 timestamp of the last update to the entity."
+                            }
+                          },
+                          "required": [
+                            "uid",
+                            "code_name",
+                            "title",
+                            "description",
+                            "category",
+                            "configurable_by_staff",
+                            "delivery_channel",
+                            "trigger_type",
+                            "content",
+                            "created_at",
+                            "updated_at"
+                          ],
+                          "definitions": {
+                            "localizedTextList": {
+                              "type": "array",
+                              "description": "List of localized strings. Each item is a locale-value pair: locale is a locale (from enum), value is a string. Each language can appear only once.",
+                              "uniqueItems": true,
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "locale": {
+                                    "type": "string",
+                                    "enum": [
+                                      "en",
+                                      "fr",
+                                      "de",
+                                      "it",
+                                      "pl",
+                                      "pt",
+                                      "es",
+                                      "nl",
+                                      "he",
+                                      "sl",
+                                      "en_gb"
+                                    ]
+                                  },
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "locale",
+                                  "value"
+                                ]
+                              }
+                            }
+                          },
+                          "example": {
+                            "uid": "notif-001",
+                            "code_name": "welcome_new_user",
+                            "title": [
+                              {
+                                "locale": "en",
+                                "value": "Welcome Notification"
+                              },
+                              {
+                                "locale": "fr",
+                                "value": "Notification de bienvenue"
+                              },
+                              {
+                                "locale": "de",
+                                "value": "Willkommensbenachrichtigung"
+                              }
+                            ],
+                            "description": [
+                              {
+                                "locale": "en",
+                                "value": "Sent to new users upon registration."
+                              },
+                              {
+                                "locale": "fr",
+                                "value": "Envoyé aux nouveaux utilisateurs lors de l'inscription."
+                              },
+                              {
+                                "locale": "es",
+                                "value": "Enviado a los nuevos usuarios al registrarse."
+                              }
+                            ],
+                            "category": "account",
+                            "configurable_by_staff": true,
+                            "delivery_channel": [
+                              "push",
+                              "email"
+                            ],
+                            "trigger_type": "system",
+                            "content": {
+                              "staff_portal": {
+                                "title": [
+                                  {
+                                    "locale": "en",
+                                    "value": "Welcome!"
+                                  },
+                                  {
+                                    "locale": "fr",
+                                    "value": "Bienvenue!"
+                                  },
+                                  {
+                                    "locale": "es",
+                                    "value": "¡Bienvenido!"
+                                  }
+                                ],
+                                "message_body": [
+                                  {
+                                    "locale": "en",
+                                    "value": "Thanks for joining us!"
+                                  },
+                                  {
+                                    "locale": "fr",
+                                    "value": "Merci de nous avoir rejoints!"
+                                  }
+                                ],
+                                "deep_link": "https://example.com/welcome"
+                              },
+                              "email": {
+                                "subject": [
+                                  {
+                                    "locale": "en",
+                                    "value": "Welcome to Our Service"
+                                  },
+                                  {
+                                    "locale": "fr",
+                                    "value": "Bienvenue à notre service"
+                                  },
+                                  {
+                                    "locale": "de",
+                                    "value": "Willkommen bei unserem Service"
+                                  }
+                                ],
+                                "top_image": {
+                                  "url": "https://example.com/banner.png",
+                                  "width": 600,
+                                  "alt": [
+                                    {
+                                      "locale": "en",
+                                      "value": "Welcome banner"
+                                    },
+                                    {
+                                      "locale": "fr",
+                                      "value": "Bannière de bienvenue"
+                                    }
+                                  ]
+                                },
+                                "main_title": [
+                                  {
+                                    "locale": "en",
+                                    "value": "Hello and Welcome!"
+                                  },
+                                  {
+                                    "locale": "fr",
+                                    "value": "Bonjour et bienvenue!"
+                                  }
+                                ],
+                                "main_text": [
+                                  {
+                                    "locale": "en",
+                                    "value": "We're excited to have you on board."
+                                  },
+                                  {
+                                    "locale": "es",
+                                    "value": "Estamos emocionados de tenerte con nosotros."
+                                  }
+                                ],
+                                "middle_image": {
+                                  "url": "https://example.com/mid.png",
+                                  "width": 400,
+                                  "alt": [
+                                    {
+                                      "locale": "en",
+                                      "value": "Mid section image"
+                                    },
+                                    {
+                                      "locale": "es",
+                                      "value": "Imagen de la sección media"
+                                    }
+                                  ]
+                                },
+                                "middle_text": [
+                                  {
+                                    "locale": "en",
+                                    "value": "Here are some tips to get started."
+                                  },
+                                  {
+                                    "locale": "fr",
+                                    "value": "Voici quelques conseils pour commencer."
+                                  }
+                                ],
+                                "footer_text": [
+                                  {
+                                    "locale": "en",
+                                    "value": "Best regards, The Team"
+                                  },
+                                  {
+                                    "locale": "de",
+                                    "value": "Mit freundlichen Grüßen, Das Team"
+                                  }
+                                ],
+                                "primary_cta_button": {
+                                  "text": [
+                                    {
+                                      "locale": "en",
+                                      "value": "Get Started"
+                                    },
+                                    {
+                                      "locale": "fr",
+                                      "value": "Commencer"
+                                    }
+                                  ],
+                                  "url": "https://example.com/start",
+                                  "alt": [
+                                    {
+                                      "locale": "en",
+                                      "value": "Start now"
+                                    },
+                                    {
+                                      "locale": "fr",
+                                      "value": "Commencez maintenant"
+                                    }
+                                  ]
+                                },
+                                "secondary_cta_button": {
+                                  "text": [
+                                    {
+                                      "locale": "en",
+                                      "value": "Contact Support"
+                                    },
+                                    {
+                                      "locale": "es",
+                                      "value": "Contactar Soporte"
+                                    }
+                                  ],
+                                  "url": "https://example.com/support",
+                                  "alt": [
+                                    {
+                                      "locale": "en",
+                                      "value": "Support"
+                                    },
+                                    {
+                                      "locale": "es",
+                                      "value": "Soporte"
+                                    }
+                                  ]
+                                }
+                              },
+                              "sms": {
+                                "message_body": [
+                                  {
+                                    "locale": "en",
+                                    "value": "Welcome! Thanks for joining us. Get started:"
+                                  },
+                                  {
+                                    "locale": "fr",
+                                    "value": "Bienvenue! Merci de nous avoir rejoints. Commencez:"
+                                  },
+                                  {
+                                    "locale": "es",
+                                    "value": "¡Bienvenido! Gracias por unirte. Comienza:"
+                                  }
+                                ],
+                                "deep_link": "https://example.com/welcome"
+                              }
+                            },
+                            "created_at": "2024-06-01T12:00:00Z",
+                            "updated_at": "2024-06-01T12:00:00Z"
+                          }
                         }
                       }
                     }
@@ -3055,7 +5984,50 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     }
                   ]
                 },
@@ -3106,12 +6078,532 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/communication/notificationTemplate.json"
+                          "title": "NotificationTemplate",
+                          "description": "Metadata definition for notification templates and delivery settings.",
+                          "type": "object",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "description": "Unique identifier for the entity instance."
+                            },
+                            "code_name": {
+                              "type": "string",
+                              "description": "Unique identifier name for the notification"
+                            },
+                            "title": {
+                              "description": "The display name of the notification template that appears in the staff portal notification settings. This is what users see when browsing available notification options (e.g., \"Payment Received Notification\"). Should contain at least one English locale entry when creating a template.",
+                              "$ref": "#/definitions/localizedTextList"
+                            },
+                            "description": {
+                              "description": "A brief explanation that appears in the staff portal notification settings to help them understand what this notification is for and when it will be triggered. Should contain at least one English locale entry when creating a template.",
+                              "$ref": "#/definitions/localizedTextList"
+                            },
+                            "category": {
+                              "type": "string",
+                              "description": "The functional category this notification belongs to (e.g., \"payments\", \"booking\", \"documents\").",
+                              "enum": [
+                                "payments",
+                                "clients",
+                                "calendar",
+                                "booking",
+                                "marketing",
+                                "teamchat",
+                                "scheduling",
+                                "advertising",
+                                "group_events",
+                                "documents",
+                                "messages",
+                                "reviews",
+                                "social",
+                                "account"
+                              ]
+                            },
+                            "configurable_by_staff": {
+                              "type": "boolean",
+                              "description": "Boolean flag that determines whether staff members can customize or modify this notification template through the staff portal."
+                            },
+                            "delivery_channel": {
+                              "type": "array",
+                              "description": "List of delivery channels for the notification.",
+                              "items": {
+                                "type": "string",
+                                "enum": [
+                                  "push",
+                                  "pane",
+                                  "email",
+                                  "sms"
+                                ]
+                              },
+                              "minItems": 1
+                            },
+                            "trigger_type": {
+                              "type": "string",
+                              "description": "Type of trigger for the notification.",
+                              "enum": [
+                                "system",
+                                "client"
+                              ]
+                            },
+                            "content": {
+                              "type": "object",
+                              "description": "Notification content for 'email', 'staff_portal', and/or 'sms'. Not all content sections are required - only the channels that are relevant to the notification need to be populated.",
+                              "properties": {
+                                "staff_portal": {
+                                  "type": "object",
+                                  "description": "Staff portal notification content. This section is optional and may be omitted or contain empty arrays for templates not intended for staff portal delivery.",
+                                  "properties": {
+                                    "title": {
+                                      "description": "Title for staff portal notification. May be an empty array if not configured.",
+                                      "$ref": "#/definitions/localizedTextList"
+                                    },
+                                    "message_body": {
+                                      "description": "Message body for staff portal notification. May be an empty array if not configured.",
+                                      "$ref": "#/definitions/localizedTextList"
+                                    },
+                                    "deep_link": {
+                                      "type": "string",
+                                      "description": "Optional deep link URL for notification action."
+                                    }
+                                  }
+                                },
+                                "email": {
+                                  "type": "object",
+                                  "description": "Email notification content. This section is optional and may contain empty arrays for templates not intended for email delivery.",
+                                  "properties": {
+                                    "subject": {
+                                      "description": "Email subject line. May be an empty array if not configured.",
+                                      "$ref": "#/definitions/localizedTextList"
+                                    },
+                                    "top_image": {
+                                      "type": "object",
+                                      "description": "Image at the top of the email.",
+                                      "properties": {
+                                        "url": {
+                                          "type": "string",
+                                          "description": "Image URL."
+                                        },
+                                        "width": {
+                                          "type": "integer",
+                                          "description": "Image width in pixels."
+                                        },
+                                        "alt": {
+                                          "description": "Alternative text for the image.",
+                                          "$ref": "#/definitions/localizedTextList"
+                                        }
+                                      }
+                                    },
+                                    "main_title": {
+                                      "description": "Header or introduction text for the email. May be an empty array if not configured.",
+                                      "$ref": "#/definitions/localizedTextList"
+                                    },
+                                    "main_text": {
+                                      "description": "Main content of the email. May be an empty array if not configured.",
+                                      "$ref": "#/definitions/localizedTextList"
+                                    },
+                                    "middle_image": {
+                                      "type": "object",
+                                      "description": "Image in the middle of the email.",
+                                      "properties": {
+                                        "url": {
+                                          "type": "string",
+                                          "description": "Image URL."
+                                        },
+                                        "width": {
+                                          "type": "integer",
+                                          "description": "Image width in pixels."
+                                        },
+                                        "alt": {
+                                          "description": "Alternative text for the image.",
+                                          "$ref": "#/definitions/localizedTextList"
+                                        }
+                                      }
+                                    },
+                                    "middle_text": {
+                                      "description": "Middle content of the email.",
+                                      "$ref": "#/definitions/localizedTextList"
+                                    },
+                                    "footer_text": {
+                                      "description": "Footer or closing text for the email.",
+                                      "$ref": "#/definitions/localizedTextList"
+                                    },
+                                    "primary_cta_button": {
+                                      "type": "object",
+                                      "description": "Call-to-action button details.",
+                                      "properties": {
+                                        "text": {
+                                          "description": "Button text.",
+                                          "$ref": "#/definitions/localizedTextList"
+                                        },
+                                        "url": {
+                                          "type": "string",
+                                          "description": "Button URL."
+                                        },
+                                        "alt": {
+                                          "description": "Alternative text for the button.",
+                                          "$ref": "#/definitions/localizedTextList"
+                                        }
+                                      }
+                                    },
+                                    "secondary_cta_button": {
+                                      "type": "object",
+                                      "description": "Secondary call-to-action button details.",
+                                      "properties": {
+                                        "text": {
+                                          "description": "Button text.",
+                                          "$ref": "#/definitions/localizedTextList"
+                                        },
+                                        "url": {
+                                          "type": "string",
+                                          "description": "Button URL."
+                                        },
+                                        "alt": {
+                                          "description": "Alternative text for the button.",
+                                          "$ref": "#/definitions/localizedTextList"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "sms": {
+                                  "type": "object",
+                                  "description": "SMS notification content. This section is optional and may contain empty arrays for templates not intended for SMS delivery.",
+                                  "properties": {
+                                    "message_body": {
+                                      "description": "Message body for SMS notification. May be an empty array if not configured.",
+                                      "$ref": "#/definitions/localizedTextList"
+                                    },
+                                    "deep_link": {
+                                      "type": "string",
+                                      "description": "Optional deep link URL for SMS notification action."
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "description": "ISO8601 timestamp of when the entity was created."
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "description": "ISO8601 timestamp of the last update to the entity."
+                            }
+                          },
+                          "required": [
+                            "uid",
+                            "code_name",
+                            "title",
+                            "description",
+                            "category",
+                            "configurable_by_staff",
+                            "delivery_channel",
+                            "trigger_type",
+                            "content",
+                            "created_at",
+                            "updated_at"
+                          ],
+                          "definitions": {
+                            "localizedTextList": {
+                              "type": "array",
+                              "description": "List of localized strings. Each item is a locale-value pair: locale is a locale (from enum), value is a string. Each language can appear only once.",
+                              "uniqueItems": true,
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "locale": {
+                                    "type": "string",
+                                    "enum": [
+                                      "en",
+                                      "fr",
+                                      "de",
+                                      "it",
+                                      "pl",
+                                      "pt",
+                                      "es",
+                                      "nl",
+                                      "he",
+                                      "sl",
+                                      "en_gb"
+                                    ]
+                                  },
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "locale",
+                                  "value"
+                                ]
+                              }
+                            }
+                          },
+                          "example": {
+                            "uid": "notif-001",
+                            "code_name": "welcome_new_user",
+                            "title": [
+                              {
+                                "locale": "en",
+                                "value": "Welcome Notification"
+                              },
+                              {
+                                "locale": "fr",
+                                "value": "Notification de bienvenue"
+                              },
+                              {
+                                "locale": "de",
+                                "value": "Willkommensbenachrichtigung"
+                              }
+                            ],
+                            "description": [
+                              {
+                                "locale": "en",
+                                "value": "Sent to new users upon registration."
+                              },
+                              {
+                                "locale": "fr",
+                                "value": "Envoyé aux nouveaux utilisateurs lors de l'inscription."
+                              },
+                              {
+                                "locale": "es",
+                                "value": "Enviado a los nuevos usuarios al registrarse."
+                              }
+                            ],
+                            "category": "account",
+                            "configurable_by_staff": true,
+                            "delivery_channel": [
+                              "push",
+                              "email"
+                            ],
+                            "trigger_type": "system",
+                            "content": {
+                              "staff_portal": {
+                                "title": [
+                                  {
+                                    "locale": "en",
+                                    "value": "Welcome!"
+                                  },
+                                  {
+                                    "locale": "fr",
+                                    "value": "Bienvenue!"
+                                  },
+                                  {
+                                    "locale": "es",
+                                    "value": "¡Bienvenido!"
+                                  }
+                                ],
+                                "message_body": [
+                                  {
+                                    "locale": "en",
+                                    "value": "Thanks for joining us!"
+                                  },
+                                  {
+                                    "locale": "fr",
+                                    "value": "Merci de nous avoir rejoints!"
+                                  }
+                                ],
+                                "deep_link": "https://example.com/welcome"
+                              },
+                              "email": {
+                                "subject": [
+                                  {
+                                    "locale": "en",
+                                    "value": "Welcome to Our Service"
+                                  },
+                                  {
+                                    "locale": "fr",
+                                    "value": "Bienvenue à notre service"
+                                  },
+                                  {
+                                    "locale": "de",
+                                    "value": "Willkommen bei unserem Service"
+                                  }
+                                ],
+                                "top_image": {
+                                  "url": "https://example.com/banner.png",
+                                  "width": 600,
+                                  "alt": [
+                                    {
+                                      "locale": "en",
+                                      "value": "Welcome banner"
+                                    },
+                                    {
+                                      "locale": "fr",
+                                      "value": "Bannière de bienvenue"
+                                    }
+                                  ]
+                                },
+                                "main_title": [
+                                  {
+                                    "locale": "en",
+                                    "value": "Hello and Welcome!"
+                                  },
+                                  {
+                                    "locale": "fr",
+                                    "value": "Bonjour et bienvenue!"
+                                  }
+                                ],
+                                "main_text": [
+                                  {
+                                    "locale": "en",
+                                    "value": "We're excited to have you on board."
+                                  },
+                                  {
+                                    "locale": "es",
+                                    "value": "Estamos emocionados de tenerte con nosotros."
+                                  }
+                                ],
+                                "middle_image": {
+                                  "url": "https://example.com/mid.png",
+                                  "width": 400,
+                                  "alt": [
+                                    {
+                                      "locale": "en",
+                                      "value": "Mid section image"
+                                    },
+                                    {
+                                      "locale": "es",
+                                      "value": "Imagen de la sección media"
+                                    }
+                                  ]
+                                },
+                                "middle_text": [
+                                  {
+                                    "locale": "en",
+                                    "value": "Here are some tips to get started."
+                                  },
+                                  {
+                                    "locale": "fr",
+                                    "value": "Voici quelques conseils pour commencer."
+                                  }
+                                ],
+                                "footer_text": [
+                                  {
+                                    "locale": "en",
+                                    "value": "Best regards, The Team"
+                                  },
+                                  {
+                                    "locale": "de",
+                                    "value": "Mit freundlichen Grüßen, Das Team"
+                                  }
+                                ],
+                                "primary_cta_button": {
+                                  "text": [
+                                    {
+                                      "locale": "en",
+                                      "value": "Get Started"
+                                    },
+                                    {
+                                      "locale": "fr",
+                                      "value": "Commencer"
+                                    }
+                                  ],
+                                  "url": "https://example.com/start",
+                                  "alt": [
+                                    {
+                                      "locale": "en",
+                                      "value": "Start now"
+                                    },
+                                    {
+                                      "locale": "fr",
+                                      "value": "Commencez maintenant"
+                                    }
+                                  ]
+                                },
+                                "secondary_cta_button": {
+                                  "text": [
+                                    {
+                                      "locale": "en",
+                                      "value": "Contact Support"
+                                    },
+                                    {
+                                      "locale": "es",
+                                      "value": "Contactar Soporte"
+                                    }
+                                  ],
+                                  "url": "https://example.com/support",
+                                  "alt": [
+                                    {
+                                      "locale": "en",
+                                      "value": "Support"
+                                    },
+                                    {
+                                      "locale": "es",
+                                      "value": "Soporte"
+                                    }
+                                  ]
+                                }
+                              },
+                              "sms": {
+                                "message_body": [
+                                  {
+                                    "locale": "en",
+                                    "value": "Welcome! Thanks for joining us. Get started:"
+                                  },
+                                  {
+                                    "locale": "fr",
+                                    "value": "Bienvenue! Merci de nous avoir rejoints. Commencez:"
+                                  },
+                                  {
+                                    "locale": "es",
+                                    "value": "¡Bienvenido! Gracias por unirte. Comienza:"
+                                  }
+                                ],
+                                "deep_link": "https://example.com/welcome"
+                              }
+                            },
+                            "created_at": "2024-06-01T12:00:00Z",
+                            "updated_at": "2024-06-01T12:00:00Z"
+                          }
                         }
                       }
                     }
@@ -3127,7 +6619,50 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     }
                   ]
                 },
@@ -3176,19 +6711,172 @@
                 "type": "object",
                 "properties": {
                   "title": {
-                    "$ref": "https://vcita.github.io/developers-hub/entities/communication/notificationTemplate.json#/properties/title"
+                    "description": "The display name of the notification template that appears in the staff portal notification settings. This is what users see when browsing available notification options (e.g., \"Payment Received Notification\"). Should contain at least one English locale entry when creating a template.",
+                    "$ref": "#/definitions/localizedTextList"
                   },
                   "description": {
-                    "$ref": "https://vcita.github.io/developers-hub/entities/communication/notificationTemplate.json#/properties/description"
+                    "description": "A brief explanation that appears in the staff portal notification settings to help them understand what this notification is for and when it will be triggered. Should contain at least one English locale entry when creating a template.",
+                    "$ref": "#/definitions/localizedTextList"
                   },
                   "category": {
-                    "$ref": "https://vcita.github.io/developers-hub/entities/communication/notificationTemplate.json#/properties/category"
+                    "type": "string",
+                    "description": "The functional category this notification belongs to (e.g., \"payments\", \"booking\", \"documents\").",
+                    "enum": [
+                      "payments",
+                      "clients",
+                      "calendar",
+                      "booking",
+                      "marketing",
+                      "teamchat",
+                      "scheduling",
+                      "advertising",
+                      "group_events",
+                      "documents",
+                      "messages",
+                      "reviews",
+                      "social",
+                      "account"
+                    ]
                   },
                   "configurable_by_staff": {
-                    "$ref": "https://vcita.github.io/developers-hub/entities/communication/notificationTemplate.json#/properties/configurable_by_staff"
+                    "type": "boolean",
+                    "description": "Boolean flag that determines whether staff members can customize or modify this notification template through the staff portal."
                   },
                   "content": {
-                    "$ref": "https://vcita.github.io/developers-hub/entities/communication/notificationTemplate.json#/properties/content"
+                    "type": "object",
+                    "description": "Notification content for 'email', 'staff_portal', and/or 'sms'. Not all content sections are required - only the channels that are relevant to the notification need to be populated.",
+                    "properties": {
+                      "staff_portal": {
+                        "type": "object",
+                        "description": "Staff portal notification content. This section is optional and may be omitted or contain empty arrays for templates not intended for staff portal delivery.",
+                        "properties": {
+                          "title": {
+                            "description": "Title for staff portal notification. May be an empty array if not configured.",
+                            "$ref": "#/definitions/localizedTextList"
+                          },
+                          "message_body": {
+                            "description": "Message body for staff portal notification. May be an empty array if not configured.",
+                            "$ref": "#/definitions/localizedTextList"
+                          },
+                          "deep_link": {
+                            "type": "string",
+                            "description": "Optional deep link URL for notification action."
+                          }
+                        }
+                      },
+                      "email": {
+                        "type": "object",
+                        "description": "Email notification content. This section is optional and may contain empty arrays for templates not intended for email delivery.",
+                        "properties": {
+                          "subject": {
+                            "description": "Email subject line. May be an empty array if not configured.",
+                            "$ref": "#/definitions/localizedTextList"
+                          },
+                          "top_image": {
+                            "type": "object",
+                            "description": "Image at the top of the email.",
+                            "properties": {
+                              "url": {
+                                "type": "string",
+                                "description": "Image URL."
+                              },
+                              "width": {
+                                "type": "integer",
+                                "description": "Image width in pixels."
+                              },
+                              "alt": {
+                                "description": "Alternative text for the image.",
+                                "$ref": "#/definitions/localizedTextList"
+                              }
+                            }
+                          },
+                          "main_title": {
+                            "description": "Header or introduction text for the email. May be an empty array if not configured.",
+                            "$ref": "#/definitions/localizedTextList"
+                          },
+                          "main_text": {
+                            "description": "Main content of the email. May be an empty array if not configured.",
+                            "$ref": "#/definitions/localizedTextList"
+                          },
+                          "middle_image": {
+                            "type": "object",
+                            "description": "Image in the middle of the email.",
+                            "properties": {
+                              "url": {
+                                "type": "string",
+                                "description": "Image URL."
+                              },
+                              "width": {
+                                "type": "integer",
+                                "description": "Image width in pixels."
+                              },
+                              "alt": {
+                                "description": "Alternative text for the image.",
+                                "$ref": "#/definitions/localizedTextList"
+                              }
+                            }
+                          },
+                          "middle_text": {
+                            "description": "Middle content of the email.",
+                            "$ref": "#/definitions/localizedTextList"
+                          },
+                          "footer_text": {
+                            "description": "Footer or closing text for the email.",
+                            "$ref": "#/definitions/localizedTextList"
+                          },
+                          "primary_cta_button": {
+                            "type": "object",
+                            "description": "Call-to-action button details.",
+                            "properties": {
+                              "text": {
+                                "description": "Button text.",
+                                "$ref": "#/definitions/localizedTextList"
+                              },
+                              "url": {
+                                "type": "string",
+                                "description": "Button URL."
+                              },
+                              "alt": {
+                                "description": "Alternative text for the button.",
+                                "$ref": "#/definitions/localizedTextList"
+                              }
+                            }
+                          },
+                          "secondary_cta_button": {
+                            "type": "object",
+                            "description": "Secondary call-to-action button details.",
+                            "properties": {
+                              "text": {
+                                "description": "Button text.",
+                                "$ref": "#/definitions/localizedTextList"
+                              },
+                              "url": {
+                                "type": "string",
+                                "description": "Button URL."
+                              },
+                              "alt": {
+                                "description": "Alternative text for the button.",
+                                "$ref": "#/definitions/localizedTextList"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "sms": {
+                        "type": "object",
+                        "description": "SMS notification content. This section is optional and may contain empty arrays for templates not intended for SMS delivery.",
+                        "properties": {
+                          "message_body": {
+                            "description": "Message body for SMS notification. May be an empty array if not configured.",
+                            "$ref": "#/definitions/localizedTextList"
+                          },
+                          "deep_link": {
+                            "type": "string",
+                            "description": "Optional deep link URL for SMS notification action."
+                          }
+                        }
+                      }
+                    }
                   }
                 }
               }
@@ -3203,12 +6891,532 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/communication/notificationTemplate.json"
+                          "title": "NotificationTemplate",
+                          "description": "Metadata definition for notification templates and delivery settings.",
+                          "type": "object",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "description": "Unique identifier for the entity instance."
+                            },
+                            "code_name": {
+                              "type": "string",
+                              "description": "Unique identifier name for the notification"
+                            },
+                            "title": {
+                              "description": "The display name of the notification template that appears in the staff portal notification settings. This is what users see when browsing available notification options (e.g., \"Payment Received Notification\"). Should contain at least one English locale entry when creating a template.",
+                              "$ref": "#/definitions/localizedTextList"
+                            },
+                            "description": {
+                              "description": "A brief explanation that appears in the staff portal notification settings to help them understand what this notification is for and when it will be triggered. Should contain at least one English locale entry when creating a template.",
+                              "$ref": "#/definitions/localizedTextList"
+                            },
+                            "category": {
+                              "type": "string",
+                              "description": "The functional category this notification belongs to (e.g., \"payments\", \"booking\", \"documents\").",
+                              "enum": [
+                                "payments",
+                                "clients",
+                                "calendar",
+                                "booking",
+                                "marketing",
+                                "teamchat",
+                                "scheduling",
+                                "advertising",
+                                "group_events",
+                                "documents",
+                                "messages",
+                                "reviews",
+                                "social",
+                                "account"
+                              ]
+                            },
+                            "configurable_by_staff": {
+                              "type": "boolean",
+                              "description": "Boolean flag that determines whether staff members can customize or modify this notification template through the staff portal."
+                            },
+                            "delivery_channel": {
+                              "type": "array",
+                              "description": "List of delivery channels for the notification.",
+                              "items": {
+                                "type": "string",
+                                "enum": [
+                                  "push",
+                                  "pane",
+                                  "email",
+                                  "sms"
+                                ]
+                              },
+                              "minItems": 1
+                            },
+                            "trigger_type": {
+                              "type": "string",
+                              "description": "Type of trigger for the notification.",
+                              "enum": [
+                                "system",
+                                "client"
+                              ]
+                            },
+                            "content": {
+                              "type": "object",
+                              "description": "Notification content for 'email', 'staff_portal', and/or 'sms'. Not all content sections are required - only the channels that are relevant to the notification need to be populated.",
+                              "properties": {
+                                "staff_portal": {
+                                  "type": "object",
+                                  "description": "Staff portal notification content. This section is optional and may be omitted or contain empty arrays for templates not intended for staff portal delivery.",
+                                  "properties": {
+                                    "title": {
+                                      "description": "Title for staff portal notification. May be an empty array if not configured.",
+                                      "$ref": "#/definitions/localizedTextList"
+                                    },
+                                    "message_body": {
+                                      "description": "Message body for staff portal notification. May be an empty array if not configured.",
+                                      "$ref": "#/definitions/localizedTextList"
+                                    },
+                                    "deep_link": {
+                                      "type": "string",
+                                      "description": "Optional deep link URL for notification action."
+                                    }
+                                  }
+                                },
+                                "email": {
+                                  "type": "object",
+                                  "description": "Email notification content. This section is optional and may contain empty arrays for templates not intended for email delivery.",
+                                  "properties": {
+                                    "subject": {
+                                      "description": "Email subject line. May be an empty array if not configured.",
+                                      "$ref": "#/definitions/localizedTextList"
+                                    },
+                                    "top_image": {
+                                      "type": "object",
+                                      "description": "Image at the top of the email.",
+                                      "properties": {
+                                        "url": {
+                                          "type": "string",
+                                          "description": "Image URL."
+                                        },
+                                        "width": {
+                                          "type": "integer",
+                                          "description": "Image width in pixels."
+                                        },
+                                        "alt": {
+                                          "description": "Alternative text for the image.",
+                                          "$ref": "#/definitions/localizedTextList"
+                                        }
+                                      }
+                                    },
+                                    "main_title": {
+                                      "description": "Header or introduction text for the email. May be an empty array if not configured.",
+                                      "$ref": "#/definitions/localizedTextList"
+                                    },
+                                    "main_text": {
+                                      "description": "Main content of the email. May be an empty array if not configured.",
+                                      "$ref": "#/definitions/localizedTextList"
+                                    },
+                                    "middle_image": {
+                                      "type": "object",
+                                      "description": "Image in the middle of the email.",
+                                      "properties": {
+                                        "url": {
+                                          "type": "string",
+                                          "description": "Image URL."
+                                        },
+                                        "width": {
+                                          "type": "integer",
+                                          "description": "Image width in pixels."
+                                        },
+                                        "alt": {
+                                          "description": "Alternative text for the image.",
+                                          "$ref": "#/definitions/localizedTextList"
+                                        }
+                                      }
+                                    },
+                                    "middle_text": {
+                                      "description": "Middle content of the email.",
+                                      "$ref": "#/definitions/localizedTextList"
+                                    },
+                                    "footer_text": {
+                                      "description": "Footer or closing text for the email.",
+                                      "$ref": "#/definitions/localizedTextList"
+                                    },
+                                    "primary_cta_button": {
+                                      "type": "object",
+                                      "description": "Call-to-action button details.",
+                                      "properties": {
+                                        "text": {
+                                          "description": "Button text.",
+                                          "$ref": "#/definitions/localizedTextList"
+                                        },
+                                        "url": {
+                                          "type": "string",
+                                          "description": "Button URL."
+                                        },
+                                        "alt": {
+                                          "description": "Alternative text for the button.",
+                                          "$ref": "#/definitions/localizedTextList"
+                                        }
+                                      }
+                                    },
+                                    "secondary_cta_button": {
+                                      "type": "object",
+                                      "description": "Secondary call-to-action button details.",
+                                      "properties": {
+                                        "text": {
+                                          "description": "Button text.",
+                                          "$ref": "#/definitions/localizedTextList"
+                                        },
+                                        "url": {
+                                          "type": "string",
+                                          "description": "Button URL."
+                                        },
+                                        "alt": {
+                                          "description": "Alternative text for the button.",
+                                          "$ref": "#/definitions/localizedTextList"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "sms": {
+                                  "type": "object",
+                                  "description": "SMS notification content. This section is optional and may contain empty arrays for templates not intended for SMS delivery.",
+                                  "properties": {
+                                    "message_body": {
+                                      "description": "Message body for SMS notification. May be an empty array if not configured.",
+                                      "$ref": "#/definitions/localizedTextList"
+                                    },
+                                    "deep_link": {
+                                      "type": "string",
+                                      "description": "Optional deep link URL for SMS notification action."
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "description": "ISO8601 timestamp of when the entity was created."
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "description": "ISO8601 timestamp of the last update to the entity."
+                            }
+                          },
+                          "required": [
+                            "uid",
+                            "code_name",
+                            "title",
+                            "description",
+                            "category",
+                            "configurable_by_staff",
+                            "delivery_channel",
+                            "trigger_type",
+                            "content",
+                            "created_at",
+                            "updated_at"
+                          ],
+                          "definitions": {
+                            "localizedTextList": {
+                              "type": "array",
+                              "description": "List of localized strings. Each item is a locale-value pair: locale is a locale (from enum), value is a string. Each language can appear only once.",
+                              "uniqueItems": true,
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "locale": {
+                                    "type": "string",
+                                    "enum": [
+                                      "en",
+                                      "fr",
+                                      "de",
+                                      "it",
+                                      "pl",
+                                      "pt",
+                                      "es",
+                                      "nl",
+                                      "he",
+                                      "sl",
+                                      "en_gb"
+                                    ]
+                                  },
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "locale",
+                                  "value"
+                                ]
+                              }
+                            }
+                          },
+                          "example": {
+                            "uid": "notif-001",
+                            "code_name": "welcome_new_user",
+                            "title": [
+                              {
+                                "locale": "en",
+                                "value": "Welcome Notification"
+                              },
+                              {
+                                "locale": "fr",
+                                "value": "Notification de bienvenue"
+                              },
+                              {
+                                "locale": "de",
+                                "value": "Willkommensbenachrichtigung"
+                              }
+                            ],
+                            "description": [
+                              {
+                                "locale": "en",
+                                "value": "Sent to new users upon registration."
+                              },
+                              {
+                                "locale": "fr",
+                                "value": "Envoyé aux nouveaux utilisateurs lors de l'inscription."
+                              },
+                              {
+                                "locale": "es",
+                                "value": "Enviado a los nuevos usuarios al registrarse."
+                              }
+                            ],
+                            "category": "account",
+                            "configurable_by_staff": true,
+                            "delivery_channel": [
+                              "push",
+                              "email"
+                            ],
+                            "trigger_type": "system",
+                            "content": {
+                              "staff_portal": {
+                                "title": [
+                                  {
+                                    "locale": "en",
+                                    "value": "Welcome!"
+                                  },
+                                  {
+                                    "locale": "fr",
+                                    "value": "Bienvenue!"
+                                  },
+                                  {
+                                    "locale": "es",
+                                    "value": "¡Bienvenido!"
+                                  }
+                                ],
+                                "message_body": [
+                                  {
+                                    "locale": "en",
+                                    "value": "Thanks for joining us!"
+                                  },
+                                  {
+                                    "locale": "fr",
+                                    "value": "Merci de nous avoir rejoints!"
+                                  }
+                                ],
+                                "deep_link": "https://example.com/welcome"
+                              },
+                              "email": {
+                                "subject": [
+                                  {
+                                    "locale": "en",
+                                    "value": "Welcome to Our Service"
+                                  },
+                                  {
+                                    "locale": "fr",
+                                    "value": "Bienvenue à notre service"
+                                  },
+                                  {
+                                    "locale": "de",
+                                    "value": "Willkommen bei unserem Service"
+                                  }
+                                ],
+                                "top_image": {
+                                  "url": "https://example.com/banner.png",
+                                  "width": 600,
+                                  "alt": [
+                                    {
+                                      "locale": "en",
+                                      "value": "Welcome banner"
+                                    },
+                                    {
+                                      "locale": "fr",
+                                      "value": "Bannière de bienvenue"
+                                    }
+                                  ]
+                                },
+                                "main_title": [
+                                  {
+                                    "locale": "en",
+                                    "value": "Hello and Welcome!"
+                                  },
+                                  {
+                                    "locale": "fr",
+                                    "value": "Bonjour et bienvenue!"
+                                  }
+                                ],
+                                "main_text": [
+                                  {
+                                    "locale": "en",
+                                    "value": "We're excited to have you on board."
+                                  },
+                                  {
+                                    "locale": "es",
+                                    "value": "Estamos emocionados de tenerte con nosotros."
+                                  }
+                                ],
+                                "middle_image": {
+                                  "url": "https://example.com/mid.png",
+                                  "width": 400,
+                                  "alt": [
+                                    {
+                                      "locale": "en",
+                                      "value": "Mid section image"
+                                    },
+                                    {
+                                      "locale": "es",
+                                      "value": "Imagen de la sección media"
+                                    }
+                                  ]
+                                },
+                                "middle_text": [
+                                  {
+                                    "locale": "en",
+                                    "value": "Here are some tips to get started."
+                                  },
+                                  {
+                                    "locale": "fr",
+                                    "value": "Voici quelques conseils pour commencer."
+                                  }
+                                ],
+                                "footer_text": [
+                                  {
+                                    "locale": "en",
+                                    "value": "Best regards, The Team"
+                                  },
+                                  {
+                                    "locale": "de",
+                                    "value": "Mit freundlichen Grüßen, Das Team"
+                                  }
+                                ],
+                                "primary_cta_button": {
+                                  "text": [
+                                    {
+                                      "locale": "en",
+                                      "value": "Get Started"
+                                    },
+                                    {
+                                      "locale": "fr",
+                                      "value": "Commencer"
+                                    }
+                                  ],
+                                  "url": "https://example.com/start",
+                                  "alt": [
+                                    {
+                                      "locale": "en",
+                                      "value": "Start now"
+                                    },
+                                    {
+                                      "locale": "fr",
+                                      "value": "Commencez maintenant"
+                                    }
+                                  ]
+                                },
+                                "secondary_cta_button": {
+                                  "text": [
+                                    {
+                                      "locale": "en",
+                                      "value": "Contact Support"
+                                    },
+                                    {
+                                      "locale": "es",
+                                      "value": "Contactar Soporte"
+                                    }
+                                  ],
+                                  "url": "https://example.com/support",
+                                  "alt": [
+                                    {
+                                      "locale": "en",
+                                      "value": "Support"
+                                    },
+                                    {
+                                      "locale": "es",
+                                      "value": "Soporte"
+                                    }
+                                  ]
+                                }
+                              },
+                              "sms": {
+                                "message_body": [
+                                  {
+                                    "locale": "en",
+                                    "value": "Welcome! Thanks for joining us. Get started:"
+                                  },
+                                  {
+                                    "locale": "fr",
+                                    "value": "Bienvenue! Merci de nous avoir rejoints. Commencez:"
+                                  },
+                                  {
+                                    "locale": "es",
+                                    "value": "¡Bienvenido! Gracias por unirte. Comienza:"
+                                  }
+                                ],
+                                "deep_link": "https://example.com/welcome"
+                              }
+                            },
+                            "created_at": "2024-06-01T12:00:00Z",
+                            "updated_at": "2024-06-01T12:00:00Z"
+                          }
                         }
                       }
                     }
@@ -3224,7 +7432,50 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     }
                   ]
                 },
@@ -3247,7 +7498,50 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     }
                   ]
                 },
@@ -3296,7 +7590,50 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     }
                   ]
                 },
@@ -3314,7 +7651,50 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     }
                   ]
                 },
@@ -3476,7 +7856,224 @@
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/communication/businessPhoneNumber.json"
+                          "type": "object",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "description": "Unique identifier for the phone number record."
+                            },
+                            "business_uid": {
+                              "type": "string",
+                              "description": "Unique identifier of the business that owns this phone number."
+                            },
+                            "phone_number": {
+                              "type": "string",
+                              "description": "The complete phone number in E.164 format without formatting (e.g., \"12127654321\"). This is the actual phone number that was purchased from the telecom provider."
+                            },
+                            "country_code": {
+                              "type": "string",
+                              "description": "ISO 3166-1 alpha-2 country code indicating the country where the phone number is registered (e.g., \"US\" for United States, \"CA\" for Canada)."
+                            },
+                            "features": {
+                              "type": "array",
+                              "description": "List of telephony features to enable for this phone number, (e.g., [\"VOICE\", \"SMS\"]).",
+                              "minItems": 1,
+                              "items": {
+                                "type": "string",
+                                "enum": [
+                                  "VOICE",
+                                  "SMS"
+                                ]
+                              }
+                            },
+                            "verification_request_data": {
+                              "type": "object",
+                              "description": "Business verification information required for text messaging compliance in the United States and Canada. This data registers your business with mobile carriers to enable SMS messaging capabilities. The verification process helps prevent spam and ensures your business messages are delivered reliably to customers.",
+                              "properties": {
+                                "entity_type": {
+                                  "type": "string",
+                                  "enum": [
+                                    "PRIVATE_PROFIT",
+                                    "PUBLIC_PROFIT",
+                                    "NON_PROFIT",
+                                    "SOLE_PROPRIETOR"
+                                  ],
+                                  "description": "Legal form of the business. PRIVATE_PROFIT: Privately-held for-profit company (e.g., LLC, Corp). PUBLIC_PROFIT: Publicly-traded for-profit company. NON_PROFIT: Non-profit organization (e.g., 501(c)(3)). SOLE_PROPRIETOR: Individual business owner without formal business entity."
+                                },
+                                "brand_name": {
+                                  "type": "string",
+                                  "maxLength": 255,
+                                  "description": "Brand name of the company or DBA (Doing Business As)"
+                                },
+                                "legal_company_name": {
+                                  "type": "string",
+                                  "maxLength": 255,
+                                  "description": "The legally registered company name"
+                                },
+                                "contact_first_name": {
+                                  "type": "string",
+                                  "maxLength": 100,
+                                  "description": "Business owner's first name"
+                                },
+                                "contact_last_name": {
+                                  "type": "string",
+                                  "maxLength": 100,
+                                  "description": "Business owner's last name"
+                                },
+                                "tax_number": {
+                                  "type": "string",
+                                  "maxLength": 21,
+                                  "description": "Tax Number/ID/EIN"
+                                },
+                                "website_url": {
+                                  "type": "string",
+                                  "format": "uri",
+                                  "description": "Business website URL"
+                                },
+                                "country_code": {
+                                  "type": "string",
+                                  "pattern": "^[A-Z]{2}$",
+                                  "description": "ISO3166-Alpha2 country code of registration (e.g., \"US\", \"CA\")"
+                                },
+                                "postal_code": {
+                                  "type": "string",
+                                  "maxLength": 10,
+                                  "pattern": "^[0-9]{5}$",
+                                  "description": "Postal/ZIP code (5 digits for US)"
+                                },
+                                "street": {
+                                  "type": "string",
+                                  "maxLength": 100,
+                                  "description": "Street address and number (e.g., \"123 Main Street\", \"456 5th Avenue\")"
+                                },
+                                "full_address": {
+                                  "type": "string",
+                                  "maxLength": 255,
+                                  "description": "Complete formatted address including street, city, state, postal code, and country (e.g., \"123 Main Street, New York, NY 10001, USA\")"
+                                },
+                                "city": {
+                                  "type": "string",
+                                  "maxLength": 100,
+                                  "description": "City name"
+                                },
+                                "state": {
+                                  "type": "string",
+                                  "maxLength": 20,
+                                  "pattern": "^[A-Z]{2}$",
+                                  "description": "State/Region (2-letter code for USA)"
+                                },
+                                "contact_email": {
+                                  "type": "string",
+                                  "format": "email",
+                                  "description": "Contact email address."
+                                },
+                                "contact_phone": {
+                                  "type": "string",
+                                  "pattern": "^[1-9][0-9]{9,14}$",
+                                  "description": "Contact phone number in E.164 format without + prefix"
+                                },
+                                "mobile_phone": {
+                                  "type": "string",
+                                  "pattern": "^[1-9][0-9]{9,14}$",
+                                  "description": "Mobile phone number for brand verification in E.164 format without + prefix"
+                                }
+                              },
+                              "required": [
+                                "entity_type",
+                                "brand_name",
+                                "contact_first_name",
+                                "contact_last_name",
+                                "website_url",
+                                "country_code",
+                                "postal_code",
+                                "street",
+                                "city",
+                                "state",
+                                "contact_email",
+                                "contact_phone",
+                                "mobile_phone"
+                              ],
+                              "example": {
+                                "entity_type": "PRIVATE_PROFIT",
+                                "brand_name": "Tech Solutions LLC",
+                                "legal_company_name": "Technology Solutions Limited Liability Company",
+                                "contact_first_name": "Jane",
+                                "contact_last_name": "Smith",
+                                "tax_number": "987654321",
+                                "website_url": "https://www.techsolutions.com",
+                                "country_code": "US",
+                                "postal_code": "94105",
+                                "street": "456 Market Street",
+                                "full_address": "456 Market Street, San Francisco, CA 94105, USA",
+                                "city": "San Francisco",
+                                "state": "CA",
+                                "contact_email": "jane.smith@techsolutions.com",
+                                "contact_phone": "14155551234",
+                                "mobile_phone": "14155559876"
+                              }
+                            },
+                            "status": {
+                              "type": "string",
+                              "enum": [
+                                "active",
+                                "inactive",
+                                "suspended"
+                              ],
+                              "description": "Current operational status of the phone number."
+                            },
+                            "verification_status": {
+                              "type": "string",
+                              "enum": [
+                                "pending",
+                                "verified",
+                                "failed"
+                              ],
+                              "description": "Indicates the outcome of verifying a phone number's ownership and validity based on business verification data provided. This field applies only to U.S. and Canadian numbers and reflects compliance verification required by telecom regulations."
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "description": "The creation date and time of the phone number record.",
+                              "format": "date-time"
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "description": "Updated date and time of the phone number record.",
+                              "format": "date-time"
+                            }
+                          },
+                          "example": {
+                            "uid": "number123",
+                            "business_uid": "business123abc",
+                            "phone_number": "12127654321",
+                            "country_code": "US",
+                            "features": [
+                              "VOICE",
+                              "SMS"
+                            ],
+                            "verification_request_data": {
+                              "entity_type": "PRIVATE_PROFIT",
+                              "brand_name": "Acme Corporation",
+                              "legal_company_name": "Acme Corporation Inc.",
+                              "contact_first_name": "John",
+                              "contact_last_name": "Doe",
+                              "tax_number": "123456789",
+                              "website_url": "https://www.acmecorp.com",
+                              "country_code": "US",
+                              "postal_code": "10001",
+                              "street": "123 Business Ave",
+                              "full_address": "123 Business Ave, New York, NY 10001, USA",
+                              "city": "New York",
+                              "state": "NY",
+                              "contact_email": "john.doe@acmecorp.com",
+                              "contact_phone": "12125551234",
+                              "mobile_phone": "19175551234"
+                            },
+                            "status": "active",
+                            "verification_status": "verified",
+                            "created_at": "2024-01-01T09:00:00Z",
+                            "updated_at": "2024-03-20T12:34:56Z"
+                          },
+                          "description": "A business-owned phone number with enabled features and lifecycle metadata."
                         }
                       }
                     }
@@ -3589,7 +8186,224 @@
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/communication/businessPhoneNumber.json"
+                          "type": "object",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "description": "Unique identifier for the phone number record."
+                            },
+                            "business_uid": {
+                              "type": "string",
+                              "description": "Unique identifier of the business that owns this phone number."
+                            },
+                            "phone_number": {
+                              "type": "string",
+                              "description": "The complete phone number in E.164 format without formatting (e.g., \"12127654321\"). This is the actual phone number that was purchased from the telecom provider."
+                            },
+                            "country_code": {
+                              "type": "string",
+                              "description": "ISO 3166-1 alpha-2 country code indicating the country where the phone number is registered (e.g., \"US\" for United States, \"CA\" for Canada)."
+                            },
+                            "features": {
+                              "type": "array",
+                              "description": "List of telephony features to enable for this phone number, (e.g., [\"VOICE\", \"SMS\"]).",
+                              "minItems": 1,
+                              "items": {
+                                "type": "string",
+                                "enum": [
+                                  "VOICE",
+                                  "SMS"
+                                ]
+                              }
+                            },
+                            "verification_request_data": {
+                              "type": "object",
+                              "description": "Business verification information required for text messaging compliance in the United States and Canada. This data registers your business with mobile carriers to enable SMS messaging capabilities. The verification process helps prevent spam and ensures your business messages are delivered reliably to customers.",
+                              "properties": {
+                                "entity_type": {
+                                  "type": "string",
+                                  "enum": [
+                                    "PRIVATE_PROFIT",
+                                    "PUBLIC_PROFIT",
+                                    "NON_PROFIT",
+                                    "SOLE_PROPRIETOR"
+                                  ],
+                                  "description": "Legal form of the business. PRIVATE_PROFIT: Privately-held for-profit company (e.g., LLC, Corp). PUBLIC_PROFIT: Publicly-traded for-profit company. NON_PROFIT: Non-profit organization (e.g., 501(c)(3)). SOLE_PROPRIETOR: Individual business owner without formal business entity."
+                                },
+                                "brand_name": {
+                                  "type": "string",
+                                  "maxLength": 255,
+                                  "description": "Brand name of the company or DBA (Doing Business As)"
+                                },
+                                "legal_company_name": {
+                                  "type": "string",
+                                  "maxLength": 255,
+                                  "description": "The legally registered company name"
+                                },
+                                "contact_first_name": {
+                                  "type": "string",
+                                  "maxLength": 100,
+                                  "description": "Business owner's first name"
+                                },
+                                "contact_last_name": {
+                                  "type": "string",
+                                  "maxLength": 100,
+                                  "description": "Business owner's last name"
+                                },
+                                "tax_number": {
+                                  "type": "string",
+                                  "maxLength": 21,
+                                  "description": "Tax Number/ID/EIN"
+                                },
+                                "website_url": {
+                                  "type": "string",
+                                  "format": "uri",
+                                  "description": "Business website URL"
+                                },
+                                "country_code": {
+                                  "type": "string",
+                                  "pattern": "^[A-Z]{2}$",
+                                  "description": "ISO3166-Alpha2 country code of registration (e.g., \"US\", \"CA\")"
+                                },
+                                "postal_code": {
+                                  "type": "string",
+                                  "maxLength": 10,
+                                  "pattern": "^[0-9]{5}$",
+                                  "description": "Postal/ZIP code (5 digits for US)"
+                                },
+                                "street": {
+                                  "type": "string",
+                                  "maxLength": 100,
+                                  "description": "Street address and number (e.g., \"123 Main Street\", \"456 5th Avenue\")"
+                                },
+                                "full_address": {
+                                  "type": "string",
+                                  "maxLength": 255,
+                                  "description": "Complete formatted address including street, city, state, postal code, and country (e.g., \"123 Main Street, New York, NY 10001, USA\")"
+                                },
+                                "city": {
+                                  "type": "string",
+                                  "maxLength": 100,
+                                  "description": "City name"
+                                },
+                                "state": {
+                                  "type": "string",
+                                  "maxLength": 20,
+                                  "pattern": "^[A-Z]{2}$",
+                                  "description": "State/Region (2-letter code for USA)"
+                                },
+                                "contact_email": {
+                                  "type": "string",
+                                  "format": "email",
+                                  "description": "Contact email address."
+                                },
+                                "contact_phone": {
+                                  "type": "string",
+                                  "pattern": "^[1-9][0-9]{9,14}$",
+                                  "description": "Contact phone number in E.164 format without + prefix"
+                                },
+                                "mobile_phone": {
+                                  "type": "string",
+                                  "pattern": "^[1-9][0-9]{9,14}$",
+                                  "description": "Mobile phone number for brand verification in E.164 format without + prefix"
+                                }
+                              },
+                              "required": [
+                                "entity_type",
+                                "brand_name",
+                                "contact_first_name",
+                                "contact_last_name",
+                                "website_url",
+                                "country_code",
+                                "postal_code",
+                                "street",
+                                "city",
+                                "state",
+                                "contact_email",
+                                "contact_phone",
+                                "mobile_phone"
+                              ],
+                              "example": {
+                                "entity_type": "PRIVATE_PROFIT",
+                                "brand_name": "Tech Solutions LLC",
+                                "legal_company_name": "Technology Solutions Limited Liability Company",
+                                "contact_first_name": "Jane",
+                                "contact_last_name": "Smith",
+                                "tax_number": "987654321",
+                                "website_url": "https://www.techsolutions.com",
+                                "country_code": "US",
+                                "postal_code": "94105",
+                                "street": "456 Market Street",
+                                "full_address": "456 Market Street, San Francisco, CA 94105, USA",
+                                "city": "San Francisco",
+                                "state": "CA",
+                                "contact_email": "jane.smith@techsolutions.com",
+                                "contact_phone": "14155551234",
+                                "mobile_phone": "14155559876"
+                              }
+                            },
+                            "status": {
+                              "type": "string",
+                              "enum": [
+                                "active",
+                                "inactive",
+                                "suspended"
+                              ],
+                              "description": "Current operational status of the phone number."
+                            },
+                            "verification_status": {
+                              "type": "string",
+                              "enum": [
+                                "pending",
+                                "verified",
+                                "failed"
+                              ],
+                              "description": "Indicates the outcome of verifying a phone number's ownership and validity based on business verification data provided. This field applies only to U.S. and Canadian numbers and reflects compliance verification required by telecom regulations."
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "description": "The creation date and time of the phone number record.",
+                              "format": "date-time"
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "description": "Updated date and time of the phone number record.",
+                              "format": "date-time"
+                            }
+                          },
+                          "example": {
+                            "uid": "number123",
+                            "business_uid": "business123abc",
+                            "phone_number": "12127654321",
+                            "country_code": "US",
+                            "features": [
+                              "VOICE",
+                              "SMS"
+                            ],
+                            "verification_request_data": {
+                              "entity_type": "PRIVATE_PROFIT",
+                              "brand_name": "Acme Corporation",
+                              "legal_company_name": "Acme Corporation Inc.",
+                              "contact_first_name": "John",
+                              "contact_last_name": "Doe",
+                              "tax_number": "123456789",
+                              "website_url": "https://www.acmecorp.com",
+                              "country_code": "US",
+                              "postal_code": "10001",
+                              "street": "123 Business Ave",
+                              "full_address": "123 Business Ave, New York, NY 10001, USA",
+                              "city": "New York",
+                              "state": "NY",
+                              "contact_email": "john.doe@acmecorp.com",
+                              "contact_phone": "12125551234",
+                              "mobile_phone": "19175551234"
+                            },
+                            "status": "active",
+                            "verification_status": "verified",
+                            "created_at": "2024-01-01T09:00:00Z",
+                            "updated_at": "2024-03-20T12:34:56Z"
+                          },
+                          "description": "A business-owned phone number with enabled features and lifecycle metadata."
                         }
                       }
                     }
@@ -3656,7 +8470,224 @@
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/communication/businessPhoneNumber.json"
+                          "type": "object",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "description": "Unique identifier for the phone number record."
+                            },
+                            "business_uid": {
+                              "type": "string",
+                              "description": "Unique identifier of the business that owns this phone number."
+                            },
+                            "phone_number": {
+                              "type": "string",
+                              "description": "The complete phone number in E.164 format without formatting (e.g., \"12127654321\"). This is the actual phone number that was purchased from the telecom provider."
+                            },
+                            "country_code": {
+                              "type": "string",
+                              "description": "ISO 3166-1 alpha-2 country code indicating the country where the phone number is registered (e.g., \"US\" for United States, \"CA\" for Canada)."
+                            },
+                            "features": {
+                              "type": "array",
+                              "description": "List of telephony features to enable for this phone number, (e.g., [\"VOICE\", \"SMS\"]).",
+                              "minItems": 1,
+                              "items": {
+                                "type": "string",
+                                "enum": [
+                                  "VOICE",
+                                  "SMS"
+                                ]
+                              }
+                            },
+                            "verification_request_data": {
+                              "type": "object",
+                              "description": "Business verification information required for text messaging compliance in the United States and Canada. This data registers your business with mobile carriers to enable SMS messaging capabilities. The verification process helps prevent spam and ensures your business messages are delivered reliably to customers.",
+                              "properties": {
+                                "entity_type": {
+                                  "type": "string",
+                                  "enum": [
+                                    "PRIVATE_PROFIT",
+                                    "PUBLIC_PROFIT",
+                                    "NON_PROFIT",
+                                    "SOLE_PROPRIETOR"
+                                  ],
+                                  "description": "Legal form of the business. PRIVATE_PROFIT: Privately-held for-profit company (e.g., LLC, Corp). PUBLIC_PROFIT: Publicly-traded for-profit company. NON_PROFIT: Non-profit organization (e.g., 501(c)(3)). SOLE_PROPRIETOR: Individual business owner without formal business entity."
+                                },
+                                "brand_name": {
+                                  "type": "string",
+                                  "maxLength": 255,
+                                  "description": "Brand name of the company or DBA (Doing Business As)"
+                                },
+                                "legal_company_name": {
+                                  "type": "string",
+                                  "maxLength": 255,
+                                  "description": "The legally registered company name"
+                                },
+                                "contact_first_name": {
+                                  "type": "string",
+                                  "maxLength": 100,
+                                  "description": "Business owner's first name"
+                                },
+                                "contact_last_name": {
+                                  "type": "string",
+                                  "maxLength": 100,
+                                  "description": "Business owner's last name"
+                                },
+                                "tax_number": {
+                                  "type": "string",
+                                  "maxLength": 21,
+                                  "description": "Tax Number/ID/EIN"
+                                },
+                                "website_url": {
+                                  "type": "string",
+                                  "format": "uri",
+                                  "description": "Business website URL"
+                                },
+                                "country_code": {
+                                  "type": "string",
+                                  "pattern": "^[A-Z]{2}$",
+                                  "description": "ISO3166-Alpha2 country code of registration (e.g., \"US\", \"CA\")"
+                                },
+                                "postal_code": {
+                                  "type": "string",
+                                  "maxLength": 10,
+                                  "pattern": "^[0-9]{5}$",
+                                  "description": "Postal/ZIP code (5 digits for US)"
+                                },
+                                "street": {
+                                  "type": "string",
+                                  "maxLength": 100,
+                                  "description": "Street address and number (e.g., \"123 Main Street\", \"456 5th Avenue\")"
+                                },
+                                "full_address": {
+                                  "type": "string",
+                                  "maxLength": 255,
+                                  "description": "Complete formatted address including street, city, state, postal code, and country (e.g., \"123 Main Street, New York, NY 10001, USA\")"
+                                },
+                                "city": {
+                                  "type": "string",
+                                  "maxLength": 100,
+                                  "description": "City name"
+                                },
+                                "state": {
+                                  "type": "string",
+                                  "maxLength": 20,
+                                  "pattern": "^[A-Z]{2}$",
+                                  "description": "State/Region (2-letter code for USA)"
+                                },
+                                "contact_email": {
+                                  "type": "string",
+                                  "format": "email",
+                                  "description": "Contact email address."
+                                },
+                                "contact_phone": {
+                                  "type": "string",
+                                  "pattern": "^[1-9][0-9]{9,14}$",
+                                  "description": "Contact phone number in E.164 format without + prefix"
+                                },
+                                "mobile_phone": {
+                                  "type": "string",
+                                  "pattern": "^[1-9][0-9]{9,14}$",
+                                  "description": "Mobile phone number for brand verification in E.164 format without + prefix"
+                                }
+                              },
+                              "required": [
+                                "entity_type",
+                                "brand_name",
+                                "contact_first_name",
+                                "contact_last_name",
+                                "website_url",
+                                "country_code",
+                                "postal_code",
+                                "street",
+                                "city",
+                                "state",
+                                "contact_email",
+                                "contact_phone",
+                                "mobile_phone"
+                              ],
+                              "example": {
+                                "entity_type": "PRIVATE_PROFIT",
+                                "brand_name": "Tech Solutions LLC",
+                                "legal_company_name": "Technology Solutions Limited Liability Company",
+                                "contact_first_name": "Jane",
+                                "contact_last_name": "Smith",
+                                "tax_number": "987654321",
+                                "website_url": "https://www.techsolutions.com",
+                                "country_code": "US",
+                                "postal_code": "94105",
+                                "street": "456 Market Street",
+                                "full_address": "456 Market Street, San Francisco, CA 94105, USA",
+                                "city": "San Francisco",
+                                "state": "CA",
+                                "contact_email": "jane.smith@techsolutions.com",
+                                "contact_phone": "14155551234",
+                                "mobile_phone": "14155559876"
+                              }
+                            },
+                            "status": {
+                              "type": "string",
+                              "enum": [
+                                "active",
+                                "inactive",
+                                "suspended"
+                              ],
+                              "description": "Current operational status of the phone number."
+                            },
+                            "verification_status": {
+                              "type": "string",
+                              "enum": [
+                                "pending",
+                                "verified",
+                                "failed"
+                              ],
+                              "description": "Indicates the outcome of verifying a phone number's ownership and validity based on business verification data provided. This field applies only to U.S. and Canadian numbers and reflects compliance verification required by telecom regulations."
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "description": "The creation date and time of the phone number record.",
+                              "format": "date-time"
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "description": "Updated date and time of the phone number record.",
+                              "format": "date-time"
+                            }
+                          },
+                          "example": {
+                            "uid": "number123",
+                            "business_uid": "business123abc",
+                            "phone_number": "12127654321",
+                            "country_code": "US",
+                            "features": [
+                              "VOICE",
+                              "SMS"
+                            ],
+                            "verification_request_data": {
+                              "entity_type": "PRIVATE_PROFIT",
+                              "brand_name": "Acme Corporation",
+                              "legal_company_name": "Acme Corporation Inc.",
+                              "contact_first_name": "John",
+                              "contact_last_name": "Doe",
+                              "tax_number": "123456789",
+                              "website_url": "https://www.acmecorp.com",
+                              "country_code": "US",
+                              "postal_code": "10001",
+                              "street": "123 Business Ave",
+                              "full_address": "123 Business Ave, New York, NY 10001, USA",
+                              "city": "New York",
+                              "state": "NY",
+                              "contact_email": "john.doe@acmecorp.com",
+                              "contact_phone": "12125551234",
+                              "mobile_phone": "19175551234"
+                            },
+                            "status": "active",
+                            "verification_status": "verified",
+                            "created_at": "2024-01-01T09:00:00Z",
+                            "updated_at": "2024-03-20T12:34:56Z"
+                          },
+                          "description": "A business-owned phone number with enabled features and lifecycle metadata."
                         }
                       }
                     }
@@ -3866,12 +8897,382 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/communication/staff_notification.json"
+                          "required": [
+                            "uid",
+                            "staff_uid",
+                            "notification_template_code_name",
+                            "locale",
+                            "created_at",
+                            "updated_at"
+                          ],
+                          "type": "object",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "description": "The unique identifier of the staff notification."
+                            },
+                            "staff_uid": {
+                              "type": "string",
+                              "description": "The unique identifier of the staff member associated with this notification."
+                            },
+                            "notification_template_code_name": {
+                              "type": "string",
+                              "description": "The code name identifying the notification template to be used."
+                            },
+                            "locale": {
+                              "type": "string",
+                              "description": "The language locale for the notification content.",
+                              "enum": [
+                                "en",
+                                "fr",
+                                "de",
+                                "it",
+                                "pl",
+                                "pt",
+                                "es",
+                                "nl",
+                                "he",
+                                "sl",
+                                "en_gb"
+                              ],
+                              "default": "en"
+                            },
+                            "params": {
+                              "type": "array",
+                              "description": "Additional parameters for populating notification templates.",
+                              "uniqueItems": true,
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "key": {
+                                    "type": "string",
+                                    "description": "The parameter name."
+                                  },
+                                  "value": {
+                                    "oneOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "object"
+                                      },
+                                      {
+                                        "type": "number"
+                                      },
+                                      {
+                                        "type": "boolean"
+                                      }
+                                    ],
+                                    "description": "The value of the parameter. Can be a string, object, number, or boolean."
+                                  }
+                                },
+                                "required": [
+                                  "key",
+                                  "value"
+                                ]
+                              }
+                            },
+                            "staff_portal_content": {
+                              "type": "object",
+                              "description": "Settings for pane notifications",
+                              "properties": {
+                                "title": {
+                                  "type": "string",
+                                  "description": "Title for the notification."
+                                },
+                                "message_body": {
+                                  "type": "string",
+                                  "description": "Message body for the notification."
+                                },
+                                "deep_link": {
+                                  "type": "string",
+                                  "description": "Optional deep link URL for notification action."
+                                }
+                              },
+                              "required": [
+                                "title",
+                                "message_body"
+                              ]
+                            },
+                            "email_content": {
+                              "type": "object",
+                              "description": "Settings for email notifications",
+                              "properties": {
+                                "subject": {
+                                  "type": "string",
+                                  "description": "Email subject line."
+                                },
+                                "top_image": {
+                                  "type": "object",
+                                  "description": "Image at the top of the email.",
+                                  "properties": {
+                                    "url": {
+                                      "type": "string",
+                                      "description": "Image URL."
+                                    },
+                                    "width": {
+                                      "type": "integer",
+                                      "description": "Image width in pixels."
+                                    },
+                                    "alt": {
+                                      "type": "string",
+                                      "description": "Alternative text for the image."
+                                    }
+                                  }
+                                },
+                                "main_title": {
+                                  "type": "string",
+                                  "description": "Header or introduction text for the email."
+                                },
+                                "main_text": {
+                                  "type": "string",
+                                  "description": "Main content of the email."
+                                },
+                                "middle_image": {
+                                  "type": "object",
+                                  "description": "Image in the middle of the email.",
+                                  "properties": {
+                                    "url": {
+                                      "type": "string",
+                                      "description": "Image URL."
+                                    },
+                                    "width": {
+                                      "type": "integer",
+                                      "description": "Image width in pixels."
+                                    },
+                                    "alt": {
+                                      "type": "string",
+                                      "description": "Alternative text for the image."
+                                    }
+                                  }
+                                },
+                                "middle_text": {
+                                  "type": "string",
+                                  "description": "Middle content of the email."
+                                },
+                                "footer_text": {
+                                  "type": "string",
+                                  "description": "Footer or closing text for the email."
+                                },
+                                "primary_cta_button": {
+                                  "type": "object",
+                                  "description": "Call-to-action button details.",
+                                  "properties": {
+                                    "text": {
+                                      "type": "string",
+                                      "description": "The text on the button."
+                                    },
+                                    "url": {
+                                      "type": "string",
+                                      "description": "The URL invoked when clicking on the button."
+                                    },
+                                    "alt": {
+                                      "type": "string",
+                                      "description": "Alternative text for the button."
+                                    }
+                                  }
+                                },
+                                "secondary_cta_button": {
+                                  "type": "object",
+                                  "description": "Secondary call-to-action button details.",
+                                  "properties": {
+                                    "text": {
+                                      "type": "string",
+                                      "description": "The text on the button."
+                                    },
+                                    "url": {
+                                      "type": "string",
+                                      "description": "The URL invoked when clicking on the button."
+                                    },
+                                    "alt": {
+                                      "type": "string",
+                                      "description": "Alternative text for the button."
+                                    }
+                                  }
+                                }
+                              },
+                              "required": [
+                                "subject",
+                                "main_title",
+                                "main_text"
+                              ]
+                            },
+                            "sms_content": {
+                              "type": "object",
+                              "description": "Settings for SMS notifications",
+                              "properties": {
+                                "message_body": {
+                                  "type": "string",
+                                  "description": "Message body for the SMS notification."
+                                },
+                                "deep_link": {
+                                  "type": "string",
+                                  "description": "Optional deep link URL for SMS notification action."
+                                }
+                              },
+                              "required": [
+                                "message_body"
+                              ]
+                            },
+                            "push_status": {
+                              "type": "string",
+                              "description": "The current delivery status of the push notification.",
+                              "enum": [
+                                "sent",
+                                "failed"
+                              ]
+                            },
+                            "pane_status": {
+                              "type": "string",
+                              "description": "The current delivery status of the pane notification.",
+                              "enum": [
+                                "sent",
+                                "read",
+                                "failed"
+                              ]
+                            },
+                            "email_status": {
+                              "type": "array",
+                              "description": "History of delivery statuses for the email notification. Each entry represents a status the notification has passed through, in chronological order.",
+                              "items": {
+                                "type": "string",
+                                "enum": [
+                                  "in_process",
+                                  "processed",
+                                  "dropped",
+                                  "deferred",
+                                  "bounce",
+                                  "delivered",
+                                  "open",
+                                  "click",
+                                  "spam_report",
+                                  "unsubscribe"
+                                ]
+                              }
+                            },
+                            "sms_status": {
+                              "type": "array",
+                              "description": "History of delivery statuses for the SMS notification. Each entry represents a status the notification has passed through, in chronological order.",
+                              "items": {
+                                "type": "string",
+                                "enum": [
+                                  "in_progress",
+                                  "processed",
+                                  "dropped",
+                                  "deferred",
+                                  "bounce",
+                                  "delivered",
+                                  "open",
+                                  "click",
+                                  "spam_report",
+                                  "unsubscribe",
+                                  "failed"
+                                ]
+                              }
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "description": "The date and time when the staff notification was created, in ISO 8601 format."
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "description": "The date and time when the staff notification was last updated, in ISO 8601 format."
+                            }
+                          },
+                          "example": {
+                            "uid": "staff-notification-12345",
+                            "staff_uid": "staff-67890",
+                            "notification_template_code_name": "new_appointment_created",
+                            "locale": "en",
+                            "params": [
+                              {
+                                "key": "client_name",
+                                "value": "John Doe"
+                              },
+                              {
+                                "key": "appointment_time",
+                                "value": "2023-05-15T14:30:00Z"
+                              }
+                            ],
+                            "staff_portal_content": {
+                              "title": "New appointment",
+                              "message_body": "You have a new appointment",
+                              "deep_link": "/appointments/12345"
+                            },
+                            "email_content": {
+                              "subject": "Appointment Confirmation",
+                              "main_title": "Your appointment is confirmed!",
+                              "main_text": "Thank you for booking with us. Your appointment is scheduled.",
+                              "footer_text": "If you have questions, contact us anytime."
+                            },
+                            "sms_content": {
+                              "message_body": "You have a new appointment scheduled for 2023-05-15 at 14:30",
+                              "deep_link": "/appointments/12345"
+                            },
+                            "push_status": "sent",
+                            "pane_status": "read",
+                            "email_status": [
+                              "delivered",
+                              "open"
+                            ],
+                            "sms_status": [
+                              "delivered",
+                              "open"
+                            ],
+                            "created_at": "2023-05-10T09:00:00Z",
+                            "updated_at": "2023-05-10T09:05:00Z"
+                          },
+                          "description": "An instance of a notification sent to a staff member, including delivery content and statuses."
                         }
                       }
                     }
@@ -3926,12 +9327,382 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/communication/staff_notification.json"
+                          "required": [
+                            "uid",
+                            "staff_uid",
+                            "notification_template_code_name",
+                            "locale",
+                            "created_at",
+                            "updated_at"
+                          ],
+                          "type": "object",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "description": "The unique identifier of the staff notification."
+                            },
+                            "staff_uid": {
+                              "type": "string",
+                              "description": "The unique identifier of the staff member associated with this notification."
+                            },
+                            "notification_template_code_name": {
+                              "type": "string",
+                              "description": "The code name identifying the notification template to be used."
+                            },
+                            "locale": {
+                              "type": "string",
+                              "description": "The language locale for the notification content.",
+                              "enum": [
+                                "en",
+                                "fr",
+                                "de",
+                                "it",
+                                "pl",
+                                "pt",
+                                "es",
+                                "nl",
+                                "he",
+                                "sl",
+                                "en_gb"
+                              ],
+                              "default": "en"
+                            },
+                            "params": {
+                              "type": "array",
+                              "description": "Additional parameters for populating notification templates.",
+                              "uniqueItems": true,
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "key": {
+                                    "type": "string",
+                                    "description": "The parameter name."
+                                  },
+                                  "value": {
+                                    "oneOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "object"
+                                      },
+                                      {
+                                        "type": "number"
+                                      },
+                                      {
+                                        "type": "boolean"
+                                      }
+                                    ],
+                                    "description": "The value of the parameter. Can be a string, object, number, or boolean."
+                                  }
+                                },
+                                "required": [
+                                  "key",
+                                  "value"
+                                ]
+                              }
+                            },
+                            "staff_portal_content": {
+                              "type": "object",
+                              "description": "Settings for pane notifications",
+                              "properties": {
+                                "title": {
+                                  "type": "string",
+                                  "description": "Title for the notification."
+                                },
+                                "message_body": {
+                                  "type": "string",
+                                  "description": "Message body for the notification."
+                                },
+                                "deep_link": {
+                                  "type": "string",
+                                  "description": "Optional deep link URL for notification action."
+                                }
+                              },
+                              "required": [
+                                "title",
+                                "message_body"
+                              ]
+                            },
+                            "email_content": {
+                              "type": "object",
+                              "description": "Settings for email notifications",
+                              "properties": {
+                                "subject": {
+                                  "type": "string",
+                                  "description": "Email subject line."
+                                },
+                                "top_image": {
+                                  "type": "object",
+                                  "description": "Image at the top of the email.",
+                                  "properties": {
+                                    "url": {
+                                      "type": "string",
+                                      "description": "Image URL."
+                                    },
+                                    "width": {
+                                      "type": "integer",
+                                      "description": "Image width in pixels."
+                                    },
+                                    "alt": {
+                                      "type": "string",
+                                      "description": "Alternative text for the image."
+                                    }
+                                  }
+                                },
+                                "main_title": {
+                                  "type": "string",
+                                  "description": "Header or introduction text for the email."
+                                },
+                                "main_text": {
+                                  "type": "string",
+                                  "description": "Main content of the email."
+                                },
+                                "middle_image": {
+                                  "type": "object",
+                                  "description": "Image in the middle of the email.",
+                                  "properties": {
+                                    "url": {
+                                      "type": "string",
+                                      "description": "Image URL."
+                                    },
+                                    "width": {
+                                      "type": "integer",
+                                      "description": "Image width in pixels."
+                                    },
+                                    "alt": {
+                                      "type": "string",
+                                      "description": "Alternative text for the image."
+                                    }
+                                  }
+                                },
+                                "middle_text": {
+                                  "type": "string",
+                                  "description": "Middle content of the email."
+                                },
+                                "footer_text": {
+                                  "type": "string",
+                                  "description": "Footer or closing text for the email."
+                                },
+                                "primary_cta_button": {
+                                  "type": "object",
+                                  "description": "Call-to-action button details.",
+                                  "properties": {
+                                    "text": {
+                                      "type": "string",
+                                      "description": "The text on the button."
+                                    },
+                                    "url": {
+                                      "type": "string",
+                                      "description": "The URL invoked when clicking on the button."
+                                    },
+                                    "alt": {
+                                      "type": "string",
+                                      "description": "Alternative text for the button."
+                                    }
+                                  }
+                                },
+                                "secondary_cta_button": {
+                                  "type": "object",
+                                  "description": "Secondary call-to-action button details.",
+                                  "properties": {
+                                    "text": {
+                                      "type": "string",
+                                      "description": "The text on the button."
+                                    },
+                                    "url": {
+                                      "type": "string",
+                                      "description": "The URL invoked when clicking on the button."
+                                    },
+                                    "alt": {
+                                      "type": "string",
+                                      "description": "Alternative text for the button."
+                                    }
+                                  }
+                                }
+                              },
+                              "required": [
+                                "subject",
+                                "main_title",
+                                "main_text"
+                              ]
+                            },
+                            "sms_content": {
+                              "type": "object",
+                              "description": "Settings for SMS notifications",
+                              "properties": {
+                                "message_body": {
+                                  "type": "string",
+                                  "description": "Message body for the SMS notification."
+                                },
+                                "deep_link": {
+                                  "type": "string",
+                                  "description": "Optional deep link URL for SMS notification action."
+                                }
+                              },
+                              "required": [
+                                "message_body"
+                              ]
+                            },
+                            "push_status": {
+                              "type": "string",
+                              "description": "The current delivery status of the push notification.",
+                              "enum": [
+                                "sent",
+                                "failed"
+                              ]
+                            },
+                            "pane_status": {
+                              "type": "string",
+                              "description": "The current delivery status of the pane notification.",
+                              "enum": [
+                                "sent",
+                                "read",
+                                "failed"
+                              ]
+                            },
+                            "email_status": {
+                              "type": "array",
+                              "description": "History of delivery statuses for the email notification. Each entry represents a status the notification has passed through, in chronological order.",
+                              "items": {
+                                "type": "string",
+                                "enum": [
+                                  "in_process",
+                                  "processed",
+                                  "dropped",
+                                  "deferred",
+                                  "bounce",
+                                  "delivered",
+                                  "open",
+                                  "click",
+                                  "spam_report",
+                                  "unsubscribe"
+                                ]
+                              }
+                            },
+                            "sms_status": {
+                              "type": "array",
+                              "description": "History of delivery statuses for the SMS notification. Each entry represents a status the notification has passed through, in chronological order.",
+                              "items": {
+                                "type": "string",
+                                "enum": [
+                                  "in_progress",
+                                  "processed",
+                                  "dropped",
+                                  "deferred",
+                                  "bounce",
+                                  "delivered",
+                                  "open",
+                                  "click",
+                                  "spam_report",
+                                  "unsubscribe",
+                                  "failed"
+                                ]
+                              }
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "description": "The date and time when the staff notification was created, in ISO 8601 format."
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "description": "The date and time when the staff notification was last updated, in ISO 8601 format."
+                            }
+                          },
+                          "example": {
+                            "uid": "staff-notification-12345",
+                            "staff_uid": "staff-67890",
+                            "notification_template_code_name": "new_appointment_created",
+                            "locale": "en",
+                            "params": [
+                              {
+                                "key": "client_name",
+                                "value": "John Doe"
+                              },
+                              {
+                                "key": "appointment_time",
+                                "value": "2023-05-15T14:30:00Z"
+                              }
+                            ],
+                            "staff_portal_content": {
+                              "title": "New appointment",
+                              "message_body": "You have a new appointment",
+                              "deep_link": "/appointments/12345"
+                            },
+                            "email_content": {
+                              "subject": "Appointment Confirmation",
+                              "main_title": "Your appointment is confirmed!",
+                              "main_text": "Thank you for booking with us. Your appointment is scheduled.",
+                              "footer_text": "If you have questions, contact us anytime."
+                            },
+                            "sms_content": {
+                              "message_body": "You have a new appointment scheduled for 2023-05-15 at 14:30",
+                              "deep_link": "/appointments/12345"
+                            },
+                            "push_status": "sent",
+                            "pane_status": "read",
+                            "email_status": [
+                              "delivered",
+                              "open"
+                            ],
+                            "sms_status": [
+                              "delivered",
+                              "open"
+                            ],
+                            "created_at": "2023-05-10T09:00:00Z",
+                            "updated_at": "2023-05-10T09:05:00Z"
+                          },
+                          "description": "An instance of a notification sent to a staff member, including delivery content and statuses."
                         }
                       }
                     }
@@ -4789,7 +10560,123 @@
           "voice_call_settings": {
             "type": "array",
             "items": {
-              "$ref": "https://vcita.github.io/developers-hub/entities/communication/voiceCallSetting.json"
+              "type": "object",
+              "properties": {
+                "uid": {
+                  "type": "string",
+                  "description": "The unique identifier of the VoiceCallSetting entity (e.g., \"56ah3478b56c\")"
+                },
+                "business_uid": {
+                  "type": "string",
+                  "description": "The unique identifier of the business (e.g., \"d290f1ee-6c54-4b01-90e6-d701748f0851\")"
+                },
+                "staff_uid": {
+                  "type": "string",
+                  "description": "The unique identifier of the staff receiving the forwarded call (e.g., \"5ya4gbwm2c3qic8\")"
+                },
+                "forward_number": {
+                  "type": "string",
+                  "description": "The phone number of the staff receiving the forwarded call (e.g., \"180348567634\")"
+                },
+                "dedicated_number": {
+                  "type": "string",
+                  "description": "The dedicated number of the business receiving calls from clients (e.g., \"12845783457\")"
+                },
+                "forwarding_enabled": {
+                  "type": "boolean",
+                  "description": "Indicates if voice call forwarding is enabled (e.g., true)"
+                },
+                "call_forwarding_policy": {
+                  "type": "string",
+                  "enum": [
+                    "ALWAYS",
+                    "WORK_HOURS",
+                    "NEVER"
+                  ],
+                  "description": "Specifies the conditions under which calls are forwarded based on staff availability (e.g., \"WORK_HOURS\")"
+                },
+                "call_timeout_sec": {
+                  "type": "number",
+                  "description": "Call ringing timeout in seconds (e.g., 20)"
+                },
+                "publish_number": {
+                  "type": "boolean",
+                  "description": "Indicates if the dedicated number should be published as the business's phone number (e.g., true)"
+                },
+                "voice_scripts": {
+                  "type": "object",
+                  "nullable": true,
+                  "description": "Configuration of voice messages played to callers during different stages of a voice call. Each key is a message name, value is an object with message (string) and enabled (boolean)."
+                },
+                "external_app_name": {
+                  "type": "string",
+                  "description": "The name of the external application managing the voice call (e.g., \"my.pa\")"
+                },
+                "app_status": {
+                  "type": "string",
+                  "enum": [
+                    "INSTALLED",
+                    "UNINSTALLED",
+                    "PAYMENT_ISSUE"
+                  ],
+                  "description": "The status of the app (e.g., \"INSTALLED\")"
+                },
+                "feature": {
+                  "type": "string",
+                  "enum": [
+                    "VOICE",
+                    "SMS",
+                    "VOICE_SMS"
+                  ],
+                  "nullable": true,
+                  "description": "The feature type for this setting (e.g., \"VOICE\")"
+                },
+                "transcript_enabled": {
+                  "type": "boolean",
+                  "description": "Whether automatic transcript processing is enabled for voice calls in this business (e.g., true)"
+                }
+              },
+              "required": [
+                "uid",
+                "business_uid",
+                "forwarding_enabled",
+                "external_app_name",
+                "app_status"
+              ],
+              "example": {
+                "uid": "56ah3478b56c",
+                "business_uid": "d290f1ee-6c54-4b01-90e6-d701748f0851",
+                "staff_uid": "5ya4gbwm2c3qic8",
+                "forward_number": "180348567634",
+                "dedicated_number": "12845783457",
+                "forwarding_enabled": true,
+                "call_forwarding_policy": "WORK_HOURS",
+                "call_timeout_sec": 20,
+                "publish_number": true,
+                "voice_scripts": {
+                  "greeting_message": {
+                    "message": "Hi, The call will be forwarded soon, please wait.",
+                    "enabled": true
+                  },
+                  "missed_call_message": {
+                    "message": "Sorry, please try again later.",
+                    "enabled": false
+                  },
+                  "voicemail_message": {
+                    "message": "Sorry, the staff is not available right now. Please leave a message after the beep.",
+                    "enabled": false
+                  },
+                  "recording_call_message": {
+                    "message": "Please note that this is a voice recording, please press 1 to continue.",
+                    "enabled": false
+                  }
+                },
+                "external_app_name": "my.pa",
+                "app_status": "INSTALLED",
+                "feature": "VOICE",
+                "transcript_enabled": true
+              },
+              "description": "Defines voice call settings for a staff member/business, including forwarding, policies, and scripts."
             }
           }
         },
@@ -4803,7 +10690,182 @@
           "voice_calls": {
             "type": "array",
             "items": {
-              "$ref": "https://vcita.github.io/developers-hub/entities/communication/voiceCall.json"
+              "type": "object",
+              "properties": {
+                "uid": {
+                  "type": "string",
+                  "description": "Unique identifier of the VoiceCall object"
+                },
+                "duration": {
+                  "type": "integer",
+                  "description": "Duration of the call in seconds"
+                },
+                "created_at": {
+                  "type": "string",
+                  "description": "The time the call was created"
+                },
+                "updated_at": {
+                  "type": "string",
+                  "description": "The time the call was last updated"
+                },
+                "status": {
+                  "type": "string",
+                  "enum": [
+                    "INCOMING_CALL",
+                    "ANSWERED_BY_STAFF",
+                    "MISSED",
+                    "ANSWERED_BY_CALLS_PROVIDER",
+                    "MISSED_CALL_HANDLED",
+                    "VOICEMAIL"
+                  ],
+                  "description": "The status of the call (e.g., \"ANSWERED_BY_STAFF\")"
+                },
+                "direction": {
+                  "type": "string",
+                  "enum": [
+                    "INBOUND",
+                    "OUTBOUND"
+                  ],
+                  "description": "The direction of the call. INBOUND for incoming calls to the business, OUTBOUND for outgoing calls from the business. Values are uppercase (e.g., \"INBOUND\")."
+                },
+                "staff_uid": {
+                  "type": "string",
+                  "description": "Unique identifier of the staff member who answered the call"
+                },
+                "client_uid": {
+                  "type": "string",
+                  "description": "Unique identifier of the client who made the call"
+                },
+                "from_number": {
+                  "type": "string",
+                  "description": "The phone number the call was made from"
+                },
+                "to_number": {
+                  "type": "string",
+                  "description": "The phone number the call was made to"
+                },
+                "call_summary": {
+                  "type": "string",
+                  "description": "Text summary of the call"
+                },
+                "recording": {
+                  "type": "object",
+                  "properties": {
+                    "uid": {
+                      "type": "string",
+                      "description": "Unique identifier of the recording entity (e.g., \"rec-abc123xyz\")"
+                    },
+                    "recordingUrl": {
+                      "type": "string",
+                      "description": "Pre-signed URL to access the recording file (e.g., \"https://example.com/recordings/presigned-url\")"
+                    },
+                    "size": {
+                      "type": "number",
+                      "description": "The size of the recording in bytes (e.g., 1048576)"
+                    },
+                    "duration": {
+                      "type": "number",
+                      "description": "The duration of the recording in seconds (e.g., 300)"
+                    },
+                    "recording_played": {
+                      "type": "boolean",
+                      "description": "Whether the call recording has been played (e.g., false)"
+                    },
+                    "recording_type": {
+                      "type": "string",
+                      "description": "The type of the recording",
+                      "enum": [
+                        "CALL",
+                        "VOICEMAIL"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "uid",
+                    "size",
+                    "duration",
+                    "recording_type"
+                  ],
+                  "example": {
+                    "uid": "rec-abc123xyz",
+                    "recordingUrl": "https://example.com/recordings/presigned-url",
+                    "size": 1048576,
+                    "duration": 300,
+                    "recording_played": false,
+                    "recording_type": "CALL"
+                  },
+                  "description": "The call recording details"
+                },
+                "external_app_url": {
+                  "type": "string",
+                  "description": "Link to an application page with additional details about the call (e.g., \"https://example.com/call-details\")"
+                },
+                "external_app_name": {
+                  "type": "string",
+                  "description": "The name of the external application that originated or manages the call (e.g., \"my.pa\")"
+                },
+                "source_id": {
+                  "type": "string",
+                  "description": "A unique source identifier for the call from the provider system (e.g., \"call-src-001\")"
+                },
+                "external_uuid": {
+                  "type": "string",
+                  "description": "An external unique identifier for the call conversation from the provider system (e.g., \"ext-call-001\")"
+                },
+                "handled_by_staff_uid": {
+                  "type": "string",
+                  "description": "The unique identifier of the staff who handled the call"
+                },
+                "handled_at": {
+                  "type": "string",
+                  "description": "The date and time when the call was handled",
+                  "format": "date-time"
+                },
+                "deleted_at": {
+                  "type": "string",
+                  "description": "Time the call was deleted - is null if the call is not deleted"
+                },
+                "transcript_status": {
+                  "type": "string",
+                  "nullable": true,
+                  "enum": [
+                    "IN_PROGRESS",
+                    "DONE",
+                    "FAILED"
+                  ],
+                  "description": "Processing status of the associated transcript. IN_PROGRESS means the transcript is being generated, DONE means it is ready, FAILED means generation failed (e.g., \"DONE\")"
+                }
+              },
+              "example": {
+                "uid": "d290f1ee-6c54-4b01-90e6-d701748f0851",
+                "created_at": "2021-07-20T14:00:00.000Z",
+                "updated_at": "2021-07-20T14:00:00.000Z",
+                "duration": 120,
+                "status": "ANSWERED_BY_STAFF",
+                "direction": "INBOUND",
+                "staff_uid": "d290f1ee-6c54-4b01-90e6-d701748f0851",
+                "client_uid": "d290f1ee-6c54-4b01-90e6-d701748f0851",
+                "from_number": "183466347342",
+                "to_number": "183466347342",
+                "call_summary": "Client called to ask about their account balance",
+                "recording": {
+                  "uid": "rec-abc123xyz",
+                  "recordingUrl": "https://example.com/recordings/presigned-url",
+                  "size": 1048576,
+                  "duration": 300,
+                  "recording_played": false,
+                  "recording_type": "CALL"
+                },
+                "external_app_url": "https://example.com/call-details",
+                "external_app_name": "my.pa",
+                "source_id": "call-src-001",
+                "external_uuid": "ext-call-001",
+                "handled_by_staff_uid": "d290f1ee-6c54-4b01-90e6-d701748f0851",
+                "handled_at": "2021-07-20T14:00:00.000Z",
+                "deleted_at": null,
+                "transcript_status": "DONE"
+              },
+              "description": "Represents a phone call record, including participants, status, recording and audit timestamps."
             }
           }
         },
@@ -4927,7 +10989,75 @@
         }
       },
       "TranscriptResponse": {
-        "$ref": "https://vcita.github.io/developers-hub/entities/communication/voiceCallTranscript.json"
+        "type": "object",
+        "properties": {
+          "transcript_uid": {
+            "type": "string",
+            "description": "Unique identifier of the transcript entity (e.g., \"a1b2c3d4-5678-90ab-cdef-1234567890ab\")"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "IN_PROGRESS",
+              "DONE",
+              "FAILED"
+            ],
+            "description": "Processing status of the transcript. IN_PROGRESS means generation is underway, DONE means it is ready, FAILED means generation failed (e.g., \"DONE\")"
+          },
+          "transcript": {
+            "type": "array",
+            "nullable": true,
+            "description": "Array of transcript entries, present only when status is DONE",
+            "items": {
+              "type": "object",
+              "properties": {
+                "timestamp": {
+                  "type": "number",
+                  "description": "Timestamp in seconds from start of audio (e.g., 12.5)"
+                },
+                "speaker_role": {
+                  "type": "string",
+                  "description": "Role of the speaker in the conversation (e.g., \"client\", \"staff\")"
+                },
+                "text": {
+                  "type": "string",
+                  "description": "Transcribed text for this segment (e.g., \"Hello, how can I help you?\")"
+                }
+              },
+              "required": [
+                "timestamp",
+                "speaker_role",
+                "text"
+              ]
+            }
+          }
+        },
+        "required": [
+          "transcript_uid",
+          "status"
+        ],
+        "example": {
+          "transcript_uid": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
+          "status": "DONE",
+          "transcript": [
+            {
+              "timestamp": 0,
+              "speaker_role": "staff",
+              "text": "Hello, thank you for calling. How can I help you today?"
+            },
+            {
+              "timestamp": 3.2,
+              "speaker_role": "client",
+              "text": "Hi, I'd like to schedule an appointment for next week."
+            },
+            {
+              "timestamp": 7.8,
+              "speaker_role": "staff",
+              "text": "Sure, let me check available slots for you."
+            }
+          ]
+        },
+        "description": "Represents the transcript of a voice call, including processing status and individual speaker entries."
       },
       "CreateVoiceCall": {
         "type": "object",
@@ -5039,7 +11169,37 @@
           "voice_call_quotas": {
             "type": "array",
             "items": {
-              "$ref": "https://vcita.github.io/developers-hub/entities/communication/voiceCallQuota.json"
+              "type": "object",
+              "properties": {
+                "uid": {
+                  "type": "string",
+                  "description": "Unique identifier of the quota object."
+                },
+                "business_uid": {
+                  "type": "string",
+                  "description": "Unique identifier of the business that the quota relates to."
+                },
+                "remaining_minutes": {
+                  "type": "integer",
+                  "description": "The remaining minutes for calls."
+                },
+                "created_at": {
+                  "type": "string",
+                  "description": "The time the quota was created."
+                },
+                "updated_at": {
+                  "type": "string",
+                  "description": "The time the quota was last updated."
+                }
+              },
+              "example": {
+                "uid": "d290f1ee6c544b01",
+                "business_uid": "d290f1e6c544b0190e6",
+                "remaining_minutes": 100,
+                "created_at": "2021-07-20T14:00:00.000Z",
+                "updated_at": "2021-07-20T14:00:00.000Z"
+              },
+              "description": "Tracks remaining voice call minutes for a business."
             }
           }
         },
@@ -5326,7 +11486,32 @@
           "available_phone_numbers": {
             "type": "array",
             "items": {
-              "$ref": "https://vcita.github.io/developers-hub/entities/communication/availablePhoneNumber.json"
+              "type": "object",
+              "properties": {
+                "country_code": {
+                  "type": "string",
+                  "description": "ISO 3166-1 alpha-2 country code indicating the country where the phone number is registered (e.g., \"US\" for United States, \"CA\" for Canada)."
+                },
+                "area_code": {
+                  "type": "string",
+                  "description": "The area code portion of the phone number. For North American numbers, this is typically a 3-digit code that identifies the geographic region (e.g., 302 for Delaware)."
+                },
+                "phone_number": {
+                  "type": "string",
+                  "description": "The complete phone number in E.164 format without formatting (e.g., \"12127654321\"). This is the actual phone number available for purchase from the telecom provider."
+                }
+              },
+              "required": [
+                "country_code",
+                "area_code",
+                "phone_number"
+              ],
+              "example": {
+                "country_code": "US",
+                "area_code": "302",
+                "phone_number": "13022440861"
+              },
+              "description": "Represents an available phone number that can be purchased, including country and area code."
             }
           }
         },
@@ -5474,7 +11659,224 @@
           "business_phone_numbers": {
             "type": "array",
             "items": {
-              "$ref": "https://vcita.github.io/developers-hub/entities/communication/businessPhoneNumber.json"
+              "type": "object",
+              "properties": {
+                "uid": {
+                  "type": "string",
+                  "description": "Unique identifier for the phone number record."
+                },
+                "business_uid": {
+                  "type": "string",
+                  "description": "Unique identifier of the business that owns this phone number."
+                },
+                "phone_number": {
+                  "type": "string",
+                  "description": "The complete phone number in E.164 format without formatting (e.g., \"12127654321\"). This is the actual phone number that was purchased from the telecom provider."
+                },
+                "country_code": {
+                  "type": "string",
+                  "description": "ISO 3166-1 alpha-2 country code indicating the country where the phone number is registered (e.g., \"US\" for United States, \"CA\" for Canada)."
+                },
+                "features": {
+                  "type": "array",
+                  "description": "List of telephony features to enable for this phone number, (e.g., [\"VOICE\", \"SMS\"]).",
+                  "minItems": 1,
+                  "items": {
+                    "type": "string",
+                    "enum": [
+                      "VOICE",
+                      "SMS"
+                    ]
+                  }
+                },
+                "verification_request_data": {
+                  "type": "object",
+                  "description": "Business verification information required for text messaging compliance in the United States and Canada. This data registers your business with mobile carriers to enable SMS messaging capabilities. The verification process helps prevent spam and ensures your business messages are delivered reliably to customers.",
+                  "properties": {
+                    "entity_type": {
+                      "type": "string",
+                      "enum": [
+                        "PRIVATE_PROFIT",
+                        "PUBLIC_PROFIT",
+                        "NON_PROFIT",
+                        "SOLE_PROPRIETOR"
+                      ],
+                      "description": "Legal form of the business. PRIVATE_PROFIT: Privately-held for-profit company (e.g., LLC, Corp). PUBLIC_PROFIT: Publicly-traded for-profit company. NON_PROFIT: Non-profit organization (e.g., 501(c)(3)). SOLE_PROPRIETOR: Individual business owner without formal business entity."
+                    },
+                    "brand_name": {
+                      "type": "string",
+                      "maxLength": 255,
+                      "description": "Brand name of the company or DBA (Doing Business As)"
+                    },
+                    "legal_company_name": {
+                      "type": "string",
+                      "maxLength": 255,
+                      "description": "The legally registered company name"
+                    },
+                    "contact_first_name": {
+                      "type": "string",
+                      "maxLength": 100,
+                      "description": "Business owner's first name"
+                    },
+                    "contact_last_name": {
+                      "type": "string",
+                      "maxLength": 100,
+                      "description": "Business owner's last name"
+                    },
+                    "tax_number": {
+                      "type": "string",
+                      "maxLength": 21,
+                      "description": "Tax Number/ID/EIN"
+                    },
+                    "website_url": {
+                      "type": "string",
+                      "format": "uri",
+                      "description": "Business website URL"
+                    },
+                    "country_code": {
+                      "type": "string",
+                      "pattern": "^[A-Z]{2}$",
+                      "description": "ISO3166-Alpha2 country code of registration (e.g., \"US\", \"CA\")"
+                    },
+                    "postal_code": {
+                      "type": "string",
+                      "maxLength": 10,
+                      "pattern": "^[0-9]{5}$",
+                      "description": "Postal/ZIP code (5 digits for US)"
+                    },
+                    "street": {
+                      "type": "string",
+                      "maxLength": 100,
+                      "description": "Street address and number (e.g., \"123 Main Street\", \"456 5th Avenue\")"
+                    },
+                    "full_address": {
+                      "type": "string",
+                      "maxLength": 255,
+                      "description": "Complete formatted address including street, city, state, postal code, and country (e.g., \"123 Main Street, New York, NY 10001, USA\")"
+                    },
+                    "city": {
+                      "type": "string",
+                      "maxLength": 100,
+                      "description": "City name"
+                    },
+                    "state": {
+                      "type": "string",
+                      "maxLength": 20,
+                      "pattern": "^[A-Z]{2}$",
+                      "description": "State/Region (2-letter code for USA)"
+                    },
+                    "contact_email": {
+                      "type": "string",
+                      "format": "email",
+                      "description": "Contact email address."
+                    },
+                    "contact_phone": {
+                      "type": "string",
+                      "pattern": "^[1-9][0-9]{9,14}$",
+                      "description": "Contact phone number in E.164 format without + prefix"
+                    },
+                    "mobile_phone": {
+                      "type": "string",
+                      "pattern": "^[1-9][0-9]{9,14}$",
+                      "description": "Mobile phone number for brand verification in E.164 format without + prefix"
+                    }
+                  },
+                  "required": [
+                    "entity_type",
+                    "brand_name",
+                    "contact_first_name",
+                    "contact_last_name",
+                    "website_url",
+                    "country_code",
+                    "postal_code",
+                    "street",
+                    "city",
+                    "state",
+                    "contact_email",
+                    "contact_phone",
+                    "mobile_phone"
+                  ],
+                  "example": {
+                    "entity_type": "PRIVATE_PROFIT",
+                    "brand_name": "Tech Solutions LLC",
+                    "legal_company_name": "Technology Solutions Limited Liability Company",
+                    "contact_first_name": "Jane",
+                    "contact_last_name": "Smith",
+                    "tax_number": "987654321",
+                    "website_url": "https://www.techsolutions.com",
+                    "country_code": "US",
+                    "postal_code": "94105",
+                    "street": "456 Market Street",
+                    "full_address": "456 Market Street, San Francisco, CA 94105, USA",
+                    "city": "San Francisco",
+                    "state": "CA",
+                    "contact_email": "jane.smith@techsolutions.com",
+                    "contact_phone": "14155551234",
+                    "mobile_phone": "14155559876"
+                  }
+                },
+                "status": {
+                  "type": "string",
+                  "enum": [
+                    "active",
+                    "inactive",
+                    "suspended"
+                  ],
+                  "description": "Current operational status of the phone number."
+                },
+                "verification_status": {
+                  "type": "string",
+                  "enum": [
+                    "pending",
+                    "verified",
+                    "failed"
+                  ],
+                  "description": "Indicates the outcome of verifying a phone number's ownership and validity based on business verification data provided. This field applies only to U.S. and Canadian numbers and reflects compliance verification required by telecom regulations."
+                },
+                "created_at": {
+                  "type": "string",
+                  "description": "The creation date and time of the phone number record.",
+                  "format": "date-time"
+                },
+                "updated_at": {
+                  "type": "string",
+                  "description": "Updated date and time of the phone number record.",
+                  "format": "date-time"
+                }
+              },
+              "example": {
+                "uid": "number123",
+                "business_uid": "business123abc",
+                "phone_number": "12127654321",
+                "country_code": "US",
+                "features": [
+                  "VOICE",
+                  "SMS"
+                ],
+                "verification_request_data": {
+                  "entity_type": "PRIVATE_PROFIT",
+                  "brand_name": "Acme Corporation",
+                  "legal_company_name": "Acme Corporation Inc.",
+                  "contact_first_name": "John",
+                  "contact_last_name": "Doe",
+                  "tax_number": "123456789",
+                  "website_url": "https://www.acmecorp.com",
+                  "country_code": "US",
+                  "postal_code": "10001",
+                  "street": "123 Business Ave",
+                  "full_address": "123 Business Ave, New York, NY 10001, USA",
+                  "city": "New York",
+                  "state": "NY",
+                  "contact_email": "john.doe@acmecorp.com",
+                  "contact_phone": "12125551234",
+                  "mobile_phone": "19175551234"
+                },
+                "status": "active",
+                "verification_status": "verified",
+                "created_at": "2024-01-01T09:00:00Z",
+                "updated_at": "2024-03-20T12:34:56Z"
+              },
+              "description": "A business-owned phone number with enabled features and lifecycle metadata."
             }
           }
         },

--- a/mcp_swagger/integrations.json
+++ b/mcp_swagger/integrations.json
@@ -81,7 +81,174 @@
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/integrations/importJob.json",
+                          "type": "object",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "description": "Unique identifier of the import job"
+                            },
+                            "provider_type": {
+                              "type": "string",
+                              "enum": [
+                                "excel",
+                                "import_job"
+                              ],
+                              "description": "The type of import provider"
+                            },
+                            "provider_data": {
+                              "description": "The data used by the provider to import the records",
+                              "oneOf": [
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "entity_type": {
+                                      "type": "string",
+                                      "description": "Type of entity being imported"
+                                    },
+                                    "original_file_name": {
+                                      "type": "string",
+                                      "description": "Name of the uploaded file"
+                                    }
+                                  },
+                                  "required": [
+                                    "entity_type",
+                                    "original_file_name"
+                                  ],
+                                  "description": "Excel provider configuration"
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "source_import_job_uid": {
+                                      "type": "string",
+                                      "description": "The UID of the import job that was used for validation"
+                                    }
+                                  },
+                                  "required": [
+                                    "source_import_job_uid"
+                                  ],
+                                  "description": "Existing import job configuration"
+                                }
+                              ]
+                            },
+                            "job_type": {
+                              "type": "string",
+                              "enum": [
+                                "validate",
+                                "execute"
+                              ],
+                              "description": "The type of job operation. 'validate' will go over the lines and return errors, use /v3/integrations/import_job_items to get detailed errors about each line.\n'execute' will run the import job. use /v3/integrations/import_job to get the progress of the import task."
+                            },
+                            "status": {
+                              "type": "string",
+                              "enum": [
+                                "pending",
+                                "processing",
+                                "done",
+                                "error"
+                              ],
+                              "description": "Current status of the import job"
+                            },
+                            "error_message": {
+                              "type": "string",
+                              "description": "Error message if the job failed"
+                            },
+                            "progress": {
+                              "type": "object",
+                              "properties": {
+                                "total": {
+                                  "type": "number",
+                                  "description": "Total number of records to be processed"
+                                },
+                                "done": {
+                                  "type": "number",
+                                  "description": "Number of records successfully processed"
+                                },
+                                "error": {
+                                  "type": "number",
+                                  "description": "Number of records that failed processing"
+                                },
+                                "pending": {
+                                  "type": "number",
+                                  "description": "Number of records pending processing"
+                                }
+                              },
+                              "required": [
+                                "total",
+                                "done",
+                                "error",
+                                "pending"
+                              ]
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "description": "Creation timestamp"
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "description": "Last update timestamp"
+                            },
+                            "metadata": {
+                              "type": "object",
+                              "properties": {
+                                "data_row_index": {
+                                  "type": "number",
+                                  "description": "Index of the data row being processed"
+                                },
+                                "locale": {
+                                  "type": "string",
+                                  "description": "Locale setting for the import job"
+                                },
+                                "shared_entity_data": {
+                                  "type": "object",
+                                  "description": "Shared entity data for the import job, this data is shared between all the import job items"
+                                }
+                              },
+                              "description": "Additional metadata for the import job"
+                            }
+                          },
+                          "required": [
+                            "uid",
+                            "provider_type",
+                            "provider_data",
+                            "job_type",
+                            "status",
+                            "error_message",
+                            "progress",
+                            "created_at",
+                            "updated_at"
+                          ],
+                          "example": {
+                            "uid": "job-xyz789",
+                            "provider_type": "excel",
+                            "provider_data": {
+                              "entity_type": "products",
+                              "original_file_name": "import.xlsx"
+                            },
+                            "job_type": "execute",
+                            "status": "processing",
+                            "error_message": null,
+                            "progress": {
+                              "total": 100,
+                              "done": 42,
+                              "error": 3,
+                              "pending": 55
+                            },
+                            "metadata": {
+                              "data_row_index": 5,
+                              "locale": "en",
+                              "shared_entity_data": {
+                                "tax_ids": [
+                                  "12345678yyu90",
+                                  "heuh39759nmf"
+                                ]
+                              }
+                            },
+                            "created_at": "2023-01-15T08:00:00.000Z",
+                            "updated_at": "2023-01-15T08:30:00.000Z"
+                          },
                           "description": "Import job details"
                         }
                       }
@@ -130,7 +297,175 @@
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/integrations/importJob.json"
+                          "type": "object",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "description": "Unique identifier of the import job"
+                            },
+                            "provider_type": {
+                              "type": "string",
+                              "enum": [
+                                "excel",
+                                "import_job"
+                              ],
+                              "description": "The type of import provider"
+                            },
+                            "provider_data": {
+                              "description": "The data used by the provider to import the records",
+                              "oneOf": [
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "entity_type": {
+                                      "type": "string",
+                                      "description": "Type of entity being imported"
+                                    },
+                                    "original_file_name": {
+                                      "type": "string",
+                                      "description": "Name of the uploaded file"
+                                    }
+                                  },
+                                  "required": [
+                                    "entity_type",
+                                    "original_file_name"
+                                  ],
+                                  "description": "Excel provider configuration"
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "source_import_job_uid": {
+                                      "type": "string",
+                                      "description": "The UID of the import job that was used for validation"
+                                    }
+                                  },
+                                  "required": [
+                                    "source_import_job_uid"
+                                  ],
+                                  "description": "Existing import job configuration"
+                                }
+                              ]
+                            },
+                            "job_type": {
+                              "type": "string",
+                              "enum": [
+                                "validate",
+                                "execute"
+                              ],
+                              "description": "The type of job operation. 'validate' will go over the lines and return errors, use /v3/integrations/import_job_items to get detailed errors about each line.\n'execute' will run the import job. use /v3/integrations/import_job to get the progress of the import task."
+                            },
+                            "status": {
+                              "type": "string",
+                              "enum": [
+                                "pending",
+                                "processing",
+                                "done",
+                                "error"
+                              ],
+                              "description": "Current status of the import job"
+                            },
+                            "error_message": {
+                              "type": "string",
+                              "description": "Error message if the job failed"
+                            },
+                            "progress": {
+                              "type": "object",
+                              "properties": {
+                                "total": {
+                                  "type": "number",
+                                  "description": "Total number of records to be processed"
+                                },
+                                "done": {
+                                  "type": "number",
+                                  "description": "Number of records successfully processed"
+                                },
+                                "error": {
+                                  "type": "number",
+                                  "description": "Number of records that failed processing"
+                                },
+                                "pending": {
+                                  "type": "number",
+                                  "description": "Number of records pending processing"
+                                }
+                              },
+                              "required": [
+                                "total",
+                                "done",
+                                "error",
+                                "pending"
+                              ]
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "description": "Creation timestamp"
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "description": "Last update timestamp"
+                            },
+                            "metadata": {
+                              "type": "object",
+                              "properties": {
+                                "data_row_index": {
+                                  "type": "number",
+                                  "description": "Index of the data row being processed"
+                                },
+                                "locale": {
+                                  "type": "string",
+                                  "description": "Locale setting for the import job"
+                                },
+                                "shared_entity_data": {
+                                  "type": "object",
+                                  "description": "Shared entity data for the import job, this data is shared between all the import job items"
+                                }
+                              },
+                              "description": "Additional metadata for the import job"
+                            }
+                          },
+                          "required": [
+                            "uid",
+                            "provider_type",
+                            "provider_data",
+                            "job_type",
+                            "status",
+                            "error_message",
+                            "progress",
+                            "created_at",
+                            "updated_at"
+                          ],
+                          "example": {
+                            "uid": "job-xyz789",
+                            "provider_type": "excel",
+                            "provider_data": {
+                              "entity_type": "products",
+                              "original_file_name": "import.xlsx"
+                            },
+                            "job_type": "execute",
+                            "status": "processing",
+                            "error_message": null,
+                            "progress": {
+                              "total": 100,
+                              "done": 42,
+                              "error": 3,
+                              "pending": 55
+                            },
+                            "metadata": {
+                              "data_row_index": 5,
+                              "locale": "en",
+                              "shared_entity_data": {
+                                "tax_ids": [
+                                  "12345678yyu90",
+                                  "heuh39759nmf"
+                                ]
+                              }
+                            },
+                            "created_at": "2023-01-15T08:00:00.000Z",
+                            "updated_at": "2023-01-15T08:30:00.000Z"
+                          },
+                          "description": "Defines an import job for validating or executing bulk data imports, with progress and metadata."
                         }
                       }
                     }
@@ -260,7 +595,82 @@
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/integrations/importJobItem.json"
+                          "type": "object",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "description": "Unique identifier of the import job item"
+                            },
+                            "import_job_uid": {
+                              "type": "string",
+                              "description": "Reference to the parent import job"
+                            },
+                            "action": {
+                              "type": "string",
+                              "enum": [
+                                "create",
+                                "update",
+                                "skip"
+                              ],
+                              "description": "The action performed for this record"
+                            },
+                            "line_number": {
+                              "type": "number",
+                              "description": "Line number in the source file"
+                            },
+                            "entity": {
+                              "type": "object",
+                              "description": "The entity data being imported"
+                            },
+                            "status": {
+                              "type": "string",
+                              "enum": [
+                                "pending",
+                                "processing",
+                                "done",
+                                "error"
+                              ],
+                              "description": "Current status of the import detail"
+                            },
+                            "error_message": {
+                              "type": "string",
+                              "description": "Error message if the import failed"
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "description": "Creation timestamp"
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "description": "Last update timestamp"
+                            }
+                          },
+                          "required": [
+                            "uid",
+                            "import_job_uid",
+                            "action",
+                            "line_number",
+                            "status",
+                            "created_at",
+                            "updated_at"
+                          ],
+                          "example": {
+                            "uid": "item-123abc",
+                            "import_job_uid": "job-xyz789",
+                            "action": "create",
+                            "line_number": 42,
+                            "entity": {
+                              "name": "John Doe",
+                              "email": "john@example.com"
+                            },
+                            "status": "done",
+                            "error_message": null,
+                            "created_at": "2023-01-15T08:30:00.000Z",
+                            "updated_at": "2023-01-15T08:35:00.000Z"
+                          },
+                          "description": "Represents a single record processed by an import job, with action and status."
                         }
                       }
                     }
@@ -346,7 +756,50 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
@@ -390,12 +843,105 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/integrations/idp_actor_mapping.json"
+                          "type": "object",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "description": "Unique identifier of the IDP actor (a user in an IDP integrated with SSO to the inTandem autheriation bridge)"
+                            },
+                            "idp_user_reference_id": {
+                              "type": "string",
+                              "description": "External reference ID of the IDP user, used to link the IDP actor to an external system."
+                            },
+                            "actor_type": {
+                              "type": "string",
+                              "default": "staff",
+                              "enum": [
+                                "staff",
+                                "operator"
+                              ],
+                              "description": "Type of the actor in the inTandem platform. 'staff' refers to a staff member, while 'operator' refers to an operator in the Operators Portal."
+                            },
+                            "actor_uid": {
+                              "type": "string",
+                              "description": "Unique identifier of the actor in the inTandem platform. This is used to link the IDP actor to a specific staff member or operator."
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "description": "Creation timestamp"
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "description": "Last update timestamp"
+                            }
+                          },
+                          "required": [
+                            "uid",
+                            "idp_user_reference_id",
+                            "actor_type",
+                            "actor_uid",
+                            "created_at",
+                            "updated_at"
+                          ],
+                          "example": {
+                            "uid": "12345",
+                            "idp_user_reference_id": "ext-12345",
+                            "actor_type": "staff",
+                            "actor_uid": "staff-67890",
+                            "created_at": "2023-10-01T12:00:00Z",
+                            "updated_at": "2023-10-01T12:00:00Z"
+                          },
+                          "description": "Maps an external IDP user to an inTandem platform actor (staff or operator)."
                         }
                       }
                     }
@@ -509,7 +1055,50 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
@@ -558,12 +1147,181 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/integrations/directory_idp.json"
+                          "type": "object",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "description": "Unique identifier for the DirectoryIDP"
+                            },
+                            "directory_uid": {
+                              "type": "string",
+                              "description": "Unique identifier of the directory"
+                            },
+                            "idp_uid": {
+                              "type": "string",
+                              "description": "Unique identifier of the Identity Provider (IDP)"
+                            },
+                            "change_email": {
+                              "type": "object",
+                              "description": "Configuration for change email functionality",
+                              "properties": {
+                                "interaction": {
+                                  "type": "string",
+                                  "enum": [
+                                    "iframe_modal",
+                                    "new_tab",
+                                    "api",
+                                    "disabled"
+                                  ],
+                                  "description": "The interaction type for change email. 'iframe_modal' opens in an iframe modal, 'new_tab' opens in a new tab, 'api' uses API endpoint, 'disabled' disables the functionality"
+                                },
+                                "value": {
+                                  "type": "string",
+                                  "description": "The endpoint URL or URL for iframe/new_tab interaction type"
+                                }
+                              },
+                              "required": [
+                                "interaction",
+                                "value"
+                              ]
+                            },
+                            "change_password": {
+                              "type": "object",
+                              "description": "Configuration for change password functionality",
+                              "properties": {
+                                "interaction": {
+                                  "type": "string",
+                                  "enum": [
+                                    "iframe_modal",
+                                    "new_tab",
+                                    "api",
+                                    "disabled"
+                                  ],
+                                  "description": "The interaction type for change password. 'iframe_modal' opens in an iframe modal, 'new_tab' opens in a new tab, 'api' uses API endpoint, 'disabled' disables the functionality"
+                                },
+                                "value": {
+                                  "type": "string",
+                                  "description": "The endpoint URL or URL for iframe/new_tab interaction type"
+                                }
+                              },
+                              "required": [
+                                "interaction",
+                                "value"
+                              ]
+                            },
+                            "reset_password": {
+                              "type": "object",
+                              "description": "Configuration for reset password functionality",
+                              "properties": {
+                                "interaction": {
+                                  "type": "string",
+                                  "enum": [
+                                    "iframe_modal",
+                                    "new_tab",
+                                    "api",
+                                    "disabled"
+                                  ],
+                                  "description": "The interaction type for reset password. 'iframe_modal' opens in an iframe modal, 'new_tab' opens in a new tab, 'api' uses API endpoint, 'disabled' disables the functionality"
+                                },
+                                "value": {
+                                  "type": "string",
+                                  "description": "The endpoint URL or URL for iframe/new_tab interaction type"
+                                }
+                              },
+                              "required": [
+                                "interaction",
+                                "value"
+                              ]
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "description": "Creation timestamp"
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "description": "Last update timestamp"
+                            }
+                          },
+                          "required": [
+                            "uid",
+                            "directory_uid",
+                            "idp_uid",
+                            "change_email",
+                            "change_password",
+                            "reset_password",
+                            "created_at",
+                            "updated_at"
+                          ],
+                          "example": {
+                            "uid": "dir-idp-123",
+                            "directory_uid": "dir-456",
+                            "idp_uid": "idp-789",
+                            "change_email": {
+                              "interaction": "iframe_modal",
+                              "value": "https://example.com/change-email"
+                            },
+                            "change_password": {
+                              "interaction": "new_tab",
+                              "value": "https://example.com/change-password"
+                            },
+                            "reset_password": {
+                              "interaction": "api",
+                              "value": "https://api.example.com/reset-password"
+                            },
+                            "created_at": "2023-10-01T12:00:00Z",
+                            "updated_at": "2023-10-01T12:00:00Z"
+                          },
+                          "description": "Defines the configuration for a Directory's Identity Provider (IDP) integration, including settings for change email, change password, and reset password functionalities."
                         }
                       }
                     }
@@ -617,12 +1375,181 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/integrations/directory_idp.json"
+                          "type": "object",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "description": "Unique identifier for the DirectoryIDP"
+                            },
+                            "directory_uid": {
+                              "type": "string",
+                              "description": "Unique identifier of the directory"
+                            },
+                            "idp_uid": {
+                              "type": "string",
+                              "description": "Unique identifier of the Identity Provider (IDP)"
+                            },
+                            "change_email": {
+                              "type": "object",
+                              "description": "Configuration for change email functionality",
+                              "properties": {
+                                "interaction": {
+                                  "type": "string",
+                                  "enum": [
+                                    "iframe_modal",
+                                    "new_tab",
+                                    "api",
+                                    "disabled"
+                                  ],
+                                  "description": "The interaction type for change email. 'iframe_modal' opens in an iframe modal, 'new_tab' opens in a new tab, 'api' uses API endpoint, 'disabled' disables the functionality"
+                                },
+                                "value": {
+                                  "type": "string",
+                                  "description": "The endpoint URL or URL for iframe/new_tab interaction type"
+                                }
+                              },
+                              "required": [
+                                "interaction",
+                                "value"
+                              ]
+                            },
+                            "change_password": {
+                              "type": "object",
+                              "description": "Configuration for change password functionality",
+                              "properties": {
+                                "interaction": {
+                                  "type": "string",
+                                  "enum": [
+                                    "iframe_modal",
+                                    "new_tab",
+                                    "api",
+                                    "disabled"
+                                  ],
+                                  "description": "The interaction type for change password. 'iframe_modal' opens in an iframe modal, 'new_tab' opens in a new tab, 'api' uses API endpoint, 'disabled' disables the functionality"
+                                },
+                                "value": {
+                                  "type": "string",
+                                  "description": "The endpoint URL or URL for iframe/new_tab interaction type"
+                                }
+                              },
+                              "required": [
+                                "interaction",
+                                "value"
+                              ]
+                            },
+                            "reset_password": {
+                              "type": "object",
+                              "description": "Configuration for reset password functionality",
+                              "properties": {
+                                "interaction": {
+                                  "type": "string",
+                                  "enum": [
+                                    "iframe_modal",
+                                    "new_tab",
+                                    "api",
+                                    "disabled"
+                                  ],
+                                  "description": "The interaction type for reset password. 'iframe_modal' opens in an iframe modal, 'new_tab' opens in a new tab, 'api' uses API endpoint, 'disabled' disables the functionality"
+                                },
+                                "value": {
+                                  "type": "string",
+                                  "description": "The endpoint URL or URL for iframe/new_tab interaction type"
+                                }
+                              },
+                              "required": [
+                                "interaction",
+                                "value"
+                              ]
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "description": "Creation timestamp"
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "description": "Last update timestamp"
+                            }
+                          },
+                          "required": [
+                            "uid",
+                            "directory_uid",
+                            "idp_uid",
+                            "change_email",
+                            "change_password",
+                            "reset_password",
+                            "created_at",
+                            "updated_at"
+                          ],
+                          "example": {
+                            "uid": "dir-idp-123",
+                            "directory_uid": "dir-456",
+                            "idp_uid": "idp-789",
+                            "change_email": {
+                              "interaction": "iframe_modal",
+                              "value": "https://example.com/change-email"
+                            },
+                            "change_password": {
+                              "interaction": "new_tab",
+                              "value": "https://example.com/change-password"
+                            },
+                            "reset_password": {
+                              "interaction": "api",
+                              "value": "https://api.example.com/reset-password"
+                            },
+                            "created_at": "2023-10-01T12:00:00Z",
+                            "updated_at": "2023-10-01T12:00:00Z"
+                          },
+                          "description": "Defines the configuration for a Directory's Identity Provider (IDP) integration, including settings for change email, change password, and reset password functionalities."
                         }
                       }
                     }
@@ -785,7 +1712,82 @@
           "import_job_items": {
             "type": "array",
             "items": {
-              "$ref": "https://vcita.github.io/developers-hub/entities/integrations/importJobItem.json"
+              "type": "object",
+              "properties": {
+                "uid": {
+                  "type": "string",
+                  "description": "Unique identifier of the import job item"
+                },
+                "import_job_uid": {
+                  "type": "string",
+                  "description": "Reference to the parent import job"
+                },
+                "action": {
+                  "type": "string",
+                  "enum": [
+                    "create",
+                    "update",
+                    "skip"
+                  ],
+                  "description": "The action performed for this record"
+                },
+                "line_number": {
+                  "type": "number",
+                  "description": "Line number in the source file"
+                },
+                "entity": {
+                  "type": "object",
+                  "description": "The entity data being imported"
+                },
+                "status": {
+                  "type": "string",
+                  "enum": [
+                    "pending",
+                    "processing",
+                    "done",
+                    "error"
+                  ],
+                  "description": "Current status of the import detail"
+                },
+                "error_message": {
+                  "type": "string",
+                  "description": "Error message if the import failed"
+                },
+                "created_at": {
+                  "type": "string",
+                  "format": "date-time",
+                  "description": "Creation timestamp"
+                },
+                "updated_at": {
+                  "type": "string",
+                  "format": "date-time",
+                  "description": "Last update timestamp"
+                }
+              },
+              "required": [
+                "uid",
+                "import_job_uid",
+                "action",
+                "line_number",
+                "status",
+                "created_at",
+                "updated_at"
+              ],
+              "example": {
+                "uid": "item-123abc",
+                "import_job_uid": "job-xyz789",
+                "action": "create",
+                "line_number": 42,
+                "entity": {
+                  "name": "John Doe",
+                  "email": "john@example.com"
+                },
+                "status": "done",
+                "error_message": null,
+                "created_at": "2023-01-15T08:30:00.000Z",
+                "updated_at": "2023-01-15T08:35:00.000Z"
+              },
+              "description": "Represents a single record processed by an import job, with action and status."
             }
           }
         },
@@ -800,7 +1802,57 @@
             "description": "List of IDP Actor Mappings",
             "type": "array",
             "items": {
-              "$ref": "https://vcita.github.io/developers-hub/entities/integrations/idp_actor_mapping.json"
+              "type": "object",
+              "properties": {
+                "uid": {
+                  "type": "string",
+                  "description": "Unique identifier of the IDP actor (a user in an IDP integrated with SSO to the inTandem autheriation bridge)"
+                },
+                "idp_user_reference_id": {
+                  "type": "string",
+                  "description": "External reference ID of the IDP user, used to link the IDP actor to an external system."
+                },
+                "actor_type": {
+                  "type": "string",
+                  "default": "staff",
+                  "enum": [
+                    "staff",
+                    "operator"
+                  ],
+                  "description": "Type of the actor in the inTandem platform. 'staff' refers to a staff member, while 'operator' refers to an operator in the Operators Portal."
+                },
+                "actor_uid": {
+                  "type": "string",
+                  "description": "Unique identifier of the actor in the inTandem platform. This is used to link the IDP actor to a specific staff member or operator."
+                },
+                "created_at": {
+                  "type": "string",
+                  "format": "date-time",
+                  "description": "Creation timestamp"
+                },
+                "updated_at": {
+                  "type": "string",
+                  "format": "date-time",
+                  "description": "Last update timestamp"
+                }
+              },
+              "required": [
+                "uid",
+                "idp_user_reference_id",
+                "actor_type",
+                "actor_uid",
+                "created_at",
+                "updated_at"
+              ],
+              "example": {
+                "uid": "12345",
+                "idp_user_reference_id": "ext-12345",
+                "actor_type": "staff",
+                "actor_uid": "staff-67890",
+                "created_at": "2023-10-01T12:00:00Z",
+                "updated_at": "2023-10-01T12:00:00Z"
+              },
+              "description": "Maps an external IDP user to an inTandem platform actor (staff or operator)."
             }
           }
         }
@@ -865,7 +1917,133 @@
             "description": "List of Directory IDP configurations",
             "type": "array",
             "items": {
-              "$ref": "https://vcita.github.io/developers-hub/entities/integrations/directory_idp.json"
+              "type": "object",
+              "properties": {
+                "uid": {
+                  "type": "string",
+                  "description": "Unique identifier for the DirectoryIDP"
+                },
+                "directory_uid": {
+                  "type": "string",
+                  "description": "Unique identifier of the directory"
+                },
+                "idp_uid": {
+                  "type": "string",
+                  "description": "Unique identifier of the Identity Provider (IDP)"
+                },
+                "change_email": {
+                  "type": "object",
+                  "description": "Configuration for change email functionality",
+                  "properties": {
+                    "interaction": {
+                      "type": "string",
+                      "enum": [
+                        "iframe_modal",
+                        "new_tab",
+                        "api",
+                        "disabled"
+                      ],
+                      "description": "The interaction type for change email. 'iframe_modal' opens in an iframe modal, 'new_tab' opens in a new tab, 'api' uses API endpoint, 'disabled' disables the functionality"
+                    },
+                    "value": {
+                      "type": "string",
+                      "description": "The endpoint URL or URL for iframe/new_tab interaction type"
+                    }
+                  },
+                  "required": [
+                    "interaction",
+                    "value"
+                  ]
+                },
+                "change_password": {
+                  "type": "object",
+                  "description": "Configuration for change password functionality",
+                  "properties": {
+                    "interaction": {
+                      "type": "string",
+                      "enum": [
+                        "iframe_modal",
+                        "new_tab",
+                        "api",
+                        "disabled"
+                      ],
+                      "description": "The interaction type for change password. 'iframe_modal' opens in an iframe modal, 'new_tab' opens in a new tab, 'api' uses API endpoint, 'disabled' disables the functionality"
+                    },
+                    "value": {
+                      "type": "string",
+                      "description": "The endpoint URL or URL for iframe/new_tab interaction type"
+                    }
+                  },
+                  "required": [
+                    "interaction",
+                    "value"
+                  ]
+                },
+                "reset_password": {
+                  "type": "object",
+                  "description": "Configuration for reset password functionality",
+                  "properties": {
+                    "interaction": {
+                      "type": "string",
+                      "enum": [
+                        "iframe_modal",
+                        "new_tab",
+                        "api",
+                        "disabled"
+                      ],
+                      "description": "The interaction type for reset password. 'iframe_modal' opens in an iframe modal, 'new_tab' opens in a new tab, 'api' uses API endpoint, 'disabled' disables the functionality"
+                    },
+                    "value": {
+                      "type": "string",
+                      "description": "The endpoint URL or URL for iframe/new_tab interaction type"
+                    }
+                  },
+                  "required": [
+                    "interaction",
+                    "value"
+                  ]
+                },
+                "created_at": {
+                  "type": "string",
+                  "format": "date-time",
+                  "description": "Creation timestamp"
+                },
+                "updated_at": {
+                  "type": "string",
+                  "format": "date-time",
+                  "description": "Last update timestamp"
+                }
+              },
+              "required": [
+                "uid",
+                "directory_uid",
+                "idp_uid",
+                "change_email",
+                "change_password",
+                "reset_password",
+                "created_at",
+                "updated_at"
+              ],
+              "example": {
+                "uid": "dir-idp-123",
+                "directory_uid": "dir-456",
+                "idp_uid": "idp-789",
+                "change_email": {
+                  "interaction": "iframe_modal",
+                  "value": "https://example.com/change-email"
+                },
+                "change_password": {
+                  "interaction": "new_tab",
+                  "value": "https://example.com/change-password"
+                },
+                "reset_password": {
+                  "interaction": "api",
+                  "value": "https://api.example.com/reset-password"
+                },
+                "created_at": "2023-10-01T12:00:00Z",
+                "updated_at": "2023-10-01T12:00:00Z"
+              },
+              "description": "Defines the configuration for a Directory's Identity Provider (IDP) integration, including settings for change email, change password, and reset password functionalities."
             }
           }
         }

--- a/mcp_swagger/online_presence.json
+++ b/mcp_swagger/online_presence.json
@@ -93,7 +93,50 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "type": "object",
@@ -190,7 +233,50 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "type": "object",
@@ -279,7 +365,50 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "type": "object",
@@ -366,7 +495,50 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "type": "object",
@@ -463,7 +635,50 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "type": "object",
@@ -532,12 +747,243 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/online_presence/AiReceptionistConfiguration.json"
+                          "type": "object",
+                          "description": "AI Receptionist Configuration for a business: controls how the AI receptionist behaves across all channels (web widget, WhatsApp, etc.). Includes FAQ/guidance, lead capture settings, business hours, knowledge inclusion flags, and proactive action offers. Returned inside `data` (wrapped by standard Response) for authenticated CRUD/main APIs.",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "readOnly": true,
+                              "description": "Configuration row UID."
+                            },
+                            "business_uid": {
+                              "type": "string",
+                              "readOnly": true,
+                              "description": "Owning business UID."
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "readOnly": true,
+                              "description": "Row creation time (ISO 8601)."
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "readOnly": true,
+                              "description": "Last update time (ISO 8601)."
+                            },
+                            "owner_uid": {
+                              "type": "string",
+                              "nullable": true,
+                              "readOnly": true,
+                              "description": "Staff UID of the last editor."
+                            },
+                            "config": {
+                              "type": "object",
+                              "description": "The AI chat configuration blob. Sparse — omitted keys use product defaults.",
+                              "properties": {
+                                "faq_and_guidance": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "description": "Free-text FAQ and guidance instructions for the AI receptionist."
+                                },
+                                "business_hours": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "description": "Business hours text; null uses calendar-derived defaults."
+                                },
+                                "lead_basic_contact_fields": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "enum": [
+                                    "phone_or_email",
+                                    "phone",
+                                    "email",
+                                    "both"
+                                  ],
+                                  "description": "Contact info the AI receptionist must try to collect before creating a lead. Guidance only; the CRM still creates a lead whenever a name and at least one of phone/email are present. Null uses the default (e.g., \"phone_or_email\")."
+                                },
+                                "lead_fields": {
+                                  "type": "array",
+                                  "nullable": true,
+                                  "description": "Additional lead fields the AI receptionist should try to collect (optional, never blocking).",
+                                  "maxItems": 10,
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "label": {
+                                        "type": "string",
+                                        "nullable": true,
+                                        "maxLength": 100,
+                                        "description": "Field label (e.g., \"Address\", \"Preferred time\")."
+                                      },
+                                      "instructions": {
+                                        "type": "string",
+                                        "nullable": true,
+                                        "maxLength": 200,
+                                        "description": "When/why to ask for this field (e.g., \"Only ask if the customer is requesting a home visit.\")."
+                                      }
+                                    }
+                                  }
+                                },
+                                "include_contact_info": {
+                                  "type": "boolean",
+                                  "nullable": true,
+                                  "description": "Whether to include business contact info in AI guidance context."
+                                },
+                                "include_services": {
+                                  "type": "boolean",
+                                  "nullable": true,
+                                  "description": "Whether to include business services in AI guidance context."
+                                },
+                                "include_products": {
+                                  "type": "boolean",
+                                  "nullable": true,
+                                  "description": "Whether to include business products in AI guidance context."
+                                },
+                                "include_booking_policies": {
+                                  "type": "boolean",
+                                  "nullable": true,
+                                  "description": "Whether to include booking policies in AI guidance context."
+                                },
+                                "include_terms_of_service": {
+                                  "type": "boolean",
+                                  "nullable": true,
+                                  "description": "Whether to include terms of service in AI guidance context."
+                                },
+                                "guidance_urls": {
+                                  "type": "array",
+                                  "nullable": true,
+                                  "items": {
+                                    "type": "string",
+                                    "format": "uri"
+                                  },
+                                  "description": "Extra URLs whose content is merged into AI guidance."
+                                },
+                                "ai_actions": {
+                                  "type": "array",
+                                  "nullable": true,
+                                  "description": "AI proactive action behavior. Defines which actions the AI should proactively offer and when.",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "action_uid": {
+                                        "type": "string",
+                                        "description": "Portal action UID."
+                                      },
+                                      "action_key": {
+                                        "type": "string",
+                                        "description": "Action key/type (e.g., \"schedule\", \"contact\")."
+                                      },
+                                      "should_offer": {
+                                        "type": "boolean",
+                                        "description": "Whether the AI should proactively suggest this action."
+                                      },
+                                      "when_to_offer": {
+                                        "type": "string",
+                                        "nullable": true,
+                                        "maxLength": 200,
+                                        "description": "Guidance text for when the AI should suggest this action (e.g., \"Offer when client asks about scheduling\")."
+                                      }
+                                    },
+                                    "required": [
+                                      "action_uid",
+                                      "action_key",
+                                      "should_offer"
+                                    ]
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "example": {
+                            "uid": "aicfg_7c2d4e91",
+                            "business_uid": "biz_2f8f7ab1",
+                            "created_at": "2026-05-28T10:30:00.000Z",
+                            "updated_at": "2026-05-28T11:12:45.000Z",
+                            "owner_uid": "staff_1182abc",
+                            "config": {
+                              "faq_and_guidance": "Answer questions about pricing, emergency calls, and availability.",
+                              "business_hours": "Mon-Fri 08:00-18:00, Sat 09:00-14:00",
+                              "lead_basic_contact_fields": "phone_or_email",
+                              "lead_fields": [
+                                {
+                                  "label": "Address",
+                                  "instructions": "Only ask if the customer is requesting a home visit."
+                                }
+                              ],
+                              "include_contact_info": true,
+                              "include_services": true,
+                              "include_products": false,
+                              "include_booking_policies": true,
+                              "include_terms_of_service": false,
+                              "guidance_urls": [
+                                "https://example.com/faq"
+                              ],
+                              "ai_actions": [
+                                {
+                                  "action_uid": "action_book",
+                                  "action_key": "schedule",
+                                  "should_offer": true,
+                                  "when_to_offer": "Offer when client asks about scheduling or availability."
+                                },
+                                {
+                                  "action_uid": "action_call",
+                                  "action_key": "contact",
+                                  "should_offer": false,
+                                  "when_to_offer": null
+                                }
+                              ]
+                            }
+                          }
                         }
                       }
                     }
@@ -607,12 +1053,243 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/online_presence/AiReceptionistConfiguration.json"
+                          "type": "object",
+                          "description": "AI Receptionist Configuration for a business: controls how the AI receptionist behaves across all channels (web widget, WhatsApp, etc.). Includes FAQ/guidance, lead capture settings, business hours, knowledge inclusion flags, and proactive action offers. Returned inside `data` (wrapped by standard Response) for authenticated CRUD/main APIs.",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "readOnly": true,
+                              "description": "Configuration row UID."
+                            },
+                            "business_uid": {
+                              "type": "string",
+                              "readOnly": true,
+                              "description": "Owning business UID."
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "readOnly": true,
+                              "description": "Row creation time (ISO 8601)."
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "readOnly": true,
+                              "description": "Last update time (ISO 8601)."
+                            },
+                            "owner_uid": {
+                              "type": "string",
+                              "nullable": true,
+                              "readOnly": true,
+                              "description": "Staff UID of the last editor."
+                            },
+                            "config": {
+                              "type": "object",
+                              "description": "The AI chat configuration blob. Sparse — omitted keys use product defaults.",
+                              "properties": {
+                                "faq_and_guidance": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "description": "Free-text FAQ and guidance instructions for the AI receptionist."
+                                },
+                                "business_hours": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "description": "Business hours text; null uses calendar-derived defaults."
+                                },
+                                "lead_basic_contact_fields": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "enum": [
+                                    "phone_or_email",
+                                    "phone",
+                                    "email",
+                                    "both"
+                                  ],
+                                  "description": "Contact info the AI receptionist must try to collect before creating a lead. Guidance only; the CRM still creates a lead whenever a name and at least one of phone/email are present. Null uses the default (e.g., \"phone_or_email\")."
+                                },
+                                "lead_fields": {
+                                  "type": "array",
+                                  "nullable": true,
+                                  "description": "Additional lead fields the AI receptionist should try to collect (optional, never blocking).",
+                                  "maxItems": 10,
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "label": {
+                                        "type": "string",
+                                        "nullable": true,
+                                        "maxLength": 100,
+                                        "description": "Field label (e.g., \"Address\", \"Preferred time\")."
+                                      },
+                                      "instructions": {
+                                        "type": "string",
+                                        "nullable": true,
+                                        "maxLength": 200,
+                                        "description": "When/why to ask for this field (e.g., \"Only ask if the customer is requesting a home visit.\")."
+                                      }
+                                    }
+                                  }
+                                },
+                                "include_contact_info": {
+                                  "type": "boolean",
+                                  "nullable": true,
+                                  "description": "Whether to include business contact info in AI guidance context."
+                                },
+                                "include_services": {
+                                  "type": "boolean",
+                                  "nullable": true,
+                                  "description": "Whether to include business services in AI guidance context."
+                                },
+                                "include_products": {
+                                  "type": "boolean",
+                                  "nullable": true,
+                                  "description": "Whether to include business products in AI guidance context."
+                                },
+                                "include_booking_policies": {
+                                  "type": "boolean",
+                                  "nullable": true,
+                                  "description": "Whether to include booking policies in AI guidance context."
+                                },
+                                "include_terms_of_service": {
+                                  "type": "boolean",
+                                  "nullable": true,
+                                  "description": "Whether to include terms of service in AI guidance context."
+                                },
+                                "guidance_urls": {
+                                  "type": "array",
+                                  "nullable": true,
+                                  "items": {
+                                    "type": "string",
+                                    "format": "uri"
+                                  },
+                                  "description": "Extra URLs whose content is merged into AI guidance."
+                                },
+                                "ai_actions": {
+                                  "type": "array",
+                                  "nullable": true,
+                                  "description": "AI proactive action behavior. Defines which actions the AI should proactively offer and when.",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "action_uid": {
+                                        "type": "string",
+                                        "description": "Portal action UID."
+                                      },
+                                      "action_key": {
+                                        "type": "string",
+                                        "description": "Action key/type (e.g., \"schedule\", \"contact\")."
+                                      },
+                                      "should_offer": {
+                                        "type": "boolean",
+                                        "description": "Whether the AI should proactively suggest this action."
+                                      },
+                                      "when_to_offer": {
+                                        "type": "string",
+                                        "nullable": true,
+                                        "maxLength": 200,
+                                        "description": "Guidance text for when the AI should suggest this action (e.g., \"Offer when client asks about scheduling\")."
+                                      }
+                                    },
+                                    "required": [
+                                      "action_uid",
+                                      "action_key",
+                                      "should_offer"
+                                    ]
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "example": {
+                            "uid": "aicfg_7c2d4e91",
+                            "business_uid": "biz_2f8f7ab1",
+                            "created_at": "2026-05-28T10:30:00.000Z",
+                            "updated_at": "2026-05-28T11:12:45.000Z",
+                            "owner_uid": "staff_1182abc",
+                            "config": {
+                              "faq_and_guidance": "Answer questions about pricing, emergency calls, and availability.",
+                              "business_hours": "Mon-Fri 08:00-18:00, Sat 09:00-14:00",
+                              "lead_basic_contact_fields": "phone_or_email",
+                              "lead_fields": [
+                                {
+                                  "label": "Address",
+                                  "instructions": "Only ask if the customer is requesting a home visit."
+                                }
+                              ],
+                              "include_contact_info": true,
+                              "include_services": true,
+                              "include_products": false,
+                              "include_booking_policies": true,
+                              "include_terms_of_service": false,
+                              "guidance_urls": [
+                                "https://example.com/faq"
+                              ],
+                              "ai_actions": [
+                                {
+                                  "action_uid": "action_book",
+                                  "action_key": "schedule",
+                                  "should_offer": true,
+                                  "when_to_offer": "Offer when client asks about scheduling or availability."
+                                },
+                                {
+                                  "action_uid": "action_call",
+                                  "action_key": "contact",
+                                  "should_offer": false,
+                                  "when_to_offer": null
+                                }
+                              ]
+                            }
+                          }
                         }
                       }
                     }
@@ -742,7 +1419,50 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
@@ -856,12 +1576,464 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/online_presence/AiReceptionistConversation.json"
+                          "type": "object",
+                          "description": "Persisted website AI Receptionist conversation resource. Returned inside `{ data }` for Staff-scoped list/get/create/update APIs (`/v3/online_presence/ai_receptionist_conversations`). Date-time fields use ISO 8601 format. Soft-deleted conversations are not returned in normal API responses.",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "readOnly": true,
+                              "description": "Public conversation UID (UUID)."
+                            },
+                            "business_uid": {
+                              "type": "string",
+                              "description": "Business that owns the conversation."
+                            },
+                            "session_id": {
+                              "type": "string",
+                              "description": "Chat session id from the online_presence chat service."
+                            },
+                            "transcript": {
+                              "description": "Conversation transcript. New records use a structured transcript object (`schemaVersion` + `messages`). Older records may still contain legacy plain text; new integrations should use the structured format.",
+                              "nullable": true,
+                              "oneOf": [
+                                {
+                                  "type": "object",
+                                  "description": "Structured transcript object captured when a session ends. Uses the same visitor-visible message list shape that is returned when resuming an active chat session. Consumers should render from `messages` and may derive plain text if needed.",
+                                  "properties": {
+                                    "schemaVersion": {
+                                      "type": "integer",
+                                      "enum": [
+                                        1
+                                      ],
+                                      "description": "Document format version."
+                                    },
+                                    "messages": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "description": "Visitor-visible chat line (**user** or **assistant**). Used in chat resume responses and stored inside the transcript document for persisted conversations. System prompts and internal tool rows are not included.",
+                                        "properties": {
+                                          "role": {
+                                            "type": "string",
+                                            "enum": [
+                                              "user",
+                                              "assistant"
+                                            ],
+                                            "description": "Who sent the message."
+                                          },
+                                          "content": {
+                                            "type": "string",
+                                            "description": "Message text (may include markdown)."
+                                          },
+                                          "message_type": {
+                                            "type": "string",
+                                            "nullable": true,
+                                            "enum": [
+                                              "tool_status"
+                                            ],
+                                            "description": "Optional semantic marker for assistant status lines emitted while backend tools run (e.g., \"Storing your information...\"). UI can use this to avoid treating the row as a normal assistant reply."
+                                          },
+                                          "at": {
+                                            "type": "string",
+                                            "format": "date-time",
+                                            "description": "Optional ISO 8601 UTC timestamp when the server recorded the turn. May be omitted on older Redis session blobs; clients may use it for ordering or display outside the embeddable widget."
+                                          }
+                                        },
+                                        "required": [
+                                          "role",
+                                          "content"
+                                        ],
+                                        "example": {
+                                          "role": "assistant",
+                                          "content": "Hi! How can I help you today?",
+                                          "at": "2026-04-19T12:34:56.789Z"
+                                        }
+                                      },
+                                      "description": "Ordered visitor-visible turns."
+                                    },
+                                    "ai_receptionist_training_feedback_history": {
+                                      "type": "array",
+                                      "description": "Append-only AI receptionist training feedback history captured from chat history UI. Each entry stores who submitted the feedback, when it was submitted, scope (`conversation` or `message`), and optional message reference metadata for message-level feedback.",
+                                      "items": {
+                                        "type": "object",
+                                        "properties": {
+                                          "created_at": {
+                                            "type": "string",
+                                            "format": "date-time",
+                                            "description": "ISO 8601 UTC timestamp when the feedback entry was created."
+                                          },
+                                          "created_by_staff_uid": {
+                                            "type": "string",
+                                            "nullable": true,
+                                            "description": "Staff UID that submitted the feedback."
+                                          },
+                                          "feedback_scope": {
+                                            "type": "string",
+                                            "enum": [
+                                              "conversation",
+                                              "message"
+                                            ],
+                                            "description": "Feedback scope: entire conversation (`conversation`) or specific assistant message (`message`)."
+                                          },
+                                          "feedback_text": {
+                                            "type": "string",
+                                            "description": "Raw user feedback text."
+                                          },
+                                          "message_reference": {
+                                            "type": "object",
+                                            "nullable": true,
+                                            "description": "Optional message reference details for `message` scope feedback.",
+                                            "properties": {
+                                              "index": {
+                                                "type": "integer",
+                                                "minimum": 0,
+                                                "description": "Message index in transcript `messages` array."
+                                              },
+                                              "snippet": {
+                                                "type": "string",
+                                                "description": "Short first-words snippet of the referenced message."
+                                              },
+                                              "message_id": {
+                                                "type": "string",
+                                                "nullable": true,
+                                                "description": "Optional UI-level transcript message id."
+                                              },
+                                              "role": {
+                                                "type": "string",
+                                                "nullable": true,
+                                                "enum": [
+                                                  "assistant",
+                                                  "visitor"
+                                                ],
+                                                "description": "Optional role hint from the UI message id."
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "required": [
+                                          "created_at",
+                                          "feedback_scope",
+                                          "feedback_text"
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  "required": [
+                                    "schemaVersion",
+                                    "messages"
+                                  ],
+                                  "example": {
+                                    "schemaVersion": 1,
+                                    "messages": [
+                                      {
+                                        "role": "assistant",
+                                        "content": "Hi! How can I help?",
+                                        "at": "2026-04-19T12:34:56.789Z"
+                                      },
+                                      {
+                                        "role": "user",
+                                        "content": "I need to book an appointment.",
+                                        "at": "2026-04-19T12:35:01.000Z"
+                                      }
+                                    ],
+                                    "ai_receptionist_training_feedback_history": [
+                                      {
+                                        "created_at": "2026-05-10T13:20:11.000Z",
+                                        "created_by_staff_uid": "evcq5xg3epuw2c1a",
+                                        "feedback_scope": "message",
+                                        "feedback_text": "Avoid asking for phone again once it was already provided.",
+                                        "message_reference": {
+                                          "index": 6,
+                                          "snippet": "Thank you, Itzik. Could you please provide your phone number...",
+                                          "message_id": "transcript-object-6-assistant",
+                                          "role": "assistant"
+                                        }
+                                      }
+                                    ]
+                                  }
+                                },
+                                {
+                                  "type": "string",
+                                  "description": "Legacy plain-text transcript (older data only)."
+                                }
+                              ]
+                            },
+                            "summary": {
+                              "type": "string",
+                              "nullable": true,
+                              "description": "Optional summary of the conversation."
+                            },
+                            "contact_full_name": {
+                              "type": "string",
+                              "nullable": true,
+                              "description": "Visitor name if captured."
+                            },
+                            "contact_email": {
+                              "type": "string",
+                              "nullable": true,
+                              "description": "Visitor email if captured."
+                            },
+                            "contact_phone": {
+                              "type": "string",
+                              "nullable": true,
+                              "description": "Visitor phone if captured."
+                            },
+                            "page_url": {
+                              "type": "string",
+                              "nullable": true,
+                              "description": "Page URL where the chat started."
+                            },
+                            "started_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "description": "Conversation start time."
+                            },
+                            "ended_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "description": "Conversation end time."
+                            },
+                            "matter_uid": {
+                              "type": "string",
+                              "nullable": true,
+                              "description": "Optional matter/case linkage."
+                            },
+                            "client_uid": {
+                              "type": "string",
+                              "nullable": true,
+                              "description": "Optional CRM client UID linked to this conversation."
+                            },
+                            "message_count": {
+                              "type": "integer",
+                              "nullable": true,
+                              "minimum": 0,
+                              "description": "Number of messages in the conversation."
+                            },
+                            "lead_intent": {
+                              "type": "string",
+                              "nullable": true,
+                              "description": "Resolved lead intent extracted at conversation close (e.g., \"General inquiry\"). When no lead data is captured, value may be \"N/A\"."
+                            },
+                            "lead_information": {
+                              "type": "object",
+                              "nullable": true,
+                              "description": "Extracted lead key/value pairs captured from the conversation (JSON object, e.g. {\"Name\":\"John Doe\",\"Phone\":\"+15551234567\"}).",
+                              "additionalProperties": {
+                                "type": "string"
+                              }
+                            },
+                            "source_app_uid": {
+                              "type": "string",
+                              "nullable": true,
+                              "description": "Application that delivered the inbound traffic for this conversation. Web widget sessions use null; voice AI Receptionist sessions use \"voicecalls\"."
+                            },
+                            "channel_uid": {
+                              "type": "string",
+                              "nullable": true,
+                              "description": "Channel identifier used for attribution in AI Receptionist reporting, such as \"voicecalls:setting_123\" for a voicecalls phone-number setting."
+                            },
+                            "delivery_kind": {
+                              "type": "string",
+                              "nullable": true,
+                              "enum": [
+                                "webaiwidgetmgr",
+                                "comm_gw",
+                                "voicecalls"
+                              ],
+                              "description": "Lifecycle owner for the conversation. **webaiwidgetmgr** means the website widget owned the session lifecycle, **comm_gw** means Communication Gateway owned lifecycle and release handling, and **voicecalls** means the voicecalls service owned PSTN lifecycle handling."
+                            },
+                            "voice_call_uid": {
+                              "type": "string",
+                              "nullable": true,
+                              "description": "Internal voicecalls call UID used to correlate AI Receptionist voice metadata and recording callbacks."
+                            },
+                            "external_uuid": {
+                              "type": "string",
+                              "nullable": true,
+                              "description": "External provider conversation UUID, usually the Vonage conversation UUID used by voicecalls webhooks."
+                            },
+                            "voice_metadata": {
+                              "type": "object",
+                              "nullable": true,
+                              "description": "Voice-specific metadata for AI Receptionist calls, including caller/callee numbers and recording details when available.",
+                              "properties": {
+                                "voice_call_uid": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "description": "Internal voicecalls call UID."
+                                },
+                                "external_uuid": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "description": "External provider conversation UUID."
+                                },
+                                "from_number": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "description": "Caller phone number in E.164 format."
+                                },
+                                "to_number": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "description": "Dialed voicecalls phone number in E.164 format."
+                                },
+                                "recording_url": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "description": "Signed call recording URL generated by voicecalls."
+                                },
+                                "file_size": {
+                                  "type": "integer",
+                                  "nullable": true,
+                                  "minimum": 0,
+                                  "description": "Recording file size in bytes."
+                                },
+                                "recording_duration": {
+                                  "type": "integer",
+                                  "nullable": true,
+                                  "minimum": 0,
+                                  "description": "Recording duration in seconds."
+                                },
+                                "recording_received_at": {
+                                  "type": "string",
+                                  "format": "date-time",
+                                  "nullable": true,
+                                  "description": "Time when webaiwidgetserver received the recording callback."
+                                }
+                              }
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "readOnly": true,
+                              "description": "Row creation time."
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "readOnly": true,
+                              "description": "Row last update time."
+                            }
+                          },
+                          "required": [
+                            "uid",
+                            "business_uid",
+                            "session_id",
+                            "started_at",
+                            "ended_at",
+                            "created_at",
+                            "updated_at"
+                          ],
+                          "example": {
+                            "uid": "8d31f5fe-9c6d-4a6a-b0a2-9d10a9f1c01a",
+                            "business_uid": "biz_2f8f7ab1",
+                            "session_id": "4f609f56-cb57-43c5-956c-252f20d67cb0",
+                            "transcript": {
+                              "schemaVersion": 1,
+                              "messages": [
+                                {
+                                  "role": "user",
+                                  "content": "Hi, I need a quote for plumbing work.",
+                                  "at": "2026-04-04T12:43:25.000Z"
+                                },
+                                {
+                                  "role": "assistant",
+                                  "content": "Sure. Could you share your name and phone number?",
+                                  "at": "2026-04-04T12:43:28.000Z"
+                                }
+                              ],
+                              "ai_receptionist_training_feedback_history": [
+                                {
+                                  "created_at": "2026-05-10T13:20:11.000Z",
+                                  "created_by_staff_uid": "evcq5xg3epuw2c1a",
+                                  "feedback_scope": "conversation",
+                                  "feedback_text": "Please use a friendlier tone in follow-up messages.",
+                                  "message_reference": null
+                                }
+                              ]
+                            },
+                            "summary": "Visitor asked for plumbing quote and shared contact details.",
+                            "contact_full_name": "John Doe",
+                            "contact_email": null,
+                            "contact_phone": "+15551234567",
+                            "page_url": "https://example.com/services/plumbing",
+                            "started_at": "2026-04-04T12:43:21.000Z",
+                            "ended_at": "2026-04-04T12:49:58.000Z",
+                            "matter_uid": "mtr_991ac2",
+                            "client_uid": "cli_1872baf9",
+                            "message_count": 18,
+                            "lead_intent": "General inquiry",
+                            "lead_information": {
+                              "Name": "John Doe",
+                              "Phone": "+15551234567",
+                              "Reason for inquiry": "Quote for plumbing work"
+                            },
+                            "source_app_uid": "voicecalls",
+                            "channel_uid": "voicecalls:setting_123",
+                            "delivery_kind": "voicecalls",
+                            "voice_call_uid": "vc_7f31d9a4",
+                            "external_uuid": "CON-123",
+                            "voice_metadata": {
+                              "voice_call_uid": "vc_7f31d9a4",
+                              "external_uuid": "CON-123",
+                              "from_number": "+15551234567",
+                              "to_number": "+12125551234",
+                              "recording_url": "https://recordings.example.com/calls/CON-123.wav",
+                              "file_size": 1048576,
+                              "recording_duration": 95,
+                              "recording_received_at": "2026-04-04T12:51:10.000Z"
+                            },
+                            "created_at": "2026-04-04T12:50:00.000Z",
+                            "updated_at": "2026-04-04T12:50:00.000Z"
+                          }
                         }
                       }
                     }
@@ -978,12 +2150,464 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/online_presence/AiReceptionistConversation.json"
+                          "type": "object",
+                          "description": "Persisted website AI Receptionist conversation resource. Returned inside `{ data }` for Staff-scoped list/get/create/update APIs (`/v3/online_presence/ai_receptionist_conversations`). Date-time fields use ISO 8601 format. Soft-deleted conversations are not returned in normal API responses.",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "readOnly": true,
+                              "description": "Public conversation UID (UUID)."
+                            },
+                            "business_uid": {
+                              "type": "string",
+                              "description": "Business that owns the conversation."
+                            },
+                            "session_id": {
+                              "type": "string",
+                              "description": "Chat session id from the online_presence chat service."
+                            },
+                            "transcript": {
+                              "description": "Conversation transcript. New records use a structured transcript object (`schemaVersion` + `messages`). Older records may still contain legacy plain text; new integrations should use the structured format.",
+                              "nullable": true,
+                              "oneOf": [
+                                {
+                                  "type": "object",
+                                  "description": "Structured transcript object captured when a session ends. Uses the same visitor-visible message list shape that is returned when resuming an active chat session. Consumers should render from `messages` and may derive plain text if needed.",
+                                  "properties": {
+                                    "schemaVersion": {
+                                      "type": "integer",
+                                      "enum": [
+                                        1
+                                      ],
+                                      "description": "Document format version."
+                                    },
+                                    "messages": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "description": "Visitor-visible chat line (**user** or **assistant**). Used in chat resume responses and stored inside the transcript document for persisted conversations. System prompts and internal tool rows are not included.",
+                                        "properties": {
+                                          "role": {
+                                            "type": "string",
+                                            "enum": [
+                                              "user",
+                                              "assistant"
+                                            ],
+                                            "description": "Who sent the message."
+                                          },
+                                          "content": {
+                                            "type": "string",
+                                            "description": "Message text (may include markdown)."
+                                          },
+                                          "message_type": {
+                                            "type": "string",
+                                            "nullable": true,
+                                            "enum": [
+                                              "tool_status"
+                                            ],
+                                            "description": "Optional semantic marker for assistant status lines emitted while backend tools run (e.g., \"Storing your information...\"). UI can use this to avoid treating the row as a normal assistant reply."
+                                          },
+                                          "at": {
+                                            "type": "string",
+                                            "format": "date-time",
+                                            "description": "Optional ISO 8601 UTC timestamp when the server recorded the turn. May be omitted on older Redis session blobs; clients may use it for ordering or display outside the embeddable widget."
+                                          }
+                                        },
+                                        "required": [
+                                          "role",
+                                          "content"
+                                        ],
+                                        "example": {
+                                          "role": "assistant",
+                                          "content": "Hi! How can I help you today?",
+                                          "at": "2026-04-19T12:34:56.789Z"
+                                        }
+                                      },
+                                      "description": "Ordered visitor-visible turns."
+                                    },
+                                    "ai_receptionist_training_feedback_history": {
+                                      "type": "array",
+                                      "description": "Append-only AI receptionist training feedback history captured from chat history UI. Each entry stores who submitted the feedback, when it was submitted, scope (`conversation` or `message`), and optional message reference metadata for message-level feedback.",
+                                      "items": {
+                                        "type": "object",
+                                        "properties": {
+                                          "created_at": {
+                                            "type": "string",
+                                            "format": "date-time",
+                                            "description": "ISO 8601 UTC timestamp when the feedback entry was created."
+                                          },
+                                          "created_by_staff_uid": {
+                                            "type": "string",
+                                            "nullable": true,
+                                            "description": "Staff UID that submitted the feedback."
+                                          },
+                                          "feedback_scope": {
+                                            "type": "string",
+                                            "enum": [
+                                              "conversation",
+                                              "message"
+                                            ],
+                                            "description": "Feedback scope: entire conversation (`conversation`) or specific assistant message (`message`)."
+                                          },
+                                          "feedback_text": {
+                                            "type": "string",
+                                            "description": "Raw user feedback text."
+                                          },
+                                          "message_reference": {
+                                            "type": "object",
+                                            "nullable": true,
+                                            "description": "Optional message reference details for `message` scope feedback.",
+                                            "properties": {
+                                              "index": {
+                                                "type": "integer",
+                                                "minimum": 0,
+                                                "description": "Message index in transcript `messages` array."
+                                              },
+                                              "snippet": {
+                                                "type": "string",
+                                                "description": "Short first-words snippet of the referenced message."
+                                              },
+                                              "message_id": {
+                                                "type": "string",
+                                                "nullable": true,
+                                                "description": "Optional UI-level transcript message id."
+                                              },
+                                              "role": {
+                                                "type": "string",
+                                                "nullable": true,
+                                                "enum": [
+                                                  "assistant",
+                                                  "visitor"
+                                                ],
+                                                "description": "Optional role hint from the UI message id."
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "required": [
+                                          "created_at",
+                                          "feedback_scope",
+                                          "feedback_text"
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  "required": [
+                                    "schemaVersion",
+                                    "messages"
+                                  ],
+                                  "example": {
+                                    "schemaVersion": 1,
+                                    "messages": [
+                                      {
+                                        "role": "assistant",
+                                        "content": "Hi! How can I help?",
+                                        "at": "2026-04-19T12:34:56.789Z"
+                                      },
+                                      {
+                                        "role": "user",
+                                        "content": "I need to book an appointment.",
+                                        "at": "2026-04-19T12:35:01.000Z"
+                                      }
+                                    ],
+                                    "ai_receptionist_training_feedback_history": [
+                                      {
+                                        "created_at": "2026-05-10T13:20:11.000Z",
+                                        "created_by_staff_uid": "evcq5xg3epuw2c1a",
+                                        "feedback_scope": "message",
+                                        "feedback_text": "Avoid asking for phone again once it was already provided.",
+                                        "message_reference": {
+                                          "index": 6,
+                                          "snippet": "Thank you, Itzik. Could you please provide your phone number...",
+                                          "message_id": "transcript-object-6-assistant",
+                                          "role": "assistant"
+                                        }
+                                      }
+                                    ]
+                                  }
+                                },
+                                {
+                                  "type": "string",
+                                  "description": "Legacy plain-text transcript (older data only)."
+                                }
+                              ]
+                            },
+                            "summary": {
+                              "type": "string",
+                              "nullable": true,
+                              "description": "Optional summary of the conversation."
+                            },
+                            "contact_full_name": {
+                              "type": "string",
+                              "nullable": true,
+                              "description": "Visitor name if captured."
+                            },
+                            "contact_email": {
+                              "type": "string",
+                              "nullable": true,
+                              "description": "Visitor email if captured."
+                            },
+                            "contact_phone": {
+                              "type": "string",
+                              "nullable": true,
+                              "description": "Visitor phone if captured."
+                            },
+                            "page_url": {
+                              "type": "string",
+                              "nullable": true,
+                              "description": "Page URL where the chat started."
+                            },
+                            "started_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "description": "Conversation start time."
+                            },
+                            "ended_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "description": "Conversation end time."
+                            },
+                            "matter_uid": {
+                              "type": "string",
+                              "nullable": true,
+                              "description": "Optional matter/case linkage."
+                            },
+                            "client_uid": {
+                              "type": "string",
+                              "nullable": true,
+                              "description": "Optional CRM client UID linked to this conversation."
+                            },
+                            "message_count": {
+                              "type": "integer",
+                              "nullable": true,
+                              "minimum": 0,
+                              "description": "Number of messages in the conversation."
+                            },
+                            "lead_intent": {
+                              "type": "string",
+                              "nullable": true,
+                              "description": "Resolved lead intent extracted at conversation close (e.g., \"General inquiry\"). When no lead data is captured, value may be \"N/A\"."
+                            },
+                            "lead_information": {
+                              "type": "object",
+                              "nullable": true,
+                              "description": "Extracted lead key/value pairs captured from the conversation (JSON object, e.g. {\"Name\":\"John Doe\",\"Phone\":\"+15551234567\"}).",
+                              "additionalProperties": {
+                                "type": "string"
+                              }
+                            },
+                            "source_app_uid": {
+                              "type": "string",
+                              "nullable": true,
+                              "description": "Application that delivered the inbound traffic for this conversation. Web widget sessions use null; voice AI Receptionist sessions use \"voicecalls\"."
+                            },
+                            "channel_uid": {
+                              "type": "string",
+                              "nullable": true,
+                              "description": "Channel identifier used for attribution in AI Receptionist reporting, such as \"voicecalls:setting_123\" for a voicecalls phone-number setting."
+                            },
+                            "delivery_kind": {
+                              "type": "string",
+                              "nullable": true,
+                              "enum": [
+                                "webaiwidgetmgr",
+                                "comm_gw",
+                                "voicecalls"
+                              ],
+                              "description": "Lifecycle owner for the conversation. **webaiwidgetmgr** means the website widget owned the session lifecycle, **comm_gw** means Communication Gateway owned lifecycle and release handling, and **voicecalls** means the voicecalls service owned PSTN lifecycle handling."
+                            },
+                            "voice_call_uid": {
+                              "type": "string",
+                              "nullable": true,
+                              "description": "Internal voicecalls call UID used to correlate AI Receptionist voice metadata and recording callbacks."
+                            },
+                            "external_uuid": {
+                              "type": "string",
+                              "nullable": true,
+                              "description": "External provider conversation UUID, usually the Vonage conversation UUID used by voicecalls webhooks."
+                            },
+                            "voice_metadata": {
+                              "type": "object",
+                              "nullable": true,
+                              "description": "Voice-specific metadata for AI Receptionist calls, including caller/callee numbers and recording details when available.",
+                              "properties": {
+                                "voice_call_uid": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "description": "Internal voicecalls call UID."
+                                },
+                                "external_uuid": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "description": "External provider conversation UUID."
+                                },
+                                "from_number": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "description": "Caller phone number in E.164 format."
+                                },
+                                "to_number": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "description": "Dialed voicecalls phone number in E.164 format."
+                                },
+                                "recording_url": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "description": "Signed call recording URL generated by voicecalls."
+                                },
+                                "file_size": {
+                                  "type": "integer",
+                                  "nullable": true,
+                                  "minimum": 0,
+                                  "description": "Recording file size in bytes."
+                                },
+                                "recording_duration": {
+                                  "type": "integer",
+                                  "nullable": true,
+                                  "minimum": 0,
+                                  "description": "Recording duration in seconds."
+                                },
+                                "recording_received_at": {
+                                  "type": "string",
+                                  "format": "date-time",
+                                  "nullable": true,
+                                  "description": "Time when webaiwidgetserver received the recording callback."
+                                }
+                              }
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "readOnly": true,
+                              "description": "Row creation time."
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "readOnly": true,
+                              "description": "Row last update time."
+                            }
+                          },
+                          "required": [
+                            "uid",
+                            "business_uid",
+                            "session_id",
+                            "started_at",
+                            "ended_at",
+                            "created_at",
+                            "updated_at"
+                          ],
+                          "example": {
+                            "uid": "8d31f5fe-9c6d-4a6a-b0a2-9d10a9f1c01a",
+                            "business_uid": "biz_2f8f7ab1",
+                            "session_id": "4f609f56-cb57-43c5-956c-252f20d67cb0",
+                            "transcript": {
+                              "schemaVersion": 1,
+                              "messages": [
+                                {
+                                  "role": "user",
+                                  "content": "Hi, I need a quote for plumbing work.",
+                                  "at": "2026-04-04T12:43:25.000Z"
+                                },
+                                {
+                                  "role": "assistant",
+                                  "content": "Sure. Could you share your name and phone number?",
+                                  "at": "2026-04-04T12:43:28.000Z"
+                                }
+                              ],
+                              "ai_receptionist_training_feedback_history": [
+                                {
+                                  "created_at": "2026-05-10T13:20:11.000Z",
+                                  "created_by_staff_uid": "evcq5xg3epuw2c1a",
+                                  "feedback_scope": "conversation",
+                                  "feedback_text": "Please use a friendlier tone in follow-up messages.",
+                                  "message_reference": null
+                                }
+                              ]
+                            },
+                            "summary": "Visitor asked for plumbing quote and shared contact details.",
+                            "contact_full_name": "John Doe",
+                            "contact_email": null,
+                            "contact_phone": "+15551234567",
+                            "page_url": "https://example.com/services/plumbing",
+                            "started_at": "2026-04-04T12:43:21.000Z",
+                            "ended_at": "2026-04-04T12:49:58.000Z",
+                            "matter_uid": "mtr_991ac2",
+                            "client_uid": "cli_1872baf9",
+                            "message_count": 18,
+                            "lead_intent": "General inquiry",
+                            "lead_information": {
+                              "Name": "John Doe",
+                              "Phone": "+15551234567",
+                              "Reason for inquiry": "Quote for plumbing work"
+                            },
+                            "source_app_uid": "voicecalls",
+                            "channel_uid": "voicecalls:setting_123",
+                            "delivery_kind": "voicecalls",
+                            "voice_call_uid": "vc_7f31d9a4",
+                            "external_uuid": "CON-123",
+                            "voice_metadata": {
+                              "voice_call_uid": "vc_7f31d9a4",
+                              "external_uuid": "CON-123",
+                              "from_number": "+15551234567",
+                              "to_number": "+12125551234",
+                              "recording_url": "https://recordings.example.com/calls/CON-123.wav",
+                              "file_size": 1048576,
+                              "recording_duration": 95,
+                              "recording_received_at": "2026-04-04T12:51:10.000Z"
+                            },
+                            "created_at": "2026-04-04T12:50:00.000Z",
+                            "updated_at": "2026-04-04T12:50:00.000Z"
+                          }
                         }
                       }
                     }
@@ -1091,12 +2715,464 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/online_presence/AiReceptionistConversation.json"
+                          "type": "object",
+                          "description": "Persisted website AI Receptionist conversation resource. Returned inside `{ data }` for Staff-scoped list/get/create/update APIs (`/v3/online_presence/ai_receptionist_conversations`). Date-time fields use ISO 8601 format. Soft-deleted conversations are not returned in normal API responses.",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "readOnly": true,
+                              "description": "Public conversation UID (UUID)."
+                            },
+                            "business_uid": {
+                              "type": "string",
+                              "description": "Business that owns the conversation."
+                            },
+                            "session_id": {
+                              "type": "string",
+                              "description": "Chat session id from the online_presence chat service."
+                            },
+                            "transcript": {
+                              "description": "Conversation transcript. New records use a structured transcript object (`schemaVersion` + `messages`). Older records may still contain legacy plain text; new integrations should use the structured format.",
+                              "nullable": true,
+                              "oneOf": [
+                                {
+                                  "type": "object",
+                                  "description": "Structured transcript object captured when a session ends. Uses the same visitor-visible message list shape that is returned when resuming an active chat session. Consumers should render from `messages` and may derive plain text if needed.",
+                                  "properties": {
+                                    "schemaVersion": {
+                                      "type": "integer",
+                                      "enum": [
+                                        1
+                                      ],
+                                      "description": "Document format version."
+                                    },
+                                    "messages": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "description": "Visitor-visible chat line (**user** or **assistant**). Used in chat resume responses and stored inside the transcript document for persisted conversations. System prompts and internal tool rows are not included.",
+                                        "properties": {
+                                          "role": {
+                                            "type": "string",
+                                            "enum": [
+                                              "user",
+                                              "assistant"
+                                            ],
+                                            "description": "Who sent the message."
+                                          },
+                                          "content": {
+                                            "type": "string",
+                                            "description": "Message text (may include markdown)."
+                                          },
+                                          "message_type": {
+                                            "type": "string",
+                                            "nullable": true,
+                                            "enum": [
+                                              "tool_status"
+                                            ],
+                                            "description": "Optional semantic marker for assistant status lines emitted while backend tools run (e.g., \"Storing your information...\"). UI can use this to avoid treating the row as a normal assistant reply."
+                                          },
+                                          "at": {
+                                            "type": "string",
+                                            "format": "date-time",
+                                            "description": "Optional ISO 8601 UTC timestamp when the server recorded the turn. May be omitted on older Redis session blobs; clients may use it for ordering or display outside the embeddable widget."
+                                          }
+                                        },
+                                        "required": [
+                                          "role",
+                                          "content"
+                                        ],
+                                        "example": {
+                                          "role": "assistant",
+                                          "content": "Hi! How can I help you today?",
+                                          "at": "2026-04-19T12:34:56.789Z"
+                                        }
+                                      },
+                                      "description": "Ordered visitor-visible turns."
+                                    },
+                                    "ai_receptionist_training_feedback_history": {
+                                      "type": "array",
+                                      "description": "Append-only AI receptionist training feedback history captured from chat history UI. Each entry stores who submitted the feedback, when it was submitted, scope (`conversation` or `message`), and optional message reference metadata for message-level feedback.",
+                                      "items": {
+                                        "type": "object",
+                                        "properties": {
+                                          "created_at": {
+                                            "type": "string",
+                                            "format": "date-time",
+                                            "description": "ISO 8601 UTC timestamp when the feedback entry was created."
+                                          },
+                                          "created_by_staff_uid": {
+                                            "type": "string",
+                                            "nullable": true,
+                                            "description": "Staff UID that submitted the feedback."
+                                          },
+                                          "feedback_scope": {
+                                            "type": "string",
+                                            "enum": [
+                                              "conversation",
+                                              "message"
+                                            ],
+                                            "description": "Feedback scope: entire conversation (`conversation`) or specific assistant message (`message`)."
+                                          },
+                                          "feedback_text": {
+                                            "type": "string",
+                                            "description": "Raw user feedback text."
+                                          },
+                                          "message_reference": {
+                                            "type": "object",
+                                            "nullable": true,
+                                            "description": "Optional message reference details for `message` scope feedback.",
+                                            "properties": {
+                                              "index": {
+                                                "type": "integer",
+                                                "minimum": 0,
+                                                "description": "Message index in transcript `messages` array."
+                                              },
+                                              "snippet": {
+                                                "type": "string",
+                                                "description": "Short first-words snippet of the referenced message."
+                                              },
+                                              "message_id": {
+                                                "type": "string",
+                                                "nullable": true,
+                                                "description": "Optional UI-level transcript message id."
+                                              },
+                                              "role": {
+                                                "type": "string",
+                                                "nullable": true,
+                                                "enum": [
+                                                  "assistant",
+                                                  "visitor"
+                                                ],
+                                                "description": "Optional role hint from the UI message id."
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "required": [
+                                          "created_at",
+                                          "feedback_scope",
+                                          "feedback_text"
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  "required": [
+                                    "schemaVersion",
+                                    "messages"
+                                  ],
+                                  "example": {
+                                    "schemaVersion": 1,
+                                    "messages": [
+                                      {
+                                        "role": "assistant",
+                                        "content": "Hi! How can I help?",
+                                        "at": "2026-04-19T12:34:56.789Z"
+                                      },
+                                      {
+                                        "role": "user",
+                                        "content": "I need to book an appointment.",
+                                        "at": "2026-04-19T12:35:01.000Z"
+                                      }
+                                    ],
+                                    "ai_receptionist_training_feedback_history": [
+                                      {
+                                        "created_at": "2026-05-10T13:20:11.000Z",
+                                        "created_by_staff_uid": "evcq5xg3epuw2c1a",
+                                        "feedback_scope": "message",
+                                        "feedback_text": "Avoid asking for phone again once it was already provided.",
+                                        "message_reference": {
+                                          "index": 6,
+                                          "snippet": "Thank you, Itzik. Could you please provide your phone number...",
+                                          "message_id": "transcript-object-6-assistant",
+                                          "role": "assistant"
+                                        }
+                                      }
+                                    ]
+                                  }
+                                },
+                                {
+                                  "type": "string",
+                                  "description": "Legacy plain-text transcript (older data only)."
+                                }
+                              ]
+                            },
+                            "summary": {
+                              "type": "string",
+                              "nullable": true,
+                              "description": "Optional summary of the conversation."
+                            },
+                            "contact_full_name": {
+                              "type": "string",
+                              "nullable": true,
+                              "description": "Visitor name if captured."
+                            },
+                            "contact_email": {
+                              "type": "string",
+                              "nullable": true,
+                              "description": "Visitor email if captured."
+                            },
+                            "contact_phone": {
+                              "type": "string",
+                              "nullable": true,
+                              "description": "Visitor phone if captured."
+                            },
+                            "page_url": {
+                              "type": "string",
+                              "nullable": true,
+                              "description": "Page URL where the chat started."
+                            },
+                            "started_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "description": "Conversation start time."
+                            },
+                            "ended_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "description": "Conversation end time."
+                            },
+                            "matter_uid": {
+                              "type": "string",
+                              "nullable": true,
+                              "description": "Optional matter/case linkage."
+                            },
+                            "client_uid": {
+                              "type": "string",
+                              "nullable": true,
+                              "description": "Optional CRM client UID linked to this conversation."
+                            },
+                            "message_count": {
+                              "type": "integer",
+                              "nullable": true,
+                              "minimum": 0,
+                              "description": "Number of messages in the conversation."
+                            },
+                            "lead_intent": {
+                              "type": "string",
+                              "nullable": true,
+                              "description": "Resolved lead intent extracted at conversation close (e.g., \"General inquiry\"). When no lead data is captured, value may be \"N/A\"."
+                            },
+                            "lead_information": {
+                              "type": "object",
+                              "nullable": true,
+                              "description": "Extracted lead key/value pairs captured from the conversation (JSON object, e.g. {\"Name\":\"John Doe\",\"Phone\":\"+15551234567\"}).",
+                              "additionalProperties": {
+                                "type": "string"
+                              }
+                            },
+                            "source_app_uid": {
+                              "type": "string",
+                              "nullable": true,
+                              "description": "Application that delivered the inbound traffic for this conversation. Web widget sessions use null; voice AI Receptionist sessions use \"voicecalls\"."
+                            },
+                            "channel_uid": {
+                              "type": "string",
+                              "nullable": true,
+                              "description": "Channel identifier used for attribution in AI Receptionist reporting, such as \"voicecalls:setting_123\" for a voicecalls phone-number setting."
+                            },
+                            "delivery_kind": {
+                              "type": "string",
+                              "nullable": true,
+                              "enum": [
+                                "webaiwidgetmgr",
+                                "comm_gw",
+                                "voicecalls"
+                              ],
+                              "description": "Lifecycle owner for the conversation. **webaiwidgetmgr** means the website widget owned the session lifecycle, **comm_gw** means Communication Gateway owned lifecycle and release handling, and **voicecalls** means the voicecalls service owned PSTN lifecycle handling."
+                            },
+                            "voice_call_uid": {
+                              "type": "string",
+                              "nullable": true,
+                              "description": "Internal voicecalls call UID used to correlate AI Receptionist voice metadata and recording callbacks."
+                            },
+                            "external_uuid": {
+                              "type": "string",
+                              "nullable": true,
+                              "description": "External provider conversation UUID, usually the Vonage conversation UUID used by voicecalls webhooks."
+                            },
+                            "voice_metadata": {
+                              "type": "object",
+                              "nullable": true,
+                              "description": "Voice-specific metadata for AI Receptionist calls, including caller/callee numbers and recording details when available.",
+                              "properties": {
+                                "voice_call_uid": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "description": "Internal voicecalls call UID."
+                                },
+                                "external_uuid": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "description": "External provider conversation UUID."
+                                },
+                                "from_number": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "description": "Caller phone number in E.164 format."
+                                },
+                                "to_number": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "description": "Dialed voicecalls phone number in E.164 format."
+                                },
+                                "recording_url": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "description": "Signed call recording URL generated by voicecalls."
+                                },
+                                "file_size": {
+                                  "type": "integer",
+                                  "nullable": true,
+                                  "minimum": 0,
+                                  "description": "Recording file size in bytes."
+                                },
+                                "recording_duration": {
+                                  "type": "integer",
+                                  "nullable": true,
+                                  "minimum": 0,
+                                  "description": "Recording duration in seconds."
+                                },
+                                "recording_received_at": {
+                                  "type": "string",
+                                  "format": "date-time",
+                                  "nullable": true,
+                                  "description": "Time when webaiwidgetserver received the recording callback."
+                                }
+                              }
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "readOnly": true,
+                              "description": "Row creation time."
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "readOnly": true,
+                              "description": "Row last update time."
+                            }
+                          },
+                          "required": [
+                            "uid",
+                            "business_uid",
+                            "session_id",
+                            "started_at",
+                            "ended_at",
+                            "created_at",
+                            "updated_at"
+                          ],
+                          "example": {
+                            "uid": "8d31f5fe-9c6d-4a6a-b0a2-9d10a9f1c01a",
+                            "business_uid": "biz_2f8f7ab1",
+                            "session_id": "4f609f56-cb57-43c5-956c-252f20d67cb0",
+                            "transcript": {
+                              "schemaVersion": 1,
+                              "messages": [
+                                {
+                                  "role": "user",
+                                  "content": "Hi, I need a quote for plumbing work.",
+                                  "at": "2026-04-04T12:43:25.000Z"
+                                },
+                                {
+                                  "role": "assistant",
+                                  "content": "Sure. Could you share your name and phone number?",
+                                  "at": "2026-04-04T12:43:28.000Z"
+                                }
+                              ],
+                              "ai_receptionist_training_feedback_history": [
+                                {
+                                  "created_at": "2026-05-10T13:20:11.000Z",
+                                  "created_by_staff_uid": "evcq5xg3epuw2c1a",
+                                  "feedback_scope": "conversation",
+                                  "feedback_text": "Please use a friendlier tone in follow-up messages.",
+                                  "message_reference": null
+                                }
+                              ]
+                            },
+                            "summary": "Visitor asked for plumbing quote and shared contact details.",
+                            "contact_full_name": "John Doe",
+                            "contact_email": null,
+                            "contact_phone": "+15551234567",
+                            "page_url": "https://example.com/services/plumbing",
+                            "started_at": "2026-04-04T12:43:21.000Z",
+                            "ended_at": "2026-04-04T12:49:58.000Z",
+                            "matter_uid": "mtr_991ac2",
+                            "client_uid": "cli_1872baf9",
+                            "message_count": 18,
+                            "lead_intent": "General inquiry",
+                            "lead_information": {
+                              "Name": "John Doe",
+                              "Phone": "+15551234567",
+                              "Reason for inquiry": "Quote for plumbing work"
+                            },
+                            "source_app_uid": "voicecalls",
+                            "channel_uid": "voicecalls:setting_123",
+                            "delivery_kind": "voicecalls",
+                            "voice_call_uid": "vc_7f31d9a4",
+                            "external_uuid": "CON-123",
+                            "voice_metadata": {
+                              "voice_call_uid": "vc_7f31d9a4",
+                              "external_uuid": "CON-123",
+                              "from_number": "+15551234567",
+                              "to_number": "+12125551234",
+                              "recording_url": "https://recordings.example.com/calls/CON-123.wav",
+                              "file_size": 1048576,
+                              "recording_duration": 95,
+                              "recording_received_at": "2026-04-04T12:51:10.000Z"
+                            },
+                            "created_at": "2026-04-04T12:50:00.000Z",
+                            "updated_at": "2026-04-04T12:50:00.000Z"
+                          }
                         }
                       }
                     }
@@ -1194,12 +3270,464 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/online_presence/AiReceptionistConversation.json"
+                          "type": "object",
+                          "description": "Persisted website AI Receptionist conversation resource. Returned inside `{ data }` for Staff-scoped list/get/create/update APIs (`/v3/online_presence/ai_receptionist_conversations`). Date-time fields use ISO 8601 format. Soft-deleted conversations are not returned in normal API responses.",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "readOnly": true,
+                              "description": "Public conversation UID (UUID)."
+                            },
+                            "business_uid": {
+                              "type": "string",
+                              "description": "Business that owns the conversation."
+                            },
+                            "session_id": {
+                              "type": "string",
+                              "description": "Chat session id from the online_presence chat service."
+                            },
+                            "transcript": {
+                              "description": "Conversation transcript. New records use a structured transcript object (`schemaVersion` + `messages`). Older records may still contain legacy plain text; new integrations should use the structured format.",
+                              "nullable": true,
+                              "oneOf": [
+                                {
+                                  "type": "object",
+                                  "description": "Structured transcript object captured when a session ends. Uses the same visitor-visible message list shape that is returned when resuming an active chat session. Consumers should render from `messages` and may derive plain text if needed.",
+                                  "properties": {
+                                    "schemaVersion": {
+                                      "type": "integer",
+                                      "enum": [
+                                        1
+                                      ],
+                                      "description": "Document format version."
+                                    },
+                                    "messages": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "description": "Visitor-visible chat line (**user** or **assistant**). Used in chat resume responses and stored inside the transcript document for persisted conversations. System prompts and internal tool rows are not included.",
+                                        "properties": {
+                                          "role": {
+                                            "type": "string",
+                                            "enum": [
+                                              "user",
+                                              "assistant"
+                                            ],
+                                            "description": "Who sent the message."
+                                          },
+                                          "content": {
+                                            "type": "string",
+                                            "description": "Message text (may include markdown)."
+                                          },
+                                          "message_type": {
+                                            "type": "string",
+                                            "nullable": true,
+                                            "enum": [
+                                              "tool_status"
+                                            ],
+                                            "description": "Optional semantic marker for assistant status lines emitted while backend tools run (e.g., \"Storing your information...\"). UI can use this to avoid treating the row as a normal assistant reply."
+                                          },
+                                          "at": {
+                                            "type": "string",
+                                            "format": "date-time",
+                                            "description": "Optional ISO 8601 UTC timestamp when the server recorded the turn. May be omitted on older Redis session blobs; clients may use it for ordering or display outside the embeddable widget."
+                                          }
+                                        },
+                                        "required": [
+                                          "role",
+                                          "content"
+                                        ],
+                                        "example": {
+                                          "role": "assistant",
+                                          "content": "Hi! How can I help you today?",
+                                          "at": "2026-04-19T12:34:56.789Z"
+                                        }
+                                      },
+                                      "description": "Ordered visitor-visible turns."
+                                    },
+                                    "ai_receptionist_training_feedback_history": {
+                                      "type": "array",
+                                      "description": "Append-only AI receptionist training feedback history captured from chat history UI. Each entry stores who submitted the feedback, when it was submitted, scope (`conversation` or `message`), and optional message reference metadata for message-level feedback.",
+                                      "items": {
+                                        "type": "object",
+                                        "properties": {
+                                          "created_at": {
+                                            "type": "string",
+                                            "format": "date-time",
+                                            "description": "ISO 8601 UTC timestamp when the feedback entry was created."
+                                          },
+                                          "created_by_staff_uid": {
+                                            "type": "string",
+                                            "nullable": true,
+                                            "description": "Staff UID that submitted the feedback."
+                                          },
+                                          "feedback_scope": {
+                                            "type": "string",
+                                            "enum": [
+                                              "conversation",
+                                              "message"
+                                            ],
+                                            "description": "Feedback scope: entire conversation (`conversation`) or specific assistant message (`message`)."
+                                          },
+                                          "feedback_text": {
+                                            "type": "string",
+                                            "description": "Raw user feedback text."
+                                          },
+                                          "message_reference": {
+                                            "type": "object",
+                                            "nullable": true,
+                                            "description": "Optional message reference details for `message` scope feedback.",
+                                            "properties": {
+                                              "index": {
+                                                "type": "integer",
+                                                "minimum": 0,
+                                                "description": "Message index in transcript `messages` array."
+                                              },
+                                              "snippet": {
+                                                "type": "string",
+                                                "description": "Short first-words snippet of the referenced message."
+                                              },
+                                              "message_id": {
+                                                "type": "string",
+                                                "nullable": true,
+                                                "description": "Optional UI-level transcript message id."
+                                              },
+                                              "role": {
+                                                "type": "string",
+                                                "nullable": true,
+                                                "enum": [
+                                                  "assistant",
+                                                  "visitor"
+                                                ],
+                                                "description": "Optional role hint from the UI message id."
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "required": [
+                                          "created_at",
+                                          "feedback_scope",
+                                          "feedback_text"
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  "required": [
+                                    "schemaVersion",
+                                    "messages"
+                                  ],
+                                  "example": {
+                                    "schemaVersion": 1,
+                                    "messages": [
+                                      {
+                                        "role": "assistant",
+                                        "content": "Hi! How can I help?",
+                                        "at": "2026-04-19T12:34:56.789Z"
+                                      },
+                                      {
+                                        "role": "user",
+                                        "content": "I need to book an appointment.",
+                                        "at": "2026-04-19T12:35:01.000Z"
+                                      }
+                                    ],
+                                    "ai_receptionist_training_feedback_history": [
+                                      {
+                                        "created_at": "2026-05-10T13:20:11.000Z",
+                                        "created_by_staff_uid": "evcq5xg3epuw2c1a",
+                                        "feedback_scope": "message",
+                                        "feedback_text": "Avoid asking for phone again once it was already provided.",
+                                        "message_reference": {
+                                          "index": 6,
+                                          "snippet": "Thank you, Itzik. Could you please provide your phone number...",
+                                          "message_id": "transcript-object-6-assistant",
+                                          "role": "assistant"
+                                        }
+                                      }
+                                    ]
+                                  }
+                                },
+                                {
+                                  "type": "string",
+                                  "description": "Legacy plain-text transcript (older data only)."
+                                }
+                              ]
+                            },
+                            "summary": {
+                              "type": "string",
+                              "nullable": true,
+                              "description": "Optional summary of the conversation."
+                            },
+                            "contact_full_name": {
+                              "type": "string",
+                              "nullable": true,
+                              "description": "Visitor name if captured."
+                            },
+                            "contact_email": {
+                              "type": "string",
+                              "nullable": true,
+                              "description": "Visitor email if captured."
+                            },
+                            "contact_phone": {
+                              "type": "string",
+                              "nullable": true,
+                              "description": "Visitor phone if captured."
+                            },
+                            "page_url": {
+                              "type": "string",
+                              "nullable": true,
+                              "description": "Page URL where the chat started."
+                            },
+                            "started_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "description": "Conversation start time."
+                            },
+                            "ended_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "description": "Conversation end time."
+                            },
+                            "matter_uid": {
+                              "type": "string",
+                              "nullable": true,
+                              "description": "Optional matter/case linkage."
+                            },
+                            "client_uid": {
+                              "type": "string",
+                              "nullable": true,
+                              "description": "Optional CRM client UID linked to this conversation."
+                            },
+                            "message_count": {
+                              "type": "integer",
+                              "nullable": true,
+                              "minimum": 0,
+                              "description": "Number of messages in the conversation."
+                            },
+                            "lead_intent": {
+                              "type": "string",
+                              "nullable": true,
+                              "description": "Resolved lead intent extracted at conversation close (e.g., \"General inquiry\"). When no lead data is captured, value may be \"N/A\"."
+                            },
+                            "lead_information": {
+                              "type": "object",
+                              "nullable": true,
+                              "description": "Extracted lead key/value pairs captured from the conversation (JSON object, e.g. {\"Name\":\"John Doe\",\"Phone\":\"+15551234567\"}).",
+                              "additionalProperties": {
+                                "type": "string"
+                              }
+                            },
+                            "source_app_uid": {
+                              "type": "string",
+                              "nullable": true,
+                              "description": "Application that delivered the inbound traffic for this conversation. Web widget sessions use null; voice AI Receptionist sessions use \"voicecalls\"."
+                            },
+                            "channel_uid": {
+                              "type": "string",
+                              "nullable": true,
+                              "description": "Channel identifier used for attribution in AI Receptionist reporting, such as \"voicecalls:setting_123\" for a voicecalls phone-number setting."
+                            },
+                            "delivery_kind": {
+                              "type": "string",
+                              "nullable": true,
+                              "enum": [
+                                "webaiwidgetmgr",
+                                "comm_gw",
+                                "voicecalls"
+                              ],
+                              "description": "Lifecycle owner for the conversation. **webaiwidgetmgr** means the website widget owned the session lifecycle, **comm_gw** means Communication Gateway owned lifecycle and release handling, and **voicecalls** means the voicecalls service owned PSTN lifecycle handling."
+                            },
+                            "voice_call_uid": {
+                              "type": "string",
+                              "nullable": true,
+                              "description": "Internal voicecalls call UID used to correlate AI Receptionist voice metadata and recording callbacks."
+                            },
+                            "external_uuid": {
+                              "type": "string",
+                              "nullable": true,
+                              "description": "External provider conversation UUID, usually the Vonage conversation UUID used by voicecalls webhooks."
+                            },
+                            "voice_metadata": {
+                              "type": "object",
+                              "nullable": true,
+                              "description": "Voice-specific metadata for AI Receptionist calls, including caller/callee numbers and recording details when available.",
+                              "properties": {
+                                "voice_call_uid": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "description": "Internal voicecalls call UID."
+                                },
+                                "external_uuid": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "description": "External provider conversation UUID."
+                                },
+                                "from_number": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "description": "Caller phone number in E.164 format."
+                                },
+                                "to_number": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "description": "Dialed voicecalls phone number in E.164 format."
+                                },
+                                "recording_url": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "description": "Signed call recording URL generated by voicecalls."
+                                },
+                                "file_size": {
+                                  "type": "integer",
+                                  "nullable": true,
+                                  "minimum": 0,
+                                  "description": "Recording file size in bytes."
+                                },
+                                "recording_duration": {
+                                  "type": "integer",
+                                  "nullable": true,
+                                  "minimum": 0,
+                                  "description": "Recording duration in seconds."
+                                },
+                                "recording_received_at": {
+                                  "type": "string",
+                                  "format": "date-time",
+                                  "nullable": true,
+                                  "description": "Time when webaiwidgetserver received the recording callback."
+                                }
+                              }
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "readOnly": true,
+                              "description": "Row creation time."
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "readOnly": true,
+                              "description": "Row last update time."
+                            }
+                          },
+                          "required": [
+                            "uid",
+                            "business_uid",
+                            "session_id",
+                            "started_at",
+                            "ended_at",
+                            "created_at",
+                            "updated_at"
+                          ],
+                          "example": {
+                            "uid": "8d31f5fe-9c6d-4a6a-b0a2-9d10a9f1c01a",
+                            "business_uid": "biz_2f8f7ab1",
+                            "session_id": "4f609f56-cb57-43c5-956c-252f20d67cb0",
+                            "transcript": {
+                              "schemaVersion": 1,
+                              "messages": [
+                                {
+                                  "role": "user",
+                                  "content": "Hi, I need a quote for plumbing work.",
+                                  "at": "2026-04-04T12:43:25.000Z"
+                                },
+                                {
+                                  "role": "assistant",
+                                  "content": "Sure. Could you share your name and phone number?",
+                                  "at": "2026-04-04T12:43:28.000Z"
+                                }
+                              ],
+                              "ai_receptionist_training_feedback_history": [
+                                {
+                                  "created_at": "2026-05-10T13:20:11.000Z",
+                                  "created_by_staff_uid": "evcq5xg3epuw2c1a",
+                                  "feedback_scope": "conversation",
+                                  "feedback_text": "Please use a friendlier tone in follow-up messages.",
+                                  "message_reference": null
+                                }
+                              ]
+                            },
+                            "summary": "Visitor asked for plumbing quote and shared contact details.",
+                            "contact_full_name": "John Doe",
+                            "contact_email": null,
+                            "contact_phone": "+15551234567",
+                            "page_url": "https://example.com/services/plumbing",
+                            "started_at": "2026-04-04T12:43:21.000Z",
+                            "ended_at": "2026-04-04T12:49:58.000Z",
+                            "matter_uid": "mtr_991ac2",
+                            "client_uid": "cli_1872baf9",
+                            "message_count": 18,
+                            "lead_intent": "General inquiry",
+                            "lead_information": {
+                              "Name": "John Doe",
+                              "Phone": "+15551234567",
+                              "Reason for inquiry": "Quote for plumbing work"
+                            },
+                            "source_app_uid": "voicecalls",
+                            "channel_uid": "voicecalls:setting_123",
+                            "delivery_kind": "voicecalls",
+                            "voice_call_uid": "vc_7f31d9a4",
+                            "external_uuid": "CON-123",
+                            "voice_metadata": {
+                              "voice_call_uid": "vc_7f31d9a4",
+                              "external_uuid": "CON-123",
+                              "from_number": "+15551234567",
+                              "to_number": "+12125551234",
+                              "recording_url": "https://recordings.example.com/calls/CON-123.wav",
+                              "file_size": 1048576,
+                              "recording_duration": 95,
+                              "recording_received_at": "2026-04-04T12:51:10.000Z"
+                            },
+                            "created_at": "2026-04-04T12:50:00.000Z",
+                            "updated_at": "2026-04-04T12:50:00.000Z"
+                          }
                         }
                       }
                     }
@@ -1511,7 +4039,164 @@
         }
       },
       "WidgetConfigurationResource": {
-        "$ref": "https://vcita.github.io/developers-hub/entities/online_presence/WidgetConfiguration.json"
+        "type": "object",
+        "description": "The Web AI Widget configuration for a business — controls the embedded chat widget's appearance, welcome message, quick-reply buttons, and client-portal actions. Sparse: any field you omit falls back to the product default. Returned directly under `data` (wrapped by the standard response envelope) by the widget configuration APIs.",
+        "properties": {
+          "uid": {
+            "type": "string",
+            "readOnly": true,
+            "description": "Configuration row UID."
+          },
+          "business_uid": {
+            "type": "string",
+            "description": "Owning business UID."
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true,
+            "description": "Row creation time (ISO 8601)."
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true,
+            "description": "Last update time (ISO 8601)."
+          },
+          "owner_uid": {
+            "type": "string",
+            "nullable": true,
+            "description": "Staff UID of the last editor (widget editor saves)."
+          },
+          "widget_title": {
+            "type": "string",
+            "description": "Header title shown in the widget."
+          },
+          "welcome_message": {
+            "type": "string",
+            "description": "Opening message when chat starts."
+          },
+          "brand_color": {
+            "type": "string",
+            "description": "Brand/theme color (hex)."
+          },
+          "text_color": {
+            "type": "string",
+            "description": "Text color (hex)."
+          },
+          "logo_url": {
+            "type": "string",
+            "nullable": true,
+            "format": "uri",
+            "description": "Logo image URL."
+          },
+          "actions": {
+            "type": "array",
+            "description": "Structured portal actions; order = array order.",
+            "items": {
+              "type": "object",
+              "description": "A single client-portal action in the stored widget configuration. Order follows array position in the API.",
+              "properties": {
+                "uid": {
+                  "type": "string",
+                  "nullable": true,
+                  "description": "Portal action UID. Required by the API for persisted actions; nullable only for legacy/backfill reads."
+                },
+                "action": {
+                  "type": "string",
+                  "description": "Action key/type (client-portal action identifier)."
+                },
+                "label": {
+                  "type": "string",
+                  "nullable": true,
+                  "maxLength": 200,
+                  "description": "Display label override; omit or null to resolve from portal defaults."
+                },
+                "availability": {
+                  "type": "boolean",
+                  "description": "Whether this action is available in the widget."
+                }
+              },
+              "required": [
+                "uid",
+                "action",
+                "availability"
+              ]
+            }
+          },
+          "auto_popup_enabled": {
+            "type": "boolean",
+            "description": "Whether the widget auto-opens."
+          },
+          "auto_popup_delay": {
+            "type": "number",
+            "description": "Delay before auto-popup (seconds, 0–3600)."
+          },
+          "welcome_buttons": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "description": "Quick-reply button shown under the welcome message in the Web AI Widget.",
+              "properties": {
+                "label": {
+                  "type": "string",
+                  "description": "Button label shown to the visitor."
+                },
+                "message": {
+                  "type": "string",
+                  "description": "Message text sent to the assistant when the button is clicked."
+                }
+              },
+              "required": [
+                "label",
+                "message"
+              ]
+            }
+          },
+          "button_text": {
+            "type": "string",
+            "description": "Engage / launcher button label."
+          }
+        },
+        "example": {
+          "uid": "widcfg_48b3f7a2",
+          "business_uid": "biz_2f8f7ab1",
+          "created_at": "2026-04-22T10:30:00.000Z",
+          "updated_at": "2026-04-22T11:12:45.000Z",
+          "owner_uid": "staff_1182abc",
+          "widget_title": "Acme Plumbing AI Assistant",
+          "welcome_message": "Hi! Need help with plumbing services?",
+          "brand_color": "#1f7ae0",
+          "text_color": "#ffffff",
+          "logo_url": "https://cdn.example.com/acme/logo.png",
+          "actions": [
+            {
+              "uid": "action_book",
+              "action": "book_appointment",
+              "label": "Book now",
+              "availability": true
+            },
+            {
+              "uid": "action_call",
+              "action": "call_business",
+              "label": "Call us",
+              "availability": true
+            }
+          ],
+          "auto_popup_enabled": true,
+          "auto_popup_delay": 8,
+          "welcome_buttons": [
+            {
+              "label": "Book an appointment",
+              "message": "I want to book an appointment."
+            },
+            {
+              "label": "Emergency service",
+              "message": "Do you provide emergency plumbing service?"
+            }
+          ],
+          "button_text": "Chat with us"
+        }
       },
       "ListWidgetConfigurationsPayload": {
         "type": "object",
@@ -1948,7 +4633,416 @@
             "type": "array",
             "description": "Conversations for the authenticated business on the current page.",
             "items": {
-              "$ref": "https://vcita.github.io/developers-hub/entities/online_presence/AiReceptionistConversation.json"
+              "type": "object",
+              "description": "Persisted website AI Receptionist conversation resource. Returned inside `{ data }` for Staff-scoped list/get/create/update APIs (`/v3/online_presence/ai_receptionist_conversations`). Date-time fields use ISO 8601 format. Soft-deleted conversations are not returned in normal API responses.",
+              "properties": {
+                "uid": {
+                  "type": "string",
+                  "readOnly": true,
+                  "description": "Public conversation UID (UUID)."
+                },
+                "business_uid": {
+                  "type": "string",
+                  "description": "Business that owns the conversation."
+                },
+                "session_id": {
+                  "type": "string",
+                  "description": "Chat session id from the online_presence chat service."
+                },
+                "transcript": {
+                  "description": "Conversation transcript. New records use a structured transcript object (`schemaVersion` + `messages`). Older records may still contain legacy plain text; new integrations should use the structured format.",
+                  "nullable": true,
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "description": "Structured transcript object captured when a session ends. Uses the same visitor-visible message list shape that is returned when resuming an active chat session. Consumers should render from `messages` and may derive plain text if needed.",
+                      "properties": {
+                        "schemaVersion": {
+                          "type": "integer",
+                          "enum": [
+                            1
+                          ],
+                          "description": "Document format version."
+                        },
+                        "messages": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "description": "Visitor-visible chat line (**user** or **assistant**). Used in chat resume responses and stored inside the transcript document for persisted conversations. System prompts and internal tool rows are not included.",
+                            "properties": {
+                              "role": {
+                                "type": "string",
+                                "enum": [
+                                  "user",
+                                  "assistant"
+                                ],
+                                "description": "Who sent the message."
+                              },
+                              "content": {
+                                "type": "string",
+                                "description": "Message text (may include markdown)."
+                              },
+                              "message_type": {
+                                "type": "string",
+                                "nullable": true,
+                                "enum": [
+                                  "tool_status"
+                                ],
+                                "description": "Optional semantic marker for assistant status lines emitted while backend tools run (e.g., \"Storing your information...\"). UI can use this to avoid treating the row as a normal assistant reply."
+                              },
+                              "at": {
+                                "type": "string",
+                                "format": "date-time",
+                                "description": "Optional ISO 8601 UTC timestamp when the server recorded the turn. May be omitted on older Redis session blobs; clients may use it for ordering or display outside the embeddable widget."
+                              }
+                            },
+                            "required": [
+                              "role",
+                              "content"
+                            ],
+                            "example": {
+                              "role": "assistant",
+                              "content": "Hi! How can I help you today?",
+                              "at": "2026-04-19T12:34:56.789Z"
+                            }
+                          },
+                          "description": "Ordered visitor-visible turns."
+                        },
+                        "ai_receptionist_training_feedback_history": {
+                          "type": "array",
+                          "description": "Append-only AI receptionist training feedback history captured from chat history UI. Each entry stores who submitted the feedback, when it was submitted, scope (`conversation` or `message`), and optional message reference metadata for message-level feedback.",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "created_at": {
+                                "type": "string",
+                                "format": "date-time",
+                                "description": "ISO 8601 UTC timestamp when the feedback entry was created."
+                              },
+                              "created_by_staff_uid": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "Staff UID that submitted the feedback."
+                              },
+                              "feedback_scope": {
+                                "type": "string",
+                                "enum": [
+                                  "conversation",
+                                  "message"
+                                ],
+                                "description": "Feedback scope: entire conversation (`conversation`) or specific assistant message (`message`)."
+                              },
+                              "feedback_text": {
+                                "type": "string",
+                                "description": "Raw user feedback text."
+                              },
+                              "message_reference": {
+                                "type": "object",
+                                "nullable": true,
+                                "description": "Optional message reference details for `message` scope feedback.",
+                                "properties": {
+                                  "index": {
+                                    "type": "integer",
+                                    "minimum": 0,
+                                    "description": "Message index in transcript `messages` array."
+                                  },
+                                  "snippet": {
+                                    "type": "string",
+                                    "description": "Short first-words snippet of the referenced message."
+                                  },
+                                  "message_id": {
+                                    "type": "string",
+                                    "nullable": true,
+                                    "description": "Optional UI-level transcript message id."
+                                  },
+                                  "role": {
+                                    "type": "string",
+                                    "nullable": true,
+                                    "enum": [
+                                      "assistant",
+                                      "visitor"
+                                    ],
+                                    "description": "Optional role hint from the UI message id."
+                                  }
+                                }
+                              }
+                            },
+                            "required": [
+                              "created_at",
+                              "feedback_scope",
+                              "feedback_text"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "schemaVersion",
+                        "messages"
+                      ],
+                      "example": {
+                        "schemaVersion": 1,
+                        "messages": [
+                          {
+                            "role": "assistant",
+                            "content": "Hi! How can I help?",
+                            "at": "2026-04-19T12:34:56.789Z"
+                          },
+                          {
+                            "role": "user",
+                            "content": "I need to book an appointment.",
+                            "at": "2026-04-19T12:35:01.000Z"
+                          }
+                        ],
+                        "ai_receptionist_training_feedback_history": [
+                          {
+                            "created_at": "2026-05-10T13:20:11.000Z",
+                            "created_by_staff_uid": "evcq5xg3epuw2c1a",
+                            "feedback_scope": "message",
+                            "feedback_text": "Avoid asking for phone again once it was already provided.",
+                            "message_reference": {
+                              "index": 6,
+                              "snippet": "Thank you, Itzik. Could you please provide your phone number...",
+                              "message_id": "transcript-object-6-assistant",
+                              "role": "assistant"
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "type": "string",
+                      "description": "Legacy plain-text transcript (older data only)."
+                    }
+                  ]
+                },
+                "summary": {
+                  "type": "string",
+                  "nullable": true,
+                  "description": "Optional summary of the conversation."
+                },
+                "contact_full_name": {
+                  "type": "string",
+                  "nullable": true,
+                  "description": "Visitor name if captured."
+                },
+                "contact_email": {
+                  "type": "string",
+                  "nullable": true,
+                  "description": "Visitor email if captured."
+                },
+                "contact_phone": {
+                  "type": "string",
+                  "nullable": true,
+                  "description": "Visitor phone if captured."
+                },
+                "page_url": {
+                  "type": "string",
+                  "nullable": true,
+                  "description": "Page URL where the chat started."
+                },
+                "started_at": {
+                  "type": "string",
+                  "format": "date-time",
+                  "description": "Conversation start time."
+                },
+                "ended_at": {
+                  "type": "string",
+                  "format": "date-time",
+                  "description": "Conversation end time."
+                },
+                "matter_uid": {
+                  "type": "string",
+                  "nullable": true,
+                  "description": "Optional matter/case linkage."
+                },
+                "client_uid": {
+                  "type": "string",
+                  "nullable": true,
+                  "description": "Optional CRM client UID linked to this conversation."
+                },
+                "message_count": {
+                  "type": "integer",
+                  "nullable": true,
+                  "minimum": 0,
+                  "description": "Number of messages in the conversation."
+                },
+                "lead_intent": {
+                  "type": "string",
+                  "nullable": true,
+                  "description": "Resolved lead intent extracted at conversation close (e.g., \"General inquiry\"). When no lead data is captured, value may be \"N/A\"."
+                },
+                "lead_information": {
+                  "type": "object",
+                  "nullable": true,
+                  "description": "Extracted lead key/value pairs captured from the conversation (JSON object, e.g. {\"Name\":\"John Doe\",\"Phone\":\"+15551234567\"}).",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                },
+                "source_app_uid": {
+                  "type": "string",
+                  "nullable": true,
+                  "description": "Application that delivered the inbound traffic for this conversation. Web widget sessions use null; voice AI Receptionist sessions use \"voicecalls\"."
+                },
+                "channel_uid": {
+                  "type": "string",
+                  "nullable": true,
+                  "description": "Channel identifier used for attribution in AI Receptionist reporting, such as \"voicecalls:setting_123\" for a voicecalls phone-number setting."
+                },
+                "delivery_kind": {
+                  "type": "string",
+                  "nullable": true,
+                  "enum": [
+                    "webaiwidgetmgr",
+                    "comm_gw",
+                    "voicecalls"
+                  ],
+                  "description": "Lifecycle owner for the conversation. **webaiwidgetmgr** means the website widget owned the session lifecycle, **comm_gw** means Communication Gateway owned lifecycle and release handling, and **voicecalls** means the voicecalls service owned PSTN lifecycle handling."
+                },
+                "voice_call_uid": {
+                  "type": "string",
+                  "nullable": true,
+                  "description": "Internal voicecalls call UID used to correlate AI Receptionist voice metadata and recording callbacks."
+                },
+                "external_uuid": {
+                  "type": "string",
+                  "nullable": true,
+                  "description": "External provider conversation UUID, usually the Vonage conversation UUID used by voicecalls webhooks."
+                },
+                "voice_metadata": {
+                  "type": "object",
+                  "nullable": true,
+                  "description": "Voice-specific metadata for AI Receptionist calls, including caller/callee numbers and recording details when available.",
+                  "properties": {
+                    "voice_call_uid": {
+                      "type": "string",
+                      "nullable": true,
+                      "description": "Internal voicecalls call UID."
+                    },
+                    "external_uuid": {
+                      "type": "string",
+                      "nullable": true,
+                      "description": "External provider conversation UUID."
+                    },
+                    "from_number": {
+                      "type": "string",
+                      "nullable": true,
+                      "description": "Caller phone number in E.164 format."
+                    },
+                    "to_number": {
+                      "type": "string",
+                      "nullable": true,
+                      "description": "Dialed voicecalls phone number in E.164 format."
+                    },
+                    "recording_url": {
+                      "type": "string",
+                      "nullable": true,
+                      "description": "Signed call recording URL generated by voicecalls."
+                    },
+                    "file_size": {
+                      "type": "integer",
+                      "nullable": true,
+                      "minimum": 0,
+                      "description": "Recording file size in bytes."
+                    },
+                    "recording_duration": {
+                      "type": "integer",
+                      "nullable": true,
+                      "minimum": 0,
+                      "description": "Recording duration in seconds."
+                    },
+                    "recording_received_at": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true,
+                      "description": "Time when webaiwidgetserver received the recording callback."
+                    }
+                  }
+                },
+                "created_at": {
+                  "type": "string",
+                  "format": "date-time",
+                  "readOnly": true,
+                  "description": "Row creation time."
+                },
+                "updated_at": {
+                  "type": "string",
+                  "format": "date-time",
+                  "readOnly": true,
+                  "description": "Row last update time."
+                }
+              },
+              "required": [
+                "uid",
+                "business_uid",
+                "session_id",
+                "started_at",
+                "ended_at",
+                "created_at",
+                "updated_at"
+              ],
+              "example": {
+                "uid": "8d31f5fe-9c6d-4a6a-b0a2-9d10a9f1c01a",
+                "business_uid": "biz_2f8f7ab1",
+                "session_id": "4f609f56-cb57-43c5-956c-252f20d67cb0",
+                "transcript": {
+                  "schemaVersion": 1,
+                  "messages": [
+                    {
+                      "role": "user",
+                      "content": "Hi, I need a quote for plumbing work.",
+                      "at": "2026-04-04T12:43:25.000Z"
+                    },
+                    {
+                      "role": "assistant",
+                      "content": "Sure. Could you share your name and phone number?",
+                      "at": "2026-04-04T12:43:28.000Z"
+                    }
+                  ],
+                  "ai_receptionist_training_feedback_history": [
+                    {
+                      "created_at": "2026-05-10T13:20:11.000Z",
+                      "created_by_staff_uid": "evcq5xg3epuw2c1a",
+                      "feedback_scope": "conversation",
+                      "feedback_text": "Please use a friendlier tone in follow-up messages.",
+                      "message_reference": null
+                    }
+                  ]
+                },
+                "summary": "Visitor asked for plumbing quote and shared contact details.",
+                "contact_full_name": "John Doe",
+                "contact_email": null,
+                "contact_phone": "+15551234567",
+                "page_url": "https://example.com/services/plumbing",
+                "started_at": "2026-04-04T12:43:21.000Z",
+                "ended_at": "2026-04-04T12:49:58.000Z",
+                "matter_uid": "mtr_991ac2",
+                "client_uid": "cli_1872baf9",
+                "message_count": 18,
+                "lead_intent": "General inquiry",
+                "lead_information": {
+                  "Name": "John Doe",
+                  "Phone": "+15551234567",
+                  "Reason for inquiry": "Quote for plumbing work"
+                },
+                "source_app_uid": "voicecalls",
+                "channel_uid": "voicecalls:setting_123",
+                "delivery_kind": "voicecalls",
+                "voice_call_uid": "vc_7f31d9a4",
+                "external_uuid": "CON-123",
+                "voice_metadata": {
+                  "voice_call_uid": "vc_7f31d9a4",
+                  "external_uuid": "CON-123",
+                  "from_number": "+15551234567",
+                  "to_number": "+12125551234",
+                  "recording_url": "https://recordings.example.com/calls/CON-123.wav",
+                  "file_size": 1048576,
+                  "recording_duration": 95,
+                  "recording_received_at": "2026-04-04T12:51:10.000Z"
+                },
+                "created_at": "2026-04-04T12:50:00.000Z",
+                "updated_at": "2026-04-04T12:50:00.000Z"
+              }
             }
           },
           "total": {

--- a/mcp_swagger/platform_administration.json
+++ b/mcp_swagger/platform_administration.json
@@ -439,7 +439,50 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
@@ -483,12 +526,274 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/license/offering.json"
+                          "type": "object",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "description": "The entity unique identifier"
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "description": "Timestamp indicating when the entity was created",
+                              "format": "date-time"
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "description": "Timestamp of the entity's most recent update",
+                              "format": "date-time"
+                            },
+                            "type": {
+                              "type": "string",
+                              "description": "Type of the offering. Possible values include: **package** for the main business subscription; **app** for marketplace app subscriptions and **addon** for other SKUs like SMS and staff_seats. A user can have one subscription with package, one subscription per SKU of type apps and any number of subscriptions for any SKU",
+                              "enum": [
+                                "package",
+                                "app",
+                                "addon"
+                              ]
+                            },
+                            "SKU": {
+                              "type": "string",
+                              "description": "The unique code of the single SKU this offering represents. Offerings support exactly one SKU; to combine multiple SKUs, use a bundledOffering or similar higher-level abstraction."
+                            },
+                            "display_name": {
+                              "type": "string",
+                              "description": "The SKU's display name"
+                            },
+                            "quantity": {
+                              "type": "number",
+                              "description": "The number of items included in the offering. Use `-1` to indicate **unlimited** quantity (e.g., unlimited staff seats). When quantity is `-1`, the system treats the resource as uncapped — no usage limit is enforced. This is typically used for `staff_seat` add-on offerings distributed as part of a bundle.",
+                              "default": 1
+                            },
+                            "payment_type": {
+                              "type": "string",
+                              "description": "The payment type field defines the payment options available for an offering,**external**: Payment is not done by the platform (typically an API call from the partner), **external_single_charge**: A one-time externally-managed payment (typically an API call from the partner) that grants a single credit (e.g., SMS); behaves like external for billing but its quota is counted as purchased; not supported for package offerings, **free**: No payment is required; **single_charge**: A single, one-time payment is required to obtain the offering; **monthly**: A recurring payment made on a monthly basis; **annual**: A recurring payment made on a yearly basis; **bundle**: A subscription bundled with another subscription",
+                              "enum": [
+                                "monthly",
+                                "annualy",
+                                "free",
+                                "single_charge",
+                                "external",
+                                "external_single_charge",
+                                "bundle"
+                              ]
+                            },
+                            "is_active": {
+                              "type": "boolean",
+                              "description": "Current status of the directory offering",
+                              "default": true
+                            },
+                            "is_listed": {
+                              "type": "boolean",
+                              "description": "Listing visibility. Defaults to `true` for every offering; when `false` the offering is hidden from listings but remains reachable via a direct link to its info page.",
+                              "default": true
+                            },
+                            "vendor": {
+                              "type": "string",
+                              "description": "The business entity or vendor that offers this SKU.",
+                              "enum": [
+                                "partner",
+                                "inTandem"
+                              ],
+                              "default": "inTandem"
+                            },
+                            "prices": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "price": {
+                                    "type": "string",
+                                    "description": "Cost of the directory offering. Returns as a string value (e.g., \"5.00\")."
+                                  },
+                                  "currency": {
+                                    "type": "string",
+                                    "description": "The currency used for the price. Supported currencies include USD, EUR, GBP, CHF, ILS, AUD, CAD, NZD, PLN, MXN, BRL.",
+                                    "enum": [
+                                      "USD",
+                                      "EUR",
+                                      "GBP",
+                                      "CHF",
+                                      "ILS",
+                                      "AUD",
+                                      "CAD",
+                                      "NZD",
+                                      "PLN",
+                                      "MXN",
+                                      "BRL"
+                                    ]
+                                  }
+                                }
+                              }
+                            },
+                            "trial_type": {
+                              "type": "string",
+                              "description": "Specifies how the trial option is managed. expire: trial is enabled and subscription will expire after trial_period days. no_trial: no trial period. Future values may include: automatic_charge (auto-charge after trial), manually_charge (stay active without charging).",
+                              "enum": [
+                                "expire",
+                                "no_trial"
+                              ],
+                              "default": "no_trial"
+                            },
+                            "trial_period": {
+                              "type": "number",
+                              "description": "Number of days for the trial period. If not specified or set to 0, it indicates no trial period is offered."
+                            },
+                            "reporting_tags": {
+                              "type": "array",
+                              "items": {
+                                "type": "string",
+                                "enum": [
+                                  "base",
+                                  "free",
+                                  "trial",
+                                  "ghost",
+                                  "business_management",
+                                  "sandbox",
+                                  "no_marketing",
+                                  "no_payments",
+                                  "no_scheduling",
+                                  "connect",
+                                  "limited-core",
+                                  "core",
+                                  "core-trial",
+                                  "test"
+                                ]
+                              },
+                              "description": "A list of tags to be used for reporting purposes. Tags categorize offerings for analytics and billing reports. Common tags include: **base** for standard base offerings; **free** for free tier offerings; **trial** for trial-period offerings; **ghost** for internal/hidden offerings; **business_management** for business management related offerings; **sandbox** for test environment offerings; **core** for core platform offerings.",
+                              "example": [
+                                "base",
+                                "free"
+                              ]
+                            },
+                            "availability_rules": {
+                              "type": "object",
+                              "additionalProperties": false,
+                              "description": "Availability rules for the offering, keyed by rule type. When present, a business only receives this offering as a bundled item if it satisfies every rule (direct subscription and catalog visibility are not gated). Empty or omitted means available everywhere. The only supported rule is `geo_location` (e.g., { \"geo_location\": { \"allow\": [\"US\"], \"deny\": [] } }).",
+                              "properties": {
+                                "geo_location": {
+                                  "type": "object",
+                                  "additionalProperties": false,
+                                  "description": "Restricts the offering by the business's country (ISO 3166-1 alpha-2). `deny` always wins over `allow`; empty lists mean available in every country; an unresolved business country is treated as not-allowed when any restriction is set (fail-closed) (e.g., { \"allow\": [\"US\", \"CA\"], \"deny\": [\"IR\"] }).",
+                                  "required": [
+                                    "allow",
+                                    "deny"
+                                  ],
+                                  "properties": {
+                                    "allow": {
+                                      "type": "array",
+                                      "description": "Country codes the offering is available in (e.g., [\"US\", \"CA\"]).",
+                                      "items": {
+                                        "type": "string",
+                                        "pattern": "^[A-Z]{2}$"
+                                      }
+                                    },
+                                    "deny": {
+                                      "type": "array",
+                                      "description": "Country codes the offering is NOT available in; takes precedence over `allow` (e.g., [\"IR\", \"KP\"]).",
+                                      "items": {
+                                        "type": "string",
+                                        "pattern": "^[A-Z]{2}$"
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "required": [
+                            "type",
+                            "SKU",
+                            "display_name",
+                            "quantity",
+                            "payment_type",
+                            "prices"
+                          ],
+                          "example": {
+                            "uid": "bc33f12d-98ee-428f-9f65-18bba589cb95",
+                            "created_at": "2024-01-01T09:00:00Z",
+                            "updated_at": "2024-03-20T12:34:56Z",
+                            "type": "package",
+                            "SKU": "premium_10",
+                            "display_name": "Premium 10",
+                            "quantity": 1,
+                            "payment_type": "monthly",
+                            "is_active": true,
+                            "is_listed": true,
+                            "vendor": "inTandem",
+                            "prices": [
+                              {
+                                "price": "5.00",
+                                "currency": "USD"
+                              },
+                              {
+                                "price": "5.00",
+                                "currency": "EUR"
+                              }
+                            ],
+                            "trial_type": "no_trial",
+                            "trial_period": 0,
+                            "reporting_tags": [
+                              "base",
+                              "no_payments"
+                            ],
+                            "availability_rules": {
+                              "geo_location": {
+                                "allow": [
+                                  "US"
+                                ],
+                                "deny": []
+                              }
+                            }
+                          },
+                          "description": "An Offering represents a commercial agreement in the inTandem platform, describing the various attributes of the commercial terms, including pricing, type, and additional metadata."
                         }
                       }
                     }
@@ -554,12 +859,274 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/license/offering.json"
+                          "type": "object",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "description": "The entity unique identifier"
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "description": "Timestamp indicating when the entity was created",
+                              "format": "date-time"
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "description": "Timestamp of the entity's most recent update",
+                              "format": "date-time"
+                            },
+                            "type": {
+                              "type": "string",
+                              "description": "Type of the offering. Possible values include: **package** for the main business subscription; **app** for marketplace app subscriptions and **addon** for other SKUs like SMS and staff_seats. A user can have one subscription with package, one subscription per SKU of type apps and any number of subscriptions for any SKU",
+                              "enum": [
+                                "package",
+                                "app",
+                                "addon"
+                              ]
+                            },
+                            "SKU": {
+                              "type": "string",
+                              "description": "The unique code of the single SKU this offering represents. Offerings support exactly one SKU; to combine multiple SKUs, use a bundledOffering or similar higher-level abstraction."
+                            },
+                            "display_name": {
+                              "type": "string",
+                              "description": "The SKU's display name"
+                            },
+                            "quantity": {
+                              "type": "number",
+                              "description": "The number of items included in the offering. Use `-1` to indicate **unlimited** quantity (e.g., unlimited staff seats). When quantity is `-1`, the system treats the resource as uncapped — no usage limit is enforced. This is typically used for `staff_seat` add-on offerings distributed as part of a bundle.",
+                              "default": 1
+                            },
+                            "payment_type": {
+                              "type": "string",
+                              "description": "The payment type field defines the payment options available for an offering,**external**: Payment is not done by the platform (typically an API call from the partner), **external_single_charge**: A one-time externally-managed payment (typically an API call from the partner) that grants a single credit (e.g., SMS); behaves like external for billing but its quota is counted as purchased; not supported for package offerings, **free**: No payment is required; **single_charge**: A single, one-time payment is required to obtain the offering; **monthly**: A recurring payment made on a monthly basis; **annual**: A recurring payment made on a yearly basis; **bundle**: A subscription bundled with another subscription",
+                              "enum": [
+                                "monthly",
+                                "annualy",
+                                "free",
+                                "single_charge",
+                                "external",
+                                "external_single_charge",
+                                "bundle"
+                              ]
+                            },
+                            "is_active": {
+                              "type": "boolean",
+                              "description": "Current status of the directory offering",
+                              "default": true
+                            },
+                            "is_listed": {
+                              "type": "boolean",
+                              "description": "Listing visibility. Defaults to `true` for every offering; when `false` the offering is hidden from listings but remains reachable via a direct link to its info page.",
+                              "default": true
+                            },
+                            "vendor": {
+                              "type": "string",
+                              "description": "The business entity or vendor that offers this SKU.",
+                              "enum": [
+                                "partner",
+                                "inTandem"
+                              ],
+                              "default": "inTandem"
+                            },
+                            "prices": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "price": {
+                                    "type": "string",
+                                    "description": "Cost of the directory offering. Returns as a string value (e.g., \"5.00\")."
+                                  },
+                                  "currency": {
+                                    "type": "string",
+                                    "description": "The currency used for the price. Supported currencies include USD, EUR, GBP, CHF, ILS, AUD, CAD, NZD, PLN, MXN, BRL.",
+                                    "enum": [
+                                      "USD",
+                                      "EUR",
+                                      "GBP",
+                                      "CHF",
+                                      "ILS",
+                                      "AUD",
+                                      "CAD",
+                                      "NZD",
+                                      "PLN",
+                                      "MXN",
+                                      "BRL"
+                                    ]
+                                  }
+                                }
+                              }
+                            },
+                            "trial_type": {
+                              "type": "string",
+                              "description": "Specifies how the trial option is managed. expire: trial is enabled and subscription will expire after trial_period days. no_trial: no trial period. Future values may include: automatic_charge (auto-charge after trial), manually_charge (stay active without charging).",
+                              "enum": [
+                                "expire",
+                                "no_trial"
+                              ],
+                              "default": "no_trial"
+                            },
+                            "trial_period": {
+                              "type": "number",
+                              "description": "Number of days for the trial period. If not specified or set to 0, it indicates no trial period is offered."
+                            },
+                            "reporting_tags": {
+                              "type": "array",
+                              "items": {
+                                "type": "string",
+                                "enum": [
+                                  "base",
+                                  "free",
+                                  "trial",
+                                  "ghost",
+                                  "business_management",
+                                  "sandbox",
+                                  "no_marketing",
+                                  "no_payments",
+                                  "no_scheduling",
+                                  "connect",
+                                  "limited-core",
+                                  "core",
+                                  "core-trial",
+                                  "test"
+                                ]
+                              },
+                              "description": "A list of tags to be used for reporting purposes. Tags categorize offerings for analytics and billing reports. Common tags include: **base** for standard base offerings; **free** for free tier offerings; **trial** for trial-period offerings; **ghost** for internal/hidden offerings; **business_management** for business management related offerings; **sandbox** for test environment offerings; **core** for core platform offerings.",
+                              "example": [
+                                "base",
+                                "free"
+                              ]
+                            },
+                            "availability_rules": {
+                              "type": "object",
+                              "additionalProperties": false,
+                              "description": "Availability rules for the offering, keyed by rule type. When present, a business only receives this offering as a bundled item if it satisfies every rule (direct subscription and catalog visibility are not gated). Empty or omitted means available everywhere. The only supported rule is `geo_location` (e.g., { \"geo_location\": { \"allow\": [\"US\"], \"deny\": [] } }).",
+                              "properties": {
+                                "geo_location": {
+                                  "type": "object",
+                                  "additionalProperties": false,
+                                  "description": "Restricts the offering by the business's country (ISO 3166-1 alpha-2). `deny` always wins over `allow`; empty lists mean available in every country; an unresolved business country is treated as not-allowed when any restriction is set (fail-closed) (e.g., { \"allow\": [\"US\", \"CA\"], \"deny\": [\"IR\"] }).",
+                                  "required": [
+                                    "allow",
+                                    "deny"
+                                  ],
+                                  "properties": {
+                                    "allow": {
+                                      "type": "array",
+                                      "description": "Country codes the offering is available in (e.g., [\"US\", \"CA\"]).",
+                                      "items": {
+                                        "type": "string",
+                                        "pattern": "^[A-Z]{2}$"
+                                      }
+                                    },
+                                    "deny": {
+                                      "type": "array",
+                                      "description": "Country codes the offering is NOT available in; takes precedence over `allow` (e.g., [\"IR\", \"KP\"]).",
+                                      "items": {
+                                        "type": "string",
+                                        "pattern": "^[A-Z]{2}$"
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "required": [
+                            "type",
+                            "SKU",
+                            "display_name",
+                            "quantity",
+                            "payment_type",
+                            "prices"
+                          ],
+                          "example": {
+                            "uid": "bc33f12d-98ee-428f-9f65-18bba589cb95",
+                            "created_at": "2024-01-01T09:00:00Z",
+                            "updated_at": "2024-03-20T12:34:56Z",
+                            "type": "package",
+                            "SKU": "premium_10",
+                            "display_name": "Premium 10",
+                            "quantity": 1,
+                            "payment_type": "monthly",
+                            "is_active": true,
+                            "is_listed": true,
+                            "vendor": "inTandem",
+                            "prices": [
+                              {
+                                "price": "5.00",
+                                "currency": "USD"
+                              },
+                              {
+                                "price": "5.00",
+                                "currency": "EUR"
+                              }
+                            ],
+                            "trial_type": "no_trial",
+                            "trial_period": 0,
+                            "reporting_tags": [
+                              "base",
+                              "no_payments"
+                            ],
+                            "availability_rules": {
+                              "geo_location": {
+                                "allow": [
+                                  "US"
+                                ],
+                                "deny": []
+                              }
+                            }
+                          },
+                          "description": "An Offering represents a commercial agreement in the inTandem platform, describing the various attributes of the commercial terms, including pricing, type, and additional metadata."
                         }
                       }
                     }
@@ -609,12 +1176,274 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/license/offering.json"
+                          "type": "object",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "description": "The entity unique identifier"
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "description": "Timestamp indicating when the entity was created",
+                              "format": "date-time"
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "description": "Timestamp of the entity's most recent update",
+                              "format": "date-time"
+                            },
+                            "type": {
+                              "type": "string",
+                              "description": "Type of the offering. Possible values include: **package** for the main business subscription; **app** for marketplace app subscriptions and **addon** for other SKUs like SMS and staff_seats. A user can have one subscription with package, one subscription per SKU of type apps and any number of subscriptions for any SKU",
+                              "enum": [
+                                "package",
+                                "app",
+                                "addon"
+                              ]
+                            },
+                            "SKU": {
+                              "type": "string",
+                              "description": "The unique code of the single SKU this offering represents. Offerings support exactly one SKU; to combine multiple SKUs, use a bundledOffering or similar higher-level abstraction."
+                            },
+                            "display_name": {
+                              "type": "string",
+                              "description": "The SKU's display name"
+                            },
+                            "quantity": {
+                              "type": "number",
+                              "description": "The number of items included in the offering. Use `-1` to indicate **unlimited** quantity (e.g., unlimited staff seats). When quantity is `-1`, the system treats the resource as uncapped — no usage limit is enforced. This is typically used for `staff_seat` add-on offerings distributed as part of a bundle.",
+                              "default": 1
+                            },
+                            "payment_type": {
+                              "type": "string",
+                              "description": "The payment type field defines the payment options available for an offering,**external**: Payment is not done by the platform (typically an API call from the partner), **external_single_charge**: A one-time externally-managed payment (typically an API call from the partner) that grants a single credit (e.g., SMS); behaves like external for billing but its quota is counted as purchased; not supported for package offerings, **free**: No payment is required; **single_charge**: A single, one-time payment is required to obtain the offering; **monthly**: A recurring payment made on a monthly basis; **annual**: A recurring payment made on a yearly basis; **bundle**: A subscription bundled with another subscription",
+                              "enum": [
+                                "monthly",
+                                "annualy",
+                                "free",
+                                "single_charge",
+                                "external",
+                                "external_single_charge",
+                                "bundle"
+                              ]
+                            },
+                            "is_active": {
+                              "type": "boolean",
+                              "description": "Current status of the directory offering",
+                              "default": true
+                            },
+                            "is_listed": {
+                              "type": "boolean",
+                              "description": "Listing visibility. Defaults to `true` for every offering; when `false` the offering is hidden from listings but remains reachable via a direct link to its info page.",
+                              "default": true
+                            },
+                            "vendor": {
+                              "type": "string",
+                              "description": "The business entity or vendor that offers this SKU.",
+                              "enum": [
+                                "partner",
+                                "inTandem"
+                              ],
+                              "default": "inTandem"
+                            },
+                            "prices": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "price": {
+                                    "type": "string",
+                                    "description": "Cost of the directory offering. Returns as a string value (e.g., \"5.00\")."
+                                  },
+                                  "currency": {
+                                    "type": "string",
+                                    "description": "The currency used for the price. Supported currencies include USD, EUR, GBP, CHF, ILS, AUD, CAD, NZD, PLN, MXN, BRL.",
+                                    "enum": [
+                                      "USD",
+                                      "EUR",
+                                      "GBP",
+                                      "CHF",
+                                      "ILS",
+                                      "AUD",
+                                      "CAD",
+                                      "NZD",
+                                      "PLN",
+                                      "MXN",
+                                      "BRL"
+                                    ]
+                                  }
+                                }
+                              }
+                            },
+                            "trial_type": {
+                              "type": "string",
+                              "description": "Specifies how the trial option is managed. expire: trial is enabled and subscription will expire after trial_period days. no_trial: no trial period. Future values may include: automatic_charge (auto-charge after trial), manually_charge (stay active without charging).",
+                              "enum": [
+                                "expire",
+                                "no_trial"
+                              ],
+                              "default": "no_trial"
+                            },
+                            "trial_period": {
+                              "type": "number",
+                              "description": "Number of days for the trial period. If not specified or set to 0, it indicates no trial period is offered."
+                            },
+                            "reporting_tags": {
+                              "type": "array",
+                              "items": {
+                                "type": "string",
+                                "enum": [
+                                  "base",
+                                  "free",
+                                  "trial",
+                                  "ghost",
+                                  "business_management",
+                                  "sandbox",
+                                  "no_marketing",
+                                  "no_payments",
+                                  "no_scheduling",
+                                  "connect",
+                                  "limited-core",
+                                  "core",
+                                  "core-trial",
+                                  "test"
+                                ]
+                              },
+                              "description": "A list of tags to be used for reporting purposes. Tags categorize offerings for analytics and billing reports. Common tags include: **base** for standard base offerings; **free** for free tier offerings; **trial** for trial-period offerings; **ghost** for internal/hidden offerings; **business_management** for business management related offerings; **sandbox** for test environment offerings; **core** for core platform offerings.",
+                              "example": [
+                                "base",
+                                "free"
+                              ]
+                            },
+                            "availability_rules": {
+                              "type": "object",
+                              "additionalProperties": false,
+                              "description": "Availability rules for the offering, keyed by rule type. When present, a business only receives this offering as a bundled item if it satisfies every rule (direct subscription and catalog visibility are not gated). Empty or omitted means available everywhere. The only supported rule is `geo_location` (e.g., { \"geo_location\": { \"allow\": [\"US\"], \"deny\": [] } }).",
+                              "properties": {
+                                "geo_location": {
+                                  "type": "object",
+                                  "additionalProperties": false,
+                                  "description": "Restricts the offering by the business's country (ISO 3166-1 alpha-2). `deny` always wins over `allow`; empty lists mean available in every country; an unresolved business country is treated as not-allowed when any restriction is set (fail-closed) (e.g., { \"allow\": [\"US\", \"CA\"], \"deny\": [\"IR\"] }).",
+                                  "required": [
+                                    "allow",
+                                    "deny"
+                                  ],
+                                  "properties": {
+                                    "allow": {
+                                      "type": "array",
+                                      "description": "Country codes the offering is available in (e.g., [\"US\", \"CA\"]).",
+                                      "items": {
+                                        "type": "string",
+                                        "pattern": "^[A-Z]{2}$"
+                                      }
+                                    },
+                                    "deny": {
+                                      "type": "array",
+                                      "description": "Country codes the offering is NOT available in; takes precedence over `allow` (e.g., [\"IR\", \"KP\"]).",
+                                      "items": {
+                                        "type": "string",
+                                        "pattern": "^[A-Z]{2}$"
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "required": [
+                            "type",
+                            "SKU",
+                            "display_name",
+                            "quantity",
+                            "payment_type",
+                            "prices"
+                          ],
+                          "example": {
+                            "uid": "bc33f12d-98ee-428f-9f65-18bba589cb95",
+                            "created_at": "2024-01-01T09:00:00Z",
+                            "updated_at": "2024-03-20T12:34:56Z",
+                            "type": "package",
+                            "SKU": "premium_10",
+                            "display_name": "Premium 10",
+                            "quantity": 1,
+                            "payment_type": "monthly",
+                            "is_active": true,
+                            "is_listed": true,
+                            "vendor": "inTandem",
+                            "prices": [
+                              {
+                                "price": "5.00",
+                                "currency": "USD"
+                              },
+                              {
+                                "price": "5.00",
+                                "currency": "EUR"
+                              }
+                            ],
+                            "trial_type": "no_trial",
+                            "trial_period": 0,
+                            "reporting_tags": [
+                              "base",
+                              "no_payments"
+                            ],
+                            "availability_rules": {
+                              "geo_location": {
+                                "allow": [
+                                  "US"
+                                ],
+                                "deny": []
+                              }
+                            }
+                          },
+                          "description": "An Offering represents a commercial agreement in the inTandem platform, describing the various attributes of the commercial terms, including pricing, type, and additional metadata."
                         }
                       }
                     }
@@ -654,7 +1483,50 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     }
                   ]
                 }
@@ -725,7 +1597,50 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
@@ -768,12 +1683,94 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/license/directoryOffering.json"
+                          "type": "object",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "description": "The entity identifier"
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "description": "Timestamp indicating when the entity was created",
+                              "format": "date-time"
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "description": "Timestamp of the entity's most recent update",
+                              "format": "date-time"
+                            },
+                            "directory_uid": {
+                              "type": "string",
+                              "description": "Unique identifier for a directory. Defines which directory is authorized to sell this offering.",
+                              "x-reference-to": "directory"
+                            },
+                            "offering_uid": {
+                              "type": "string",
+                              "description": "Unique identifier for an offering. Defines an offering the directory is authorized to sell.",
+                              "x-reference-to": "offering"
+                            }
+                          },
+                          "required": [
+                            "uid",
+                            "directory_uid",
+                            "offering_uid"
+                          ],
+                          "example": {
+                            "uid": "bc33f12d-98ee-428f-9f65-18bba589cb95",
+                            "created_at": "2024-01-01T09:00:00Z",
+                            "updated_at": "2024-03-20T12:34:56Z",
+                            "directory_uid": "98ees428fq9f65tyh",
+                            "offering_uid": "3f12fb61-98ee-428f-9f65-18bba589cb95"
+                          },
+                          "description": "The directoryOffering represents the association of a directory with an offering, allowing the directory to provide the underlying product to its businesses under a specific commercial agreement."
                         }
                       }
                     }
@@ -879,12 +1876,94 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/license/directoryOffering.json"
+                          "type": "object",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "description": "The entity identifier"
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "description": "Timestamp indicating when the entity was created",
+                              "format": "date-time"
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "description": "Timestamp of the entity's most recent update",
+                              "format": "date-time"
+                            },
+                            "directory_uid": {
+                              "type": "string",
+                              "description": "Unique identifier for a directory. Defines which directory is authorized to sell this offering.",
+                              "x-reference-to": "directory"
+                            },
+                            "offering_uid": {
+                              "type": "string",
+                              "description": "Unique identifier for an offering. Defines an offering the directory is authorized to sell.",
+                              "x-reference-to": "offering"
+                            }
+                          },
+                          "required": [
+                            "uid",
+                            "directory_uid",
+                            "offering_uid"
+                          ],
+                          "example": {
+                            "uid": "bc33f12d-98ee-428f-9f65-18bba589cb95",
+                            "created_at": "2024-01-01T09:00:00Z",
+                            "updated_at": "2024-03-20T12:34:56Z",
+                            "directory_uid": "98ees428fq9f65tyh",
+                            "offering_uid": "3f12fb61-98ee-428f-9f65-18bba589cb95"
+                          },
+                          "description": "The directoryOffering represents the association of a directory with an offering, allowing the directory to provide the underlying product to its businesses under a specific commercial agreement."
                         }
                       }
                     }
@@ -924,7 +2003,50 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     }
                   ]
                 }
@@ -1001,7 +2123,50 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
@@ -1045,7 +2210,50 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
@@ -1053,7 +2261,49 @@
                           "type": "object",
                           "properties": {
                             "bundled_offering": {
-                              "$ref": "https://vcita.github.io/developers-hub/entities/license/bundledOffering.json"
+                              "type": "object",
+                              "description": "A bundled offering represents a relationship between two offerings where one (the child) is automatically included when the other (the parent) is purchased. The parent offering must be of type `package` or `app`, while the child offering can be of type `app` or `addon` (but not `package`). This entity does not include bundled staff seats.",
+                              "properties": {
+                                "uid": {
+                                  "type": "string",
+                                  "readOnly": true,
+                                  "description": "Unique identifier for this bundled offering relationship."
+                                },
+                                "created_at": {
+                                  "type": "string",
+                                  "readOnly": true,
+                                  "description": "Timestamp indicating when the bundled offering relationship was created, in ISO 8601 format (e.g., \"2024-01-01T09:00:00Z\").",
+                                  "format": "date-time"
+                                },
+                                "updated_at": {
+                                  "type": "string",
+                                  "readOnly": true,
+                                  "description": "Timestamp of the bundled offering relationship's most recent update, in ISO 8601 format (e.g., \"2024-03-20T12:34:56Z\").",
+                                  "format": "date-time"
+                                },
+                                "offering_uid": {
+                                  "type": "string",
+                                  "description": "Unique identifier of the parent offering. This is the main product that customers purchase. The parent offering must be of type `package` or `app`. Obtain valid offering UIDs from `GET /v3/license/offerings`.",
+                                  "x-reference-to": "offering"
+                                },
+                                "bundled_offering_uid": {
+                                  "type": "string",
+                                  "description": "Unique identifier of the child offering that is bundled with the parent. When the parent offering is purchased, this offering is automatically included at no additional cost. The child offering must be of type `app` or `addon` (not `package`). Obtain valid offering UIDs from `GET /v3/license/offerings`.",
+                                  "x-reference-to": "offering"
+                                }
+                              },
+                              "required": [
+                                "uid",
+                                "offering_uid",
+                                "bundled_offering_uid"
+                              ],
+                              "example": {
+                                "uid": "bc33f12d-98ee-428f-9f65-12bca589cb21",
+                                "created_at": "2024-01-01T09:00:00Z",
+                                "updated_at": "2024-03-20T12:34:56Z",
+                                "offering_uid": "fc33f32c-95ae-4e8f-9f65-18bba589cb43",
+                                "bundled_offering_uid": "bc33f12d-98ee-428f-9f65-18bba589cb95"
+                              }
                             }
                           }
                         }
@@ -1241,7 +2491,50 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
@@ -1286,7 +2579,50 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     }
                   ]
                 }
@@ -1385,7 +2721,50 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
@@ -1429,12 +2808,255 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/license/subscription.json"
+                          "type": "object",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "description": "The entity unique identifier",
+                              "x-security": [
+                                "Business"
+                              ]
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "description": "The creation date and time of the object",
+                              "format": "date-time"
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "description": "The last updated date and time of the object",
+                              "format": "date-time"
+                            },
+                            "display_name": {
+                              "type": "string",
+                              "description": "The subscription display name"
+                            },
+                            "is_active": {
+                              "type": "boolean",
+                              "description": "Calculated active subscription is when the subscription is not canceled and not expired"
+                            },
+                            "offering_uid": {
+                              "type": "string",
+                              "description": "The underlying directory offering uid"
+                            },
+                            "offering_type": {
+                              "type": "string",
+                              "description": "Category of the offering. Possible values include: **plan**: For the main business subscription; **app**: for marketplace app subscriptions; **SMS**: For text message offerings; **staff_seat**: For additional business seats.",
+                              "enum": [
+                                "package",
+                                "app",
+                                "sms",
+                                "staff_slot"
+                              ]
+                            },
+                            "purchase_state": {
+                              "type": "string",
+                              "description": "The current subscription state. **purchased**: The subscription is paid for and active; **suspended**: The subscription is temporarily suspended; **canceled**: The subscription was canceled and will expire on expiration_date; **expired**: The subscription has expired.",
+                              "enum": [
+                                "purchased",
+                                "suspended",
+                                "canceled",
+                                "expired"
+                              ]
+                            },
+                            "cancellation_date": {
+                              "type": "string",
+                              "description": "The date when subscription was canceled",
+                              "format": "date-time"
+                            },
+                            "expiration_date": {
+                              "type": "string",
+                              "description": "The date when subscription will expire (or expired)",
+                              "format": "date-time"
+                            },
+                            "buyer_uid": {
+                              "type": "string",
+                              "description": "The actor of the action. typically, the staff uid"
+                            },
+                            "business_uid": {
+                              "type": "string",
+                              "description": "The business that the subscription relates to"
+                            },
+                            "original_price": {
+                              "type": "number",
+                              "description": "The standard offering price before any discounts. This represents the original price of the offering before coupon or discount application."
+                            },
+                            "purchase_price": {
+                              "type": [
+                                "number",
+                                "string"
+                              ],
+                              "description": "The actual amount charged to the customer at the moment of the subscription was created. When a discount is applied, this will differ from original_price. May return as a number or string (e.g., \"49.99\")."
+                            },
+                            "purchase_currency": {
+                              "type": "string",
+                              "description": "The purchase currency at the moment of the subscription was created. Currently supported currencies: USD; EUR; GPB.",
+                              "enum": [
+                                "USD",
+                                "EUR",
+                                "GBP"
+                              ]
+                            },
+                            "payment_type": {
+                              "type": "string",
+                              "description": "The payment type field defines the payment options available for an offering, **free**: No payment is required; **one_time**: A single, one-time payment is required to obtain the offering; **monthly**: A recurring payment made on a monthly basis; **annual**: A recurring payment made on a yearly basis; **bundle**: A subscription bundled with another subscription",
+                              "enum": [
+                                "monthly",
+                                "annual",
+                                "free",
+                                "single_charge",
+                                "bundle",
+                                "external",
+                                "external_single_charge"
+                              ]
+                            },
+                            "bundled_from_subscription_uid": {
+                              "type": "string",
+                              "description": "The subscription uid that this subscription is bundled from"
+                            },
+                            "charged_by": {
+                              "type": "string",
+                              "description": "Who charges for this subscription. **partner**: Transaction managed by partner; **platform**: Transaction managed within the platform's integral billing system",
+                              "enum": [
+                                "partner",
+                                "platform"
+                              ]
+                            },
+                            "trial_type": {
+                              "type": "string",
+                              "description": "Indicates whether this subscription was created with a trial. expire: subscription has a trial period and will expire when it ends. no_trial: subscription was created without a trial. automatic_charge: reserved for future use.",
+                              "enum": [
+                                "no_trial",
+                                "automatic_charge",
+                                "expire"
+                              ],
+                              "default": "no_trial"
+                            },
+                            "trial_period": {
+                              "type": "number",
+                              "readOnly": true,
+                              "description": "Number of days for the trial period. Copied from the offering at subscription creation time. 0 indicates no trial period.",
+                              "default": 0
+                            },
+                            "next_charge_date": {
+                              "type": "string",
+                              "format": "date-time",
+                              "description": "The start date of the next billing cycle. This property is `null` if the subscription is set to expire."
+                            },
+                            "quantity": {
+                              "type": "number",
+                              "description": "The number of units (e.g., staff seats, SMS messages, AI tokens) allocated under this offering, defining the quantity available for use during the subscription period. A value of `-1` indicates **unlimited** quantity — the resource has no usage cap. This value is inherited from the offering at subscription creation time.",
+                              "default": 1
+                            },
+                            "can_purchase_additional_seats": {
+                              "type": "boolean",
+                              "description": "Indicates if a business can purchase additional seats beyond the bundled subscription (default: True); if False, only the bundled seats are available.",
+                              "default": true
+                            },
+                            "sku": {
+                              "type": "string",
+                              "description": "The SKU (app/packageaddon unique code name) related to this subscription"
+                            },
+                            "discount_code_name": {
+                              "type": "string",
+                              "description": "String identifier for the coupon/discount type (e.g., 'percent', 'fixed_amount'). Used for tracking and reporting purposes."
+                            },
+                            "coupon_code": {
+                              "type": "string",
+                              "description": "Discount identifier used for tracking and Recurly integration. This is the coupon code that was applied to the subscription."
+                            }
+                          },
+                          "required": [
+                            "uid",
+                            "created_at",
+                            "updated_at",
+                            "display_name",
+                            "offering_uid",
+                            "buyer_uid",
+                            "business_uid",
+                            "purchase_price",
+                            "purchase_currency",
+                            "payment_type",
+                            "charged_by",
+                            "sku"
+                          ],
+                          "example": {
+                            "uid": "c33f32c-95ae-4e8f-9f65-18bba589cb43",
+                            "created_at": "2024-01-01T09:00:00Z",
+                            "updated_at": "2024-03-20T12:34:56Z",
+                            "display_name": "Premium 10",
+                            "sku": "premium_10",
+                            "is_active": true,
+                            "offering_uid": "bc33f12d-98ee-428f-9f65-18bba589cb95",
+                            "offering_type": "package",
+                            "purchase_state": "purchased",
+                            "cancellation_date": "",
+                            "expiration_date": "",
+                            "buyer_uid": "user_12345",
+                            "business_uid": "biz_67890",
+                            "original_price": 99.99,
+                            "purchase_price": 49.99,
+                            "purchase_currency": "USD",
+                            "payment_type": "monthly",
+                            "bundled_from_subscription_uid": "",
+                            "charged_by": "platform",
+                            "trial_type": "no_trial",
+                            "trial_period": 0,
+                            "next_charge_date": "2025-03-20T12:34:56Z",
+                            "quantity": 1,
+                            "can_purchase_additional_seats": true,
+                            "discount_code_name": null,
+                            "coupon_code": null
+                          },
+                          "description": "A subscription represents a purchased offering related to a business. It includes details such as the buyer, pricing, trial period, and the subscription's lifecycle state. Supports discounted and free plans using coupons, with tracking of both original and discounted prices."
                         }
                       }
                     }
@@ -1479,12 +3101,255 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/license/subscription.json"
+                          "type": "object",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "description": "The entity unique identifier",
+                              "x-security": [
+                                "Business"
+                              ]
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "description": "The creation date and time of the object",
+                              "format": "date-time"
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "description": "The last updated date and time of the object",
+                              "format": "date-time"
+                            },
+                            "display_name": {
+                              "type": "string",
+                              "description": "The subscription display name"
+                            },
+                            "is_active": {
+                              "type": "boolean",
+                              "description": "Calculated active subscription is when the subscription is not canceled and not expired"
+                            },
+                            "offering_uid": {
+                              "type": "string",
+                              "description": "The underlying directory offering uid"
+                            },
+                            "offering_type": {
+                              "type": "string",
+                              "description": "Category of the offering. Possible values include: **plan**: For the main business subscription; **app**: for marketplace app subscriptions; **SMS**: For text message offerings; **staff_seat**: For additional business seats.",
+                              "enum": [
+                                "package",
+                                "app",
+                                "sms",
+                                "staff_slot"
+                              ]
+                            },
+                            "purchase_state": {
+                              "type": "string",
+                              "description": "The current subscription state. **purchased**: The subscription is paid for and active; **suspended**: The subscription is temporarily suspended; **canceled**: The subscription was canceled and will expire on expiration_date; **expired**: The subscription has expired.",
+                              "enum": [
+                                "purchased",
+                                "suspended",
+                                "canceled",
+                                "expired"
+                              ]
+                            },
+                            "cancellation_date": {
+                              "type": "string",
+                              "description": "The date when subscription was canceled",
+                              "format": "date-time"
+                            },
+                            "expiration_date": {
+                              "type": "string",
+                              "description": "The date when subscription will expire (or expired)",
+                              "format": "date-time"
+                            },
+                            "buyer_uid": {
+                              "type": "string",
+                              "description": "The actor of the action. typically, the staff uid"
+                            },
+                            "business_uid": {
+                              "type": "string",
+                              "description": "The business that the subscription relates to"
+                            },
+                            "original_price": {
+                              "type": "number",
+                              "description": "The standard offering price before any discounts. This represents the original price of the offering before coupon or discount application."
+                            },
+                            "purchase_price": {
+                              "type": [
+                                "number",
+                                "string"
+                              ],
+                              "description": "The actual amount charged to the customer at the moment of the subscription was created. When a discount is applied, this will differ from original_price. May return as a number or string (e.g., \"49.99\")."
+                            },
+                            "purchase_currency": {
+                              "type": "string",
+                              "description": "The purchase currency at the moment of the subscription was created. Currently supported currencies: USD; EUR; GPB.",
+                              "enum": [
+                                "USD",
+                                "EUR",
+                                "GBP"
+                              ]
+                            },
+                            "payment_type": {
+                              "type": "string",
+                              "description": "The payment type field defines the payment options available for an offering, **free**: No payment is required; **one_time**: A single, one-time payment is required to obtain the offering; **monthly**: A recurring payment made on a monthly basis; **annual**: A recurring payment made on a yearly basis; **bundle**: A subscription bundled with another subscription",
+                              "enum": [
+                                "monthly",
+                                "annual",
+                                "free",
+                                "single_charge",
+                                "bundle",
+                                "external",
+                                "external_single_charge"
+                              ]
+                            },
+                            "bundled_from_subscription_uid": {
+                              "type": "string",
+                              "description": "The subscription uid that this subscription is bundled from"
+                            },
+                            "charged_by": {
+                              "type": "string",
+                              "description": "Who charges for this subscription. **partner**: Transaction managed by partner; **platform**: Transaction managed within the platform's integral billing system",
+                              "enum": [
+                                "partner",
+                                "platform"
+                              ]
+                            },
+                            "trial_type": {
+                              "type": "string",
+                              "description": "Indicates whether this subscription was created with a trial. expire: subscription has a trial period and will expire when it ends. no_trial: subscription was created without a trial. automatic_charge: reserved for future use.",
+                              "enum": [
+                                "no_trial",
+                                "automatic_charge",
+                                "expire"
+                              ],
+                              "default": "no_trial"
+                            },
+                            "trial_period": {
+                              "type": "number",
+                              "readOnly": true,
+                              "description": "Number of days for the trial period. Copied from the offering at subscription creation time. 0 indicates no trial period.",
+                              "default": 0
+                            },
+                            "next_charge_date": {
+                              "type": "string",
+                              "format": "date-time",
+                              "description": "The start date of the next billing cycle. This property is `null` if the subscription is set to expire."
+                            },
+                            "quantity": {
+                              "type": "number",
+                              "description": "The number of units (e.g., staff seats, SMS messages, AI tokens) allocated under this offering, defining the quantity available for use during the subscription period. A value of `-1` indicates **unlimited** quantity — the resource has no usage cap. This value is inherited from the offering at subscription creation time.",
+                              "default": 1
+                            },
+                            "can_purchase_additional_seats": {
+                              "type": "boolean",
+                              "description": "Indicates if a business can purchase additional seats beyond the bundled subscription (default: True); if False, only the bundled seats are available.",
+                              "default": true
+                            },
+                            "sku": {
+                              "type": "string",
+                              "description": "The SKU (app/packageaddon unique code name) related to this subscription"
+                            },
+                            "discount_code_name": {
+                              "type": "string",
+                              "description": "String identifier for the coupon/discount type (e.g., 'percent', 'fixed_amount'). Used for tracking and reporting purposes."
+                            },
+                            "coupon_code": {
+                              "type": "string",
+                              "description": "Discount identifier used for tracking and Recurly integration. This is the coupon code that was applied to the subscription."
+                            }
+                          },
+                          "required": [
+                            "uid",
+                            "created_at",
+                            "updated_at",
+                            "display_name",
+                            "offering_uid",
+                            "buyer_uid",
+                            "business_uid",
+                            "purchase_price",
+                            "purchase_currency",
+                            "payment_type",
+                            "charged_by",
+                            "sku"
+                          ],
+                          "example": {
+                            "uid": "c33f32c-95ae-4e8f-9f65-18bba589cb43",
+                            "created_at": "2024-01-01T09:00:00Z",
+                            "updated_at": "2024-03-20T12:34:56Z",
+                            "display_name": "Premium 10",
+                            "sku": "premium_10",
+                            "is_active": true,
+                            "offering_uid": "bc33f12d-98ee-428f-9f65-18bba589cb95",
+                            "offering_type": "package",
+                            "purchase_state": "purchased",
+                            "cancellation_date": "",
+                            "expiration_date": "",
+                            "buyer_uid": "user_12345",
+                            "business_uid": "biz_67890",
+                            "original_price": 99.99,
+                            "purchase_price": 49.99,
+                            "purchase_currency": "USD",
+                            "payment_type": "monthly",
+                            "bundled_from_subscription_uid": "",
+                            "charged_by": "platform",
+                            "trial_type": "no_trial",
+                            "trial_period": 0,
+                            "next_charge_date": "2025-03-20T12:34:56Z",
+                            "quantity": 1,
+                            "can_purchase_additional_seats": true,
+                            "discount_code_name": null,
+                            "coupon_code": null
+                          },
+                          "description": "A subscription represents a purchased offering related to a business. It includes details such as the buyer, pricing, trial period, and the subscription's lifecycle state. Supports discounted and free plans using coupons, with tracking of both original and discounted prices."
                         }
                       }
                     }
@@ -1534,12 +3399,255 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/license/subscription.json"
+                          "type": "object",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "description": "The entity unique identifier",
+                              "x-security": [
+                                "Business"
+                              ]
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "description": "The creation date and time of the object",
+                              "format": "date-time"
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "description": "The last updated date and time of the object",
+                              "format": "date-time"
+                            },
+                            "display_name": {
+                              "type": "string",
+                              "description": "The subscription display name"
+                            },
+                            "is_active": {
+                              "type": "boolean",
+                              "description": "Calculated active subscription is when the subscription is not canceled and not expired"
+                            },
+                            "offering_uid": {
+                              "type": "string",
+                              "description": "The underlying directory offering uid"
+                            },
+                            "offering_type": {
+                              "type": "string",
+                              "description": "Category of the offering. Possible values include: **plan**: For the main business subscription; **app**: for marketplace app subscriptions; **SMS**: For text message offerings; **staff_seat**: For additional business seats.",
+                              "enum": [
+                                "package",
+                                "app",
+                                "sms",
+                                "staff_slot"
+                              ]
+                            },
+                            "purchase_state": {
+                              "type": "string",
+                              "description": "The current subscription state. **purchased**: The subscription is paid for and active; **suspended**: The subscription is temporarily suspended; **canceled**: The subscription was canceled and will expire on expiration_date; **expired**: The subscription has expired.",
+                              "enum": [
+                                "purchased",
+                                "suspended",
+                                "canceled",
+                                "expired"
+                              ]
+                            },
+                            "cancellation_date": {
+                              "type": "string",
+                              "description": "The date when subscription was canceled",
+                              "format": "date-time"
+                            },
+                            "expiration_date": {
+                              "type": "string",
+                              "description": "The date when subscription will expire (or expired)",
+                              "format": "date-time"
+                            },
+                            "buyer_uid": {
+                              "type": "string",
+                              "description": "The actor of the action. typically, the staff uid"
+                            },
+                            "business_uid": {
+                              "type": "string",
+                              "description": "The business that the subscription relates to"
+                            },
+                            "original_price": {
+                              "type": "number",
+                              "description": "The standard offering price before any discounts. This represents the original price of the offering before coupon or discount application."
+                            },
+                            "purchase_price": {
+                              "type": [
+                                "number",
+                                "string"
+                              ],
+                              "description": "The actual amount charged to the customer at the moment of the subscription was created. When a discount is applied, this will differ from original_price. May return as a number or string (e.g., \"49.99\")."
+                            },
+                            "purchase_currency": {
+                              "type": "string",
+                              "description": "The purchase currency at the moment of the subscription was created. Currently supported currencies: USD; EUR; GPB.",
+                              "enum": [
+                                "USD",
+                                "EUR",
+                                "GBP"
+                              ]
+                            },
+                            "payment_type": {
+                              "type": "string",
+                              "description": "The payment type field defines the payment options available for an offering, **free**: No payment is required; **one_time**: A single, one-time payment is required to obtain the offering; **monthly**: A recurring payment made on a monthly basis; **annual**: A recurring payment made on a yearly basis; **bundle**: A subscription bundled with another subscription",
+                              "enum": [
+                                "monthly",
+                                "annual",
+                                "free",
+                                "single_charge",
+                                "bundle",
+                                "external",
+                                "external_single_charge"
+                              ]
+                            },
+                            "bundled_from_subscription_uid": {
+                              "type": "string",
+                              "description": "The subscription uid that this subscription is bundled from"
+                            },
+                            "charged_by": {
+                              "type": "string",
+                              "description": "Who charges for this subscription. **partner**: Transaction managed by partner; **platform**: Transaction managed within the platform's integral billing system",
+                              "enum": [
+                                "partner",
+                                "platform"
+                              ]
+                            },
+                            "trial_type": {
+                              "type": "string",
+                              "description": "Indicates whether this subscription was created with a trial. expire: subscription has a trial period and will expire when it ends. no_trial: subscription was created without a trial. automatic_charge: reserved for future use.",
+                              "enum": [
+                                "no_trial",
+                                "automatic_charge",
+                                "expire"
+                              ],
+                              "default": "no_trial"
+                            },
+                            "trial_period": {
+                              "type": "number",
+                              "readOnly": true,
+                              "description": "Number of days for the trial period. Copied from the offering at subscription creation time. 0 indicates no trial period.",
+                              "default": 0
+                            },
+                            "next_charge_date": {
+                              "type": "string",
+                              "format": "date-time",
+                              "description": "The start date of the next billing cycle. This property is `null` if the subscription is set to expire."
+                            },
+                            "quantity": {
+                              "type": "number",
+                              "description": "The number of units (e.g., staff seats, SMS messages, AI tokens) allocated under this offering, defining the quantity available for use during the subscription period. A value of `-1` indicates **unlimited** quantity — the resource has no usage cap. This value is inherited from the offering at subscription creation time.",
+                              "default": 1
+                            },
+                            "can_purchase_additional_seats": {
+                              "type": "boolean",
+                              "description": "Indicates if a business can purchase additional seats beyond the bundled subscription (default: True); if False, only the bundled seats are available.",
+                              "default": true
+                            },
+                            "sku": {
+                              "type": "string",
+                              "description": "The SKU (app/packageaddon unique code name) related to this subscription"
+                            },
+                            "discount_code_name": {
+                              "type": "string",
+                              "description": "String identifier for the coupon/discount type (e.g., 'percent', 'fixed_amount'). Used for tracking and reporting purposes."
+                            },
+                            "coupon_code": {
+                              "type": "string",
+                              "description": "Discount identifier used for tracking and Recurly integration. This is the coupon code that was applied to the subscription."
+                            }
+                          },
+                          "required": [
+                            "uid",
+                            "created_at",
+                            "updated_at",
+                            "display_name",
+                            "offering_uid",
+                            "buyer_uid",
+                            "business_uid",
+                            "purchase_price",
+                            "purchase_currency",
+                            "payment_type",
+                            "charged_by",
+                            "sku"
+                          ],
+                          "example": {
+                            "uid": "c33f32c-95ae-4e8f-9f65-18bba589cb43",
+                            "created_at": "2024-01-01T09:00:00Z",
+                            "updated_at": "2024-03-20T12:34:56Z",
+                            "display_name": "Premium 10",
+                            "sku": "premium_10",
+                            "is_active": true,
+                            "offering_uid": "bc33f12d-98ee-428f-9f65-18bba589cb95",
+                            "offering_type": "package",
+                            "purchase_state": "purchased",
+                            "cancellation_date": "",
+                            "expiration_date": "",
+                            "buyer_uid": "user_12345",
+                            "business_uid": "biz_67890",
+                            "original_price": 99.99,
+                            "purchase_price": 49.99,
+                            "purchase_currency": "USD",
+                            "payment_type": "monthly",
+                            "bundled_from_subscription_uid": "",
+                            "charged_by": "platform",
+                            "trial_type": "no_trial",
+                            "trial_period": 0,
+                            "next_charge_date": "2025-03-20T12:34:56Z",
+                            "quantity": 1,
+                            "can_purchase_additional_seats": true,
+                            "discount_code_name": null,
+                            "coupon_code": null
+                          },
+                          "description": "A subscription represents a purchased offering related to a business. It includes details such as the buyer, pricing, trial period, and the subscription's lifecycle state. Supports discounted and free plans using coupons, with tracking of both original and discounted prices."
                         }
                       }
                     }
@@ -1600,7 +3708,86 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "https://vcita.github.io/developers-hub/entities/license/businessCart.json"
+                  "type": "object",
+                  "properties": {
+                    "uid": {
+                      "type": "string",
+                      "description": "Unique identifier for the entity",
+                      "format": "uuid"
+                    },
+                    "created_at": {
+                      "type": "string",
+                      "description": "Timestamp when the entity was created",
+                      "format": "date-time"
+                    },
+                    "updated_at": {
+                      "type": "string",
+                      "description": "Timestamp when the entity was last updated",
+                      "format": "date-time"
+                    },
+                    "business_uid": {
+                      "type": "string",
+                      "description": "Unique identifier of the business",
+                      "maxLength": 16
+                    },
+                    "business_cart_items": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "uid": {
+                            "type": "string",
+                            "description": "Unique identifier for the entity",
+                            "format": "uuid"
+                          },
+                          "created_at": {
+                            "type": "string",
+                            "description": "Timestamp when the entity was created",
+                            "format": "date-time"
+                          },
+                          "updated_at": {
+                            "type": "string",
+                            "description": "Timestamp when the entity was last updated",
+                            "format": "date-time"
+                          },
+                          "business_cart_uid": {
+                            "type": "string"
+                          },
+                          "offering_uid": {
+                            "type": "string"
+                          },
+                          "price": {
+                            "type": "number"
+                          },
+                          "currency": {
+                            "type": "string"
+                          },
+                          "Payment_type": {
+                            "type": "string"
+                          },
+                          "display_name": {
+                            "type": "string"
+                          },
+                          "subscription_uid": {
+                            "type": "string"
+                          },
+                          "description": "An item within a business cart referencing an offering, price, and subscription linkage."
+                        }
+                      }
+                    },
+                    "cart_total": {
+                      "type": "number",
+                      "description": "Calculated field"
+                    }
+                  },
+                  "required": [
+                    "uid",
+                    "business_uid",
+                    "created_at",
+                    "updated_at",
+                    "business_cart_items"
+                  ],
+                  "description": "A businessCart object represents a temporary collection of products, organized as cart items, that a business plans to purchase."
                 }
               }
             }
@@ -1637,7 +3824,86 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "https://vcita.github.io/developers-hub/entities/license/businessCart.json"
+                  "type": "object",
+                  "properties": {
+                    "uid": {
+                      "type": "string",
+                      "description": "Unique identifier for the entity",
+                      "format": "uuid"
+                    },
+                    "created_at": {
+                      "type": "string",
+                      "description": "Timestamp when the entity was created",
+                      "format": "date-time"
+                    },
+                    "updated_at": {
+                      "type": "string",
+                      "description": "Timestamp when the entity was last updated",
+                      "format": "date-time"
+                    },
+                    "business_uid": {
+                      "type": "string",
+                      "description": "Unique identifier of the business",
+                      "maxLength": 16
+                    },
+                    "business_cart_items": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "uid": {
+                            "type": "string",
+                            "description": "Unique identifier for the entity",
+                            "format": "uuid"
+                          },
+                          "created_at": {
+                            "type": "string",
+                            "description": "Timestamp when the entity was created",
+                            "format": "date-time"
+                          },
+                          "updated_at": {
+                            "type": "string",
+                            "description": "Timestamp when the entity was last updated",
+                            "format": "date-time"
+                          },
+                          "business_cart_uid": {
+                            "type": "string"
+                          },
+                          "offering_uid": {
+                            "type": "string"
+                          },
+                          "price": {
+                            "type": "number"
+                          },
+                          "currency": {
+                            "type": "string"
+                          },
+                          "Payment_type": {
+                            "type": "string"
+                          },
+                          "display_name": {
+                            "type": "string"
+                          },
+                          "subscription_uid": {
+                            "type": "string"
+                          },
+                          "description": "An item within a business cart referencing an offering, price, and subscription linkage."
+                        }
+                      }
+                    },
+                    "cart_total": {
+                      "type": "number",
+                      "description": "Calculated field"
+                    }
+                  },
+                  "required": [
+                    "uid",
+                    "business_uid",
+                    "created_at",
+                    "updated_at",
+                    "business_cart_items"
+                  ],
+                  "description": "A businessCart object represents a temporary collection of products, organized as cart items, that a business plans to purchase."
                 }
               }
             }
@@ -1726,7 +3992,50 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
@@ -1805,7 +4114,50 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
@@ -1989,7 +4341,183 @@
                         "businesses": {
                           "type": "array",
                           "items": {
-                            "$ref": "https://vcita.github.io/developers-hub/entities/business_administration/business.json"
+                            "type": "object",
+                            "description": "Represents a business account, including identity, ownership, contact information, and subscription details.",
+                            "required": [
+                              "uid",
+                              "name"
+                            ],
+                            "properties": {
+                              "uid": {
+                                "type": "string",
+                                "readOnly": true,
+                                "description": "Unique identifier for the business."
+                              },
+                              "directory_uid": {
+                                "type": "string",
+                                "description": "Unique identifier of the directory this business belongs to."
+                              },
+                              "is_template": {
+                                "type": "boolean",
+                                "description": "Indicates whether this account is used as a template within the directory. Template accounts are not live businesses — they serve as a base configuration for creating new accounts under the directory."
+                              },
+                              "name": {
+                                "type": "string",
+                                "description": "The business name."
+                              },
+                              "business_category": {
+                                "type": "string",
+                                "description": "The business's primary occupation, identified by a profession code (e.g. \"health_wellness\", \"home_services\", \"legal_services\")."
+                              },
+                              "identities": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "uniqueItems": true,
+                                "description": "List of occupational vertical UIDs associated with the business."
+                              },
+                              "tags": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "uniqueItems": true,
+                                "description": "Free-form tags assigned to the business by the directory. Used to differentiate and group accounts (e.g. by franchise, tier, region, or account type). Tags are directory-defined and have no enforced schema."
+                              },
+                              "external_reference_id": {
+                                "type": "string",
+                                "description": "Unique identifier for the business in the directory's external system. Set by the directory at creation time."
+                              },
+                              "reference_id": {
+                                "type": "string",
+                                "description": "Secondary external reference identifier for the business, used for additional partner-system mapping."
+                              },
+                              "business_maturity_in_years": {
+                                "type": "string",
+                                "nullable": true,
+                                "enum": [
+                                  null,
+                                  "0",
+                                  "0.5",
+                                  "0.5-2",
+                                  "2+"
+                                ],
+                                "description": "How long the business has been operating. Use null for unspecified, \"0\" for brand new, \"0.5\" for less than a year, \"0.5-2\" for one to two years, \"2+\" for more than two years."
+                              },
+                              "short_description": {
+                                "type": "string",
+                                "description": "A brief description of the business. Up to 255 characters."
+                              },
+                              "owner_uid": {
+                                "type": "string",
+                                "description": "Unique identifier of the staff member who is the business owner."
+                              },
+                              "owner_email": {
+                                "type": "string",
+                                "format": "email",
+                                "description": "Email address of the business owner."
+                              },
+                              "phone": {
+                                "type": "string",
+                                "description": "Business phone number. Up to 20 characters."
+                              },
+                              "address": {
+                                "type": "string",
+                                "description": "Physical address of the business."
+                              },
+                              "hide_address": {
+                                "type": "boolean",
+                                "description": "Whether the business address is hidden from clients."
+                              },
+                              "country_name": {
+                                "type": "string",
+                                "description": "The country where the business is located (e.g. \"United States\")."
+                              },
+                              "website_url": {
+                                "type": "string",
+                                "format": "uri",
+                                "description": "URL of the business website."
+                              },
+                              "time_zone": {
+                                "type": "string",
+                                "description": "The business's time zone using Rails time zone name conventions (e.g. \"Eastern Time (US & Canada)\")."
+                              },
+                              "locale": {
+                                "type": "string",
+                                "description": "The locale/language code for the business (e.g. \"en\", \"es\", \"fr\")."
+                              },
+                              "time_format": {
+                                "type": "string",
+                                "enum": [
+                                  "12h",
+                                  "24h"
+                                ],
+                                "description": "The time display format used by the business. Either \"12h\" (e.g. 2:30 PM) or \"24h\" (e.g. 14:30)."
+                              },
+                              "current_package": {
+                                "type": "string",
+                                "readOnly": true,
+                                "description": "The business's current subscription package or plan identifier."
+                              },
+                              "in_setup": {
+                                "type": "boolean",
+                                "nullable": true,
+                                "description": "Indicates whether the business account is still in setup (onboarding) mode. When `true`, the account has not yet completed onboarding and is not live — sales operators can impersonate the account. When `false`, setup is complete, the account is live, and operator impersonation is no longer permitted. `null` when the business has no directory membership."
+                              },
+                              "account_blocked_at": {
+                                "type": "string",
+                                "format": "date-time",
+                                "readOnly": true,
+                                "description": "The date and time when the business account was blocked, in ISO 8601 format. Null if the account is active."
+                              },
+                              "created_at": {
+                                "type": "string",
+                                "format": "date-time",
+                                "readOnly": true,
+                                "description": "The date and time when the business was created, in ISO 8601 format."
+                              },
+                              "updated_at": {
+                                "type": "string",
+                                "format": "date-time",
+                                "readOnly": true,
+                                "description": "The date and time when the business was last updated, in ISO 8601 format."
+                              }
+                            },
+                            "example": {
+                              "uid": "b_a1b2c3d4e5f6",
+                              "directory_uid": "dir_x9y8z7w6v5",
+                              "is_template": false,
+                              "name": "Green Leaf Wellness",
+                              "business_category": "health_wellness",
+                              "identities": [
+                                "vert_yoga",
+                                "vert_nutrition"
+                              ],
+                              "tags": [
+                                "franchise-east",
+                                "vip"
+                              ],
+                              "external_reference_id": "partner-biz-98765",
+                              "reference_id": "crm-ref-00123",
+                              "business_maturity_in_years": "2+",
+                              "short_description": "A holistic wellness center offering yoga, meditation, and nutrition coaching.",
+                              "owner_uid": "staff_q1r2s3t4u5",
+                              "owner_email": "jane.doe@greenleafwellness.com",
+                              "phone": "+15551234567",
+                              "address": "456 Elm Street, Suite 3, Austin, TX 78701",
+                              "hide_address": false,
+                              "country_name": "United States",
+                              "website_url": "https://www.greenleafwellness.com",
+                              "time_zone": "Central Time (US & Canada)",
+                              "locale": "en",
+                              "time_format": "12h",
+                              "current_package": "essential",
+                              "in_setup": false,
+                              "account_blocked_at": null,
+                              "created_at": "2023-03-15T10:00:00Z",
+                              "updated_at": "2024-11-20T14:35:22Z"
+                            }
                           }
                         }
                       }
@@ -6306,7 +8834,545 @@
                       "type": "boolean"
                     },
                     "data": {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/business_administration/directory.json"
+                      "type": "object",
+                      "description": "Defines a partner directory (brand/tenant) and its core configuration and URLs.",
+                      "properties": {
+                        "id": {
+                          "type": "integer",
+                          "description": "Internal ID for the directory."
+                        },
+                        "uid": {
+                          "type": "string",
+                          "description": "Unique identifier for the directory."
+                        },
+                        "name": {
+                          "type": "string",
+                          "description": "Name of the directory. Used only internally."
+                        },
+                        "partner_name": {
+                          "type": "string",
+                          "description": "Partner-facing display name for the directory (e.g., \"samplepartner\")."
+                        },
+                        "parent_directory_id": {
+                          "type": "integer",
+                          "description": "ID of the parent directory, if this directory is a child of another directory. Null if top-level.",
+                          "nullable": true
+                        },
+                        "admin_email": {
+                          "type": "string",
+                          "format": "email",
+                          "description": "Administrative contact email for the directory (e.g., \"samplepartner@vcita.com\")."
+                        },
+                        "billing_type": {
+                          "type": "string",
+                          "description": "Billing type for the directory.",
+                          "enum": [
+                            "recurly",
+                            "manual"
+                          ]
+                        },
+                        "manual_type": {
+                          "type": "string",
+                          "description": "Manual type of the directory. Use this to ensure Solution Provider / White Label features even if the directory owner didn't pay for it or there was a payment issue.",
+                          "enum": [
+                            "solution_provider",
+                            "white_label",
+                            "co_branded"
+                          ],
+                          "nullable": true
+                        },
+                        "configuration_key": {
+                          "type": "string",
+                          "description": "Configuration key for the directory."
+                        },
+                        "branding_theme_id": {
+                          "type": "string",
+                          "description": "ID of the branding theme applied to the directory.",
+                          "nullable": true
+                        },
+                        "management_theme_id": {
+                          "type": "string",
+                          "description": "ID of the management theme applied to the directory (e.g., \"2366701\").",
+                          "nullable": true
+                        },
+                        "management_theme_attributes": {
+                          "type": "object",
+                          "description": "Attributes for the management theme associated with the directory.",
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "description": "ID of the management theme."
+                            },
+                            "logo_url": {
+                              "type": "string",
+                              "description": "URL of the logo used in the management theme.",
+                              "nullable": true
+                            }
+                          }
+                        },
+                        "is_managed": {
+                          "type": "boolean",
+                          "description": "Indicates if the directory is managed by a partner. Relevant for reports only."
+                        },
+                        "is_deprecated": {
+                          "type": "boolean",
+                          "description": "Indicates if the directory is deprecated."
+                        },
+                        "is_slim_register_enabled": {
+                          "type": "boolean",
+                          "description": "Indicates if slim registration mode is enabled during onboarding."
+                        },
+                        "locale": {
+                          "type": "string",
+                          "description": "Default locale for the directory."
+                        },
+                        "time_zone": {
+                          "type": "string",
+                          "description": "Default time zone for the directory."
+                        },
+                        "paypal_email": {
+                          "type": "string",
+                          "description": "PayPal email for the directory."
+                        },
+                        "rev_share": {
+                          "type": "number",
+                          "description": "Revenue share percentage (e.g., 20)."
+                        },
+                        "rev_share_tier2": {
+                          "type": "number",
+                          "description": "Revenue share percentage for tier 2.",
+                          "nullable": true
+                        },
+                        "only_owner_login_redirect": {
+                          "type": "boolean",
+                          "description": "When true, only the business owner is redirected to the logout URL on logout. When false and logout URL is defined, all logged-out users are redirected."
+                        },
+                        "paid_total": {
+                          "type": "string",
+                          "description": "Total paid amount."
+                        },
+                        "custom_sms_sending_phone_number": {
+                          "type": "string",
+                          "description": "Custom SMS sending phone number."
+                        },
+                        "features": {
+                          "type": "object",
+                          "description": "Feature flags for the directory."
+                        },
+                        "features_info": {
+                          "type": "object",
+                          "description": "Additional feature information."
+                        },
+                        "settings": {
+                          "type": "object",
+                          "description": "Directory settings and configuration options.",
+                          "properties": {
+                            "block_external_app_uninstall": {
+                              "type": "boolean",
+                              "description": "When enabled, apps purchased via API (payment_type: external) cannot be uninstalled from the App Market."
+                            },
+                            "static_page_data": {
+                              "oneOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "url": {
+                                      "type": "string"
+                                    },
+                                    "url_params": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                }
+                              ],
+                              "description": "Static page configuration data. Must use the same subdomain as the directory."
+                            },
+                            "myaccount_page_url": {
+                              "type": "string",
+                              "description": "My account page URL."
+                            },
+                            "managed_login_url": {
+                              "type": "string",
+                              "description": "Managed login URL for SSO (e.g., \"https://one.samplepartner.com/authbridge/oauth/login\")."
+                            },
+                            "new_staff_url": {
+                              "type": "string",
+                              "description": "URL for adding new staff members."
+                            },
+                            "change_password_url": {
+                              "type": "string",
+                              "description": "URL for password change (e.g., \"https://auth.samplepartner.com/forgot_password?origin_uri=https://one.samplepartner.com/\")."
+                            },
+                            "use_login_with_code": {
+                              "type": "boolean",
+                              "description": "Whether login with code is enabled."
+                            },
+                            "op_support_url": {
+                              "type": "string",
+                              "description": "Operator support page URL."
+                            },
+                            "privacy_policy": {
+                              "type": "string",
+                              "description": "Privacy policy URL. If left blank, the default URL is intandem.vcita.com/privacy-policy."
+                            },
+                            "terms_of_service": {
+                              "type": "string",
+                              "description": "Terms of service URL. If left blank, the default URL is intandem.vcita.com/terms-of-service."
+                            },
+                            "compliance_in_billing_app": {
+                              "type": "boolean",
+                              "description": "Whether TOS and privacy policy are visible in the billing app."
+                            },
+                            "enable_upgrade_page_tab": {
+                              "type": "string",
+                              "description": "Whether the upgrade page opens in a new tab (\"0\" = disabled, \"1\" = enabled)."
+                            },
+                            "enable_separate_payment_method": {
+                              "type": "string",
+                              "description": "Whether a separate payment method section is enabled for add-on purchases. Hides the payment method tab and adds a section on the purchased add-ons page (\"0\" = disabled, \"1\" = enabled)."
+                            },
+                            "external_review_site": {
+                              "type": "object",
+                              "description": "External review site configuration.",
+                              "properties": {
+                                "url": {
+                                  "type": "string",
+                                  "description": "Review site URL."
+                                },
+                                "label": {
+                                  "type": "string",
+                                  "description": "Review site display name."
+                                }
+                              }
+                            },
+                            "revshare_coupon": {
+                              "type": "string",
+                              "description": "Revenue share coupon code."
+                            },
+                            "app_market_url": {
+                              "type": "string",
+                              "description": "Custom app market URL."
+                            },
+                            "ada_handle": {
+                              "type": "string",
+                              "description": "ADA chatbot handle code configured in ada.support. Each partner has a separate ADA dashboard (e.g., \"samplepartner\")."
+                            },
+                            "pendo": {
+                              "type": "string",
+                              "description": "Pendo analytics data/configuration for the directory.",
+                              "nullable": true
+                            },
+                            "chatbot": {
+                              "type": "string",
+                              "description": "Custom chatbot HTML snippet injected into the directory pages.",
+                              "nullable": true
+                            }
+                          }
+                        },
+                        "welcome_engagement_params": {
+                          "type": "object",
+                          "description": "Welcome engagement parameters.",
+                          "nullable": true
+                        },
+                        "invite_subject": {
+                          "type": "string",
+                          "description": "Email subject for invitations."
+                        },
+                        "invite_body": {
+                          "type": "string",
+                          "description": "Email body for invitations."
+                        },
+                        "is_unsubscribe_sms": {
+                          "type": "boolean",
+                          "description": "Indicates if unsubscribe text is added to SMS messages."
+                        },
+                        "is_disable_analytics": {
+                          "type": "boolean",
+                          "description": "Indicates if analytics are disabled."
+                        },
+                        "content_business_id": {
+                          "type": "integer",
+                          "description": "Content business ID."
+                        },
+                        "is_content_manager_enabled": {
+                          "type": "boolean",
+                          "description": "Indicates if the directory is added to Verticalization (content manager)."
+                        },
+                        "is_user_identity_manager_enabled": {
+                          "type": "boolean",
+                          "description": "Indicates if the directory manages user identities."
+                        },
+                        "ultimate_monthly_subscription_id": {
+                          "type": "integer",
+                          "description": "Ultimate monthly subscription ID."
+                        },
+                        "ultimate_annual_subscription_id": {
+                          "type": "integer",
+                          "description": "Ultimate annual subscription ID."
+                        },
+                        "subscriptions_mismatch_at": {
+                          "type": "string",
+                          "format": "date-time",
+                          "description": "Timestamp of subscription mismatch."
+                        },
+                        "white_label_subscription_id": {
+                          "type": "integer",
+                          "description": "White label subscription ID."
+                        },
+                        "current_subscription_id": {
+                          "type": "integer",
+                          "description": "Current subscription ID."
+                        },
+                        "pending_member_id": {
+                          "type": "integer",
+                          "description": "Pending member ID."
+                        },
+                        "default_package_id": {
+                          "type": "integer",
+                          "description": "Default package ID assigned to new businesses in this directory."
+                        },
+                        "is_default_self_paid": {
+                          "type": "boolean",
+                          "description": "Indicates if default self paid is enabled."
+                        },
+                        "redeem_state": {
+                          "type": "string",
+                          "description": "Redeem state."
+                        },
+                        "mobile_app_name": {
+                          "type": "string",
+                          "description": "Mobile app name."
+                        },
+                        "mobile_app_ios": {
+                          "type": "string",
+                          "description": "iOS mobile app URL."
+                        },
+                        "mobile_app_android": {
+                          "type": "string",
+                          "description": "Android mobile app URL."
+                        },
+                        "email_template_owner_uid": {
+                          "type": "string",
+                          "description": "Email template owner UID."
+                        },
+                        "urls": {
+                          "type": "object",
+                          "description": "Collection of setup URLs related to the directory.",
+                          "properties": {
+                            "home_url": {
+                              "type": "string",
+                              "description": "Home URL for the directory (e.g., \"https://www.samplepartner.com/\")."
+                            },
+                            "support_url": {
+                              "type": "string",
+                              "description": "Support URL for the directory."
+                            },
+                            "faq_url": {
+                              "type": "string",
+                              "description": "FAQ URL for the directory."
+                            },
+                            "login_url": {
+                              "type": "string",
+                              "description": "Logout redirect URL for the directory. Despite the field name, this is the URL users are redirected to upon logout."
+                            },
+                            "signup_url": {
+                              "type": "string",
+                              "description": "Signup URL for the directory."
+                            },
+                            "upgrade_page_url": {
+                              "type": "string",
+                              "description": "Upgrade page URL for the directory."
+                            },
+                            "cancel_page_url": {
+                              "type": "string",
+                              "description": "Cancel page URL for the directory."
+                            },
+                            "sms_purchase_url": {
+                              "type": "string",
+                              "description": "SMS purchase URL for the directory."
+                            },
+                            "backoffice_url": {
+                              "type": "string",
+                              "description": "Operator Portal Backoffice URL for the directory."
+                            }
+                          }
+                        },
+                        "domain_hosting": {
+                          "type": "object",
+                          "description": "Domain and hosting configuration for the directory's whitelabel setup.",
+                          "properties": {
+                            "subdomain": {
+                              "type": "string",
+                              "description": "The subdomain for the directory. Available at subdomain.vcita.com (or subdomain.myclients.io). Required in order to configure host-mapping DNS (e.g., \"samplepartner\")."
+                            },
+                            "whitelabel_subdomain": {
+                              "type": "boolean",
+                              "description": "When true, forces the whitelabel domain (subdomain.myclients.io) if host mapping is not configured."
+                            },
+                            "host_mapping": {
+                              "type": "string",
+                              "description": "The whitelabel host for the directory. The vendor must configure the DNS record to point to the configured subdomain.vcita.com or subdomain.myclients.io (e.g., \"www.samplepartner.ch\").",
+                              "nullable": true
+                            },
+                            "ssl_enabled": {
+                              "type": "boolean",
+                              "description": "When true, an SSL certificate has been deployed for the host mapping and all traffic is force-redirected to HTTPS."
+                            },
+                            "old_host_mapping": {
+                              "type": "string",
+                              "description": "The previous whitelabel host mapping. Used to redirect to myclients.io when the host mapping is removed.",
+                              "nullable": true
+                            },
+                            "host_mapping_verified_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "description": "Timestamp when the host mapping DNS was last verified.",
+                              "nullable": true
+                            }
+                          }
+                        },
+                        "configs": {
+                          "type": "array",
+                          "description": "Directory-level configuration flags that control behavior and categorization.",
+                          "items": {
+                            "type": "string",
+                            "enum": [
+                              "is_vcita_marketing",
+                              "is_vcita_sales",
+                              "is_vcita_cs",
+                              "is_vcita_support",
+                              "is_default_rollout",
+                              "is_managed_partner",
+                              "is_sandbox",
+                              "send_confirmation_email"
+                            ]
+                          },
+                          "uniqueItems": true
+                        },
+                        "created_at": {
+                          "type": "string",
+                          "format": "date-time",
+                          "description": "Timestamp when the directory was created."
+                        },
+                        "updated_at": {
+                          "type": "string",
+                          "format": "date-time",
+                          "description": "Timestamp when the directory was last updated."
+                        }
+                      },
+                      "required": [
+                        "uid",
+                        "name",
+                        "created_at",
+                        "updated_at"
+                      ],
+                      "example": {
+                        "id": 20338,
+                        "uid": "dir-20338",
+                        "name": "samplepartner",
+                        "partner_name": "samplepartner",
+                        "parent_directory_id": null,
+                        "admin_email": "samplepartner@vcita.com",
+                        "billing_type": "manual",
+                        "manual_type": "co_branded",
+                        "configuration_key": "samplepartner",
+                        "branding_theme_id": null,
+                        "management_theme_id": "2366701",
+                        "management_theme_attributes": {
+                          "id": "2366701",
+                          "logo_url": ""
+                        },
+                        "is_managed": true,
+                        "is_deprecated": false,
+                        "is_slim_register_enabled": false,
+                        "locale": "en",
+                        "time_zone": "America/New_York",
+                        "paypal_email": "",
+                        "rev_share": 20,
+                        "rev_share_tier2": null,
+                        "only_owner_login_redirect": false,
+                        "paid_total": null,
+                        "custom_sms_sending_phone_number": null,
+                        "features": null,
+                        "features_info": {
+                          "524": "available",
+                          "649": "available"
+                        },
+                        "settings": {
+                          "static_page_data": "",
+                          "myaccount_page_url": "",
+                          "managed_login_url": "https://one.samplepartner.com/authbridge/oauth/login",
+                          "new_staff_url": "",
+                          "change_password_url": "https://auth.samplepartner.com/forgot_password?origin_uri=https://one.samplepartner.com/",
+                          "use_login_with_code": false,
+                          "op_support_url": "",
+                          "privacy_policy": "",
+                          "terms_of_service": "",
+                          "compliance_in_billing_app": true,
+                          "enable_upgrade_page_tab": "1",
+                          "enable_separate_payment_method": "0",
+                          "external_review_site": null,
+                          "ada_handle": "samplepartner",
+                          "revshare_coupon": "PARTNER20OFF",
+                          "app_market_url": "https://apps.samplepartner.com/market",
+                          "block_external_app_uninstall": false,
+                          "pendo": "",
+                          "chatbot": ""
+                        },
+                        "welcome_engagement_params": null,
+                        "invite_subject": null,
+                        "invite_body": null,
+                        "is_unsubscribe_sms": false,
+                        "is_disable_analytics": null,
+                        "content_business_id": null,
+                        "is_content_manager_enabled": false,
+                        "is_user_identity_manager_enabled": true,
+                        "ultimate_monthly_subscription_id": null,
+                        "ultimate_annual_subscription_id": null,
+                        "subscriptions_mismatch_at": null,
+                        "white_label_subscription_id": null,
+                        "current_subscription_id": null,
+                        "pending_member_id": null,
+                        "default_package_id": 243,
+                        "is_default_self_paid": true,
+                        "redeem_state": null,
+                        "mobile_app_name": "",
+                        "mobile_app_ios": "",
+                        "mobile_app_android": "",
+                        "email_template_owner_uid": "",
+                        "urls": {
+                          "home_url": "https://home.example.com",
+                          "support_url": "https://support.example.com",
+                          "faq_url": "https://faq.example.com",
+                          "login_url": "https://login.example.com",
+                          "signup_url": "https://signup.example.com",
+                          "upgrade_page_url": "https://upgrade.example.com",
+                          "cancel_page_url": "https://cancel.example.com",
+                          "sms_purchase_url": "https://sms.example.com",
+                          "backoffice_url": "https://backoffice.example.com"
+                        },
+                        "domain_hosting": {
+                          "subdomain": "samplepartner",
+                          "whitelabel_subdomain": true,
+                          "host_mapping": "one.samplepartner.com",
+                          "ssl_enabled": true,
+                          "old_host_mapping": null,
+                          "host_mapping_verified_at": "2025-01-20T17:56:00Z"
+                        },
+                        "configs": [
+                          "is_vcita_marketing",
+                          "is_default_rollout",
+                          "is_managed_partner"
+                        ],
+                        "created_at": "2023-08-01T12:00:00Z",
+                        "updated_at": "2023-10-01T12:00:00Z"
+                      }
                     }
                   }
                 }
@@ -6447,7 +9513,545 @@
                         "directories": {
                           "type": "array",
                           "items": {
-                            "$ref": "https://vcita.github.io/developers-hub/entities/business_administration/directory.json"
+                            "type": "object",
+                            "description": "Defines a partner directory (brand/tenant) and its core configuration and URLs.",
+                            "properties": {
+                              "id": {
+                                "type": "integer",
+                                "description": "Internal ID for the directory."
+                              },
+                              "uid": {
+                                "type": "string",
+                                "description": "Unique identifier for the directory."
+                              },
+                              "name": {
+                                "type": "string",
+                                "description": "Name of the directory. Used only internally."
+                              },
+                              "partner_name": {
+                                "type": "string",
+                                "description": "Partner-facing display name for the directory (e.g., \"samplepartner\")."
+                              },
+                              "parent_directory_id": {
+                                "type": "integer",
+                                "description": "ID of the parent directory, if this directory is a child of another directory. Null if top-level.",
+                                "nullable": true
+                              },
+                              "admin_email": {
+                                "type": "string",
+                                "format": "email",
+                                "description": "Administrative contact email for the directory (e.g., \"samplepartner@vcita.com\")."
+                              },
+                              "billing_type": {
+                                "type": "string",
+                                "description": "Billing type for the directory.",
+                                "enum": [
+                                  "recurly",
+                                  "manual"
+                                ]
+                              },
+                              "manual_type": {
+                                "type": "string",
+                                "description": "Manual type of the directory. Use this to ensure Solution Provider / White Label features even if the directory owner didn't pay for it or there was a payment issue.",
+                                "enum": [
+                                  "solution_provider",
+                                  "white_label",
+                                  "co_branded"
+                                ],
+                                "nullable": true
+                              },
+                              "configuration_key": {
+                                "type": "string",
+                                "description": "Configuration key for the directory."
+                              },
+                              "branding_theme_id": {
+                                "type": "string",
+                                "description": "ID of the branding theme applied to the directory.",
+                                "nullable": true
+                              },
+                              "management_theme_id": {
+                                "type": "string",
+                                "description": "ID of the management theme applied to the directory (e.g., \"2366701\").",
+                                "nullable": true
+                              },
+                              "management_theme_attributes": {
+                                "type": "object",
+                                "description": "Attributes for the management theme associated with the directory.",
+                                "properties": {
+                                  "id": {
+                                    "type": "string",
+                                    "description": "ID of the management theme."
+                                  },
+                                  "logo_url": {
+                                    "type": "string",
+                                    "description": "URL of the logo used in the management theme.",
+                                    "nullable": true
+                                  }
+                                }
+                              },
+                              "is_managed": {
+                                "type": "boolean",
+                                "description": "Indicates if the directory is managed by a partner. Relevant for reports only."
+                              },
+                              "is_deprecated": {
+                                "type": "boolean",
+                                "description": "Indicates if the directory is deprecated."
+                              },
+                              "is_slim_register_enabled": {
+                                "type": "boolean",
+                                "description": "Indicates if slim registration mode is enabled during onboarding."
+                              },
+                              "locale": {
+                                "type": "string",
+                                "description": "Default locale for the directory."
+                              },
+                              "time_zone": {
+                                "type": "string",
+                                "description": "Default time zone for the directory."
+                              },
+                              "paypal_email": {
+                                "type": "string",
+                                "description": "PayPal email for the directory."
+                              },
+                              "rev_share": {
+                                "type": "number",
+                                "description": "Revenue share percentage (e.g., 20)."
+                              },
+                              "rev_share_tier2": {
+                                "type": "number",
+                                "description": "Revenue share percentage for tier 2.",
+                                "nullable": true
+                              },
+                              "only_owner_login_redirect": {
+                                "type": "boolean",
+                                "description": "When true, only the business owner is redirected to the logout URL on logout. When false and logout URL is defined, all logged-out users are redirected."
+                              },
+                              "paid_total": {
+                                "type": "string",
+                                "description": "Total paid amount."
+                              },
+                              "custom_sms_sending_phone_number": {
+                                "type": "string",
+                                "description": "Custom SMS sending phone number."
+                              },
+                              "features": {
+                                "type": "object",
+                                "description": "Feature flags for the directory."
+                              },
+                              "features_info": {
+                                "type": "object",
+                                "description": "Additional feature information."
+                              },
+                              "settings": {
+                                "type": "object",
+                                "description": "Directory settings and configuration options.",
+                                "properties": {
+                                  "block_external_app_uninstall": {
+                                    "type": "boolean",
+                                    "description": "When enabled, apps purchased via API (payment_type: external) cannot be uninstalled from the App Market."
+                                  },
+                                  "static_page_data": {
+                                    "oneOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "url": {
+                                            "type": "string"
+                                          },
+                                          "url_params": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "string"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    ],
+                                    "description": "Static page configuration data. Must use the same subdomain as the directory."
+                                  },
+                                  "myaccount_page_url": {
+                                    "type": "string",
+                                    "description": "My account page URL."
+                                  },
+                                  "managed_login_url": {
+                                    "type": "string",
+                                    "description": "Managed login URL for SSO (e.g., \"https://one.samplepartner.com/authbridge/oauth/login\")."
+                                  },
+                                  "new_staff_url": {
+                                    "type": "string",
+                                    "description": "URL for adding new staff members."
+                                  },
+                                  "change_password_url": {
+                                    "type": "string",
+                                    "description": "URL for password change (e.g., \"https://auth.samplepartner.com/forgot_password?origin_uri=https://one.samplepartner.com/\")."
+                                  },
+                                  "use_login_with_code": {
+                                    "type": "boolean",
+                                    "description": "Whether login with code is enabled."
+                                  },
+                                  "op_support_url": {
+                                    "type": "string",
+                                    "description": "Operator support page URL."
+                                  },
+                                  "privacy_policy": {
+                                    "type": "string",
+                                    "description": "Privacy policy URL. If left blank, the default URL is intandem.vcita.com/privacy-policy."
+                                  },
+                                  "terms_of_service": {
+                                    "type": "string",
+                                    "description": "Terms of service URL. If left blank, the default URL is intandem.vcita.com/terms-of-service."
+                                  },
+                                  "compliance_in_billing_app": {
+                                    "type": "boolean",
+                                    "description": "Whether TOS and privacy policy are visible in the billing app."
+                                  },
+                                  "enable_upgrade_page_tab": {
+                                    "type": "string",
+                                    "description": "Whether the upgrade page opens in a new tab (\"0\" = disabled, \"1\" = enabled)."
+                                  },
+                                  "enable_separate_payment_method": {
+                                    "type": "string",
+                                    "description": "Whether a separate payment method section is enabled for add-on purchases. Hides the payment method tab and adds a section on the purchased add-ons page (\"0\" = disabled, \"1\" = enabled)."
+                                  },
+                                  "external_review_site": {
+                                    "type": "object",
+                                    "description": "External review site configuration.",
+                                    "properties": {
+                                      "url": {
+                                        "type": "string",
+                                        "description": "Review site URL."
+                                      },
+                                      "label": {
+                                        "type": "string",
+                                        "description": "Review site display name."
+                                      }
+                                    }
+                                  },
+                                  "revshare_coupon": {
+                                    "type": "string",
+                                    "description": "Revenue share coupon code."
+                                  },
+                                  "app_market_url": {
+                                    "type": "string",
+                                    "description": "Custom app market URL."
+                                  },
+                                  "ada_handle": {
+                                    "type": "string",
+                                    "description": "ADA chatbot handle code configured in ada.support. Each partner has a separate ADA dashboard (e.g., \"samplepartner\")."
+                                  },
+                                  "pendo": {
+                                    "type": "string",
+                                    "description": "Pendo analytics data/configuration for the directory.",
+                                    "nullable": true
+                                  },
+                                  "chatbot": {
+                                    "type": "string",
+                                    "description": "Custom chatbot HTML snippet injected into the directory pages.",
+                                    "nullable": true
+                                  }
+                                }
+                              },
+                              "welcome_engagement_params": {
+                                "type": "object",
+                                "description": "Welcome engagement parameters.",
+                                "nullable": true
+                              },
+                              "invite_subject": {
+                                "type": "string",
+                                "description": "Email subject for invitations."
+                              },
+                              "invite_body": {
+                                "type": "string",
+                                "description": "Email body for invitations."
+                              },
+                              "is_unsubscribe_sms": {
+                                "type": "boolean",
+                                "description": "Indicates if unsubscribe text is added to SMS messages."
+                              },
+                              "is_disable_analytics": {
+                                "type": "boolean",
+                                "description": "Indicates if analytics are disabled."
+                              },
+                              "content_business_id": {
+                                "type": "integer",
+                                "description": "Content business ID."
+                              },
+                              "is_content_manager_enabled": {
+                                "type": "boolean",
+                                "description": "Indicates if the directory is added to Verticalization (content manager)."
+                              },
+                              "is_user_identity_manager_enabled": {
+                                "type": "boolean",
+                                "description": "Indicates if the directory manages user identities."
+                              },
+                              "ultimate_monthly_subscription_id": {
+                                "type": "integer",
+                                "description": "Ultimate monthly subscription ID."
+                              },
+                              "ultimate_annual_subscription_id": {
+                                "type": "integer",
+                                "description": "Ultimate annual subscription ID."
+                              },
+                              "subscriptions_mismatch_at": {
+                                "type": "string",
+                                "format": "date-time",
+                                "description": "Timestamp of subscription mismatch."
+                              },
+                              "white_label_subscription_id": {
+                                "type": "integer",
+                                "description": "White label subscription ID."
+                              },
+                              "current_subscription_id": {
+                                "type": "integer",
+                                "description": "Current subscription ID."
+                              },
+                              "pending_member_id": {
+                                "type": "integer",
+                                "description": "Pending member ID."
+                              },
+                              "default_package_id": {
+                                "type": "integer",
+                                "description": "Default package ID assigned to new businesses in this directory."
+                              },
+                              "is_default_self_paid": {
+                                "type": "boolean",
+                                "description": "Indicates if default self paid is enabled."
+                              },
+                              "redeem_state": {
+                                "type": "string",
+                                "description": "Redeem state."
+                              },
+                              "mobile_app_name": {
+                                "type": "string",
+                                "description": "Mobile app name."
+                              },
+                              "mobile_app_ios": {
+                                "type": "string",
+                                "description": "iOS mobile app URL."
+                              },
+                              "mobile_app_android": {
+                                "type": "string",
+                                "description": "Android mobile app URL."
+                              },
+                              "email_template_owner_uid": {
+                                "type": "string",
+                                "description": "Email template owner UID."
+                              },
+                              "urls": {
+                                "type": "object",
+                                "description": "Collection of setup URLs related to the directory.",
+                                "properties": {
+                                  "home_url": {
+                                    "type": "string",
+                                    "description": "Home URL for the directory (e.g., \"https://www.samplepartner.com/\")."
+                                  },
+                                  "support_url": {
+                                    "type": "string",
+                                    "description": "Support URL for the directory."
+                                  },
+                                  "faq_url": {
+                                    "type": "string",
+                                    "description": "FAQ URL for the directory."
+                                  },
+                                  "login_url": {
+                                    "type": "string",
+                                    "description": "Logout redirect URL for the directory. Despite the field name, this is the URL users are redirected to upon logout."
+                                  },
+                                  "signup_url": {
+                                    "type": "string",
+                                    "description": "Signup URL for the directory."
+                                  },
+                                  "upgrade_page_url": {
+                                    "type": "string",
+                                    "description": "Upgrade page URL for the directory."
+                                  },
+                                  "cancel_page_url": {
+                                    "type": "string",
+                                    "description": "Cancel page URL for the directory."
+                                  },
+                                  "sms_purchase_url": {
+                                    "type": "string",
+                                    "description": "SMS purchase URL for the directory."
+                                  },
+                                  "backoffice_url": {
+                                    "type": "string",
+                                    "description": "Operator Portal Backoffice URL for the directory."
+                                  }
+                                }
+                              },
+                              "domain_hosting": {
+                                "type": "object",
+                                "description": "Domain and hosting configuration for the directory's whitelabel setup.",
+                                "properties": {
+                                  "subdomain": {
+                                    "type": "string",
+                                    "description": "The subdomain for the directory. Available at subdomain.vcita.com (or subdomain.myclients.io). Required in order to configure host-mapping DNS (e.g., \"samplepartner\")."
+                                  },
+                                  "whitelabel_subdomain": {
+                                    "type": "boolean",
+                                    "description": "When true, forces the whitelabel domain (subdomain.myclients.io) if host mapping is not configured."
+                                  },
+                                  "host_mapping": {
+                                    "type": "string",
+                                    "description": "The whitelabel host for the directory. The vendor must configure the DNS record to point to the configured subdomain.vcita.com or subdomain.myclients.io (e.g., \"www.samplepartner.ch\").",
+                                    "nullable": true
+                                  },
+                                  "ssl_enabled": {
+                                    "type": "boolean",
+                                    "description": "When true, an SSL certificate has been deployed for the host mapping and all traffic is force-redirected to HTTPS."
+                                  },
+                                  "old_host_mapping": {
+                                    "type": "string",
+                                    "description": "The previous whitelabel host mapping. Used to redirect to myclients.io when the host mapping is removed.",
+                                    "nullable": true
+                                  },
+                                  "host_mapping_verified_at": {
+                                    "type": "string",
+                                    "format": "date-time",
+                                    "description": "Timestamp when the host mapping DNS was last verified.",
+                                    "nullable": true
+                                  }
+                                }
+                              },
+                              "configs": {
+                                "type": "array",
+                                "description": "Directory-level configuration flags that control behavior and categorization.",
+                                "items": {
+                                  "type": "string",
+                                  "enum": [
+                                    "is_vcita_marketing",
+                                    "is_vcita_sales",
+                                    "is_vcita_cs",
+                                    "is_vcita_support",
+                                    "is_default_rollout",
+                                    "is_managed_partner",
+                                    "is_sandbox",
+                                    "send_confirmation_email"
+                                  ]
+                                },
+                                "uniqueItems": true
+                              },
+                              "created_at": {
+                                "type": "string",
+                                "format": "date-time",
+                                "description": "Timestamp when the directory was created."
+                              },
+                              "updated_at": {
+                                "type": "string",
+                                "format": "date-time",
+                                "description": "Timestamp when the directory was last updated."
+                              }
+                            },
+                            "required": [
+                              "uid",
+                              "name",
+                              "created_at",
+                              "updated_at"
+                            ],
+                            "example": {
+                              "id": 20338,
+                              "uid": "dir-20338",
+                              "name": "samplepartner",
+                              "partner_name": "samplepartner",
+                              "parent_directory_id": null,
+                              "admin_email": "samplepartner@vcita.com",
+                              "billing_type": "manual",
+                              "manual_type": "co_branded",
+                              "configuration_key": "samplepartner",
+                              "branding_theme_id": null,
+                              "management_theme_id": "2366701",
+                              "management_theme_attributes": {
+                                "id": "2366701",
+                                "logo_url": ""
+                              },
+                              "is_managed": true,
+                              "is_deprecated": false,
+                              "is_slim_register_enabled": false,
+                              "locale": "en",
+                              "time_zone": "America/New_York",
+                              "paypal_email": "",
+                              "rev_share": 20,
+                              "rev_share_tier2": null,
+                              "only_owner_login_redirect": false,
+                              "paid_total": null,
+                              "custom_sms_sending_phone_number": null,
+                              "features": null,
+                              "features_info": {
+                                "524": "available",
+                                "649": "available"
+                              },
+                              "settings": {
+                                "static_page_data": "",
+                                "myaccount_page_url": "",
+                                "managed_login_url": "https://one.samplepartner.com/authbridge/oauth/login",
+                                "new_staff_url": "",
+                                "change_password_url": "https://auth.samplepartner.com/forgot_password?origin_uri=https://one.samplepartner.com/",
+                                "use_login_with_code": false,
+                                "op_support_url": "",
+                                "privacy_policy": "",
+                                "terms_of_service": "",
+                                "compliance_in_billing_app": true,
+                                "enable_upgrade_page_tab": "1",
+                                "enable_separate_payment_method": "0",
+                                "external_review_site": null,
+                                "ada_handle": "samplepartner",
+                                "revshare_coupon": "PARTNER20OFF",
+                                "app_market_url": "https://apps.samplepartner.com/market",
+                                "block_external_app_uninstall": false,
+                                "pendo": "",
+                                "chatbot": ""
+                              },
+                              "welcome_engagement_params": null,
+                              "invite_subject": null,
+                              "invite_body": null,
+                              "is_unsubscribe_sms": false,
+                              "is_disable_analytics": null,
+                              "content_business_id": null,
+                              "is_content_manager_enabled": false,
+                              "is_user_identity_manager_enabled": true,
+                              "ultimate_monthly_subscription_id": null,
+                              "ultimate_annual_subscription_id": null,
+                              "subscriptions_mismatch_at": null,
+                              "white_label_subscription_id": null,
+                              "current_subscription_id": null,
+                              "pending_member_id": null,
+                              "default_package_id": 243,
+                              "is_default_self_paid": true,
+                              "redeem_state": null,
+                              "mobile_app_name": "",
+                              "mobile_app_ios": "",
+                              "mobile_app_android": "",
+                              "email_template_owner_uid": "",
+                              "urls": {
+                                "home_url": "https://home.example.com",
+                                "support_url": "https://support.example.com",
+                                "faq_url": "https://faq.example.com",
+                                "login_url": "https://login.example.com",
+                                "signup_url": "https://signup.example.com",
+                                "upgrade_page_url": "https://upgrade.example.com",
+                                "cancel_page_url": "https://cancel.example.com",
+                                "sms_purchase_url": "https://sms.example.com",
+                                "backoffice_url": "https://backoffice.example.com"
+                              },
+                              "domain_hosting": {
+                                "subdomain": "samplepartner",
+                                "whitelabel_subdomain": true,
+                                "host_mapping": "one.samplepartner.com",
+                                "ssl_enabled": true,
+                                "old_host_mapping": null,
+                                "host_mapping_verified_at": "2025-01-20T17:56:00Z"
+                              },
+                              "configs": [
+                                "is_vcita_marketing",
+                                "is_default_rollout",
+                                "is_managed_partner"
+                              ],
+                              "created_at": "2023-08-01T12:00:00Z",
+                              "updated_at": "2023-10-01T12:00:00Z"
+                            }
                           }
                         }
                       }
@@ -6470,7 +10074,105 @@
                       "data": {
                         "directories": [
                           {
-                            "$ref": "https://vcita.github.io/developers-hub/entities/business_administration/directory.json#/example"
+                            "id": 20338,
+                            "uid": "dir-20338",
+                            "name": "samplepartner",
+                            "partner_name": "samplepartner",
+                            "parent_directory_id": null,
+                            "admin_email": "samplepartner@vcita.com",
+                            "billing_type": "manual",
+                            "manual_type": "co_branded",
+                            "configuration_key": "samplepartner",
+                            "branding_theme_id": null,
+                            "management_theme_id": "2366701",
+                            "management_theme_attributes": {
+                              "id": "2366701",
+                              "logo_url": ""
+                            },
+                            "is_managed": true,
+                            "is_deprecated": false,
+                            "is_slim_register_enabled": false,
+                            "locale": "en",
+                            "time_zone": "America/New_York",
+                            "paypal_email": "",
+                            "rev_share": 20,
+                            "rev_share_tier2": null,
+                            "only_owner_login_redirect": false,
+                            "paid_total": null,
+                            "custom_sms_sending_phone_number": null,
+                            "features": null,
+                            "features_info": {
+                              "524": "available",
+                              "649": "available"
+                            },
+                            "settings": {
+                              "static_page_data": "",
+                              "myaccount_page_url": "",
+                              "managed_login_url": "https://one.samplepartner.com/authbridge/oauth/login",
+                              "new_staff_url": "",
+                              "change_password_url": "https://auth.samplepartner.com/forgot_password?origin_uri=https://one.samplepartner.com/",
+                              "use_login_with_code": false,
+                              "op_support_url": "",
+                              "privacy_policy": "",
+                              "terms_of_service": "",
+                              "compliance_in_billing_app": true,
+                              "enable_upgrade_page_tab": "1",
+                              "enable_separate_payment_method": "0",
+                              "external_review_site": null,
+                              "ada_handle": "samplepartner",
+                              "revshare_coupon": "PARTNER20OFF",
+                              "app_market_url": "https://apps.samplepartner.com/market",
+                              "block_external_app_uninstall": false,
+                              "pendo": "",
+                              "chatbot": ""
+                            },
+                            "welcome_engagement_params": null,
+                            "invite_subject": null,
+                            "invite_body": null,
+                            "is_unsubscribe_sms": false,
+                            "is_disable_analytics": null,
+                            "content_business_id": null,
+                            "is_content_manager_enabled": false,
+                            "is_user_identity_manager_enabled": true,
+                            "ultimate_monthly_subscription_id": null,
+                            "ultimate_annual_subscription_id": null,
+                            "subscriptions_mismatch_at": null,
+                            "white_label_subscription_id": null,
+                            "current_subscription_id": null,
+                            "pending_member_id": null,
+                            "default_package_id": 243,
+                            "is_default_self_paid": true,
+                            "redeem_state": null,
+                            "mobile_app_name": "",
+                            "mobile_app_ios": "",
+                            "mobile_app_android": "",
+                            "email_template_owner_uid": "",
+                            "urls": {
+                              "home_url": "https://home.example.com",
+                              "support_url": "https://support.example.com",
+                              "faq_url": "https://faq.example.com",
+                              "login_url": "https://login.example.com",
+                              "signup_url": "https://signup.example.com",
+                              "upgrade_page_url": "https://upgrade.example.com",
+                              "cancel_page_url": "https://cancel.example.com",
+                              "sms_purchase_url": "https://sms.example.com",
+                              "backoffice_url": "https://backoffice.example.com"
+                            },
+                            "domain_hosting": {
+                              "subdomain": "samplepartner",
+                              "whitelabel_subdomain": true,
+                              "host_mapping": "one.samplepartner.com",
+                              "ssl_enabled": true,
+                              "old_host_mapping": null,
+                              "host_mapping_verified_at": "2025-01-20T17:56:00Z"
+                            },
+                            "configs": [
+                              "is_vcita_marketing",
+                              "is_default_rollout",
+                              "is_managed_partner"
+                            ],
+                            "created_at": "2023-08-01T12:00:00Z",
+                            "updated_at": "2023-10-01T12:00:00Z"
                           }
                         ]
                       },
@@ -6595,7 +10297,545 @@
                       "type": "boolean"
                     },
                     "data": {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/business_administration/directory.json"
+                      "type": "object",
+                      "description": "Defines a partner directory (brand/tenant) and its core configuration and URLs.",
+                      "properties": {
+                        "id": {
+                          "type": "integer",
+                          "description": "Internal ID for the directory."
+                        },
+                        "uid": {
+                          "type": "string",
+                          "description": "Unique identifier for the directory."
+                        },
+                        "name": {
+                          "type": "string",
+                          "description": "Name of the directory. Used only internally."
+                        },
+                        "partner_name": {
+                          "type": "string",
+                          "description": "Partner-facing display name for the directory (e.g., \"samplepartner\")."
+                        },
+                        "parent_directory_id": {
+                          "type": "integer",
+                          "description": "ID of the parent directory, if this directory is a child of another directory. Null if top-level.",
+                          "nullable": true
+                        },
+                        "admin_email": {
+                          "type": "string",
+                          "format": "email",
+                          "description": "Administrative contact email for the directory (e.g., \"samplepartner@vcita.com\")."
+                        },
+                        "billing_type": {
+                          "type": "string",
+                          "description": "Billing type for the directory.",
+                          "enum": [
+                            "recurly",
+                            "manual"
+                          ]
+                        },
+                        "manual_type": {
+                          "type": "string",
+                          "description": "Manual type of the directory. Use this to ensure Solution Provider / White Label features even if the directory owner didn't pay for it or there was a payment issue.",
+                          "enum": [
+                            "solution_provider",
+                            "white_label",
+                            "co_branded"
+                          ],
+                          "nullable": true
+                        },
+                        "configuration_key": {
+                          "type": "string",
+                          "description": "Configuration key for the directory."
+                        },
+                        "branding_theme_id": {
+                          "type": "string",
+                          "description": "ID of the branding theme applied to the directory.",
+                          "nullable": true
+                        },
+                        "management_theme_id": {
+                          "type": "string",
+                          "description": "ID of the management theme applied to the directory (e.g., \"2366701\").",
+                          "nullable": true
+                        },
+                        "management_theme_attributes": {
+                          "type": "object",
+                          "description": "Attributes for the management theme associated with the directory.",
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "description": "ID of the management theme."
+                            },
+                            "logo_url": {
+                              "type": "string",
+                              "description": "URL of the logo used in the management theme.",
+                              "nullable": true
+                            }
+                          }
+                        },
+                        "is_managed": {
+                          "type": "boolean",
+                          "description": "Indicates if the directory is managed by a partner. Relevant for reports only."
+                        },
+                        "is_deprecated": {
+                          "type": "boolean",
+                          "description": "Indicates if the directory is deprecated."
+                        },
+                        "is_slim_register_enabled": {
+                          "type": "boolean",
+                          "description": "Indicates if slim registration mode is enabled during onboarding."
+                        },
+                        "locale": {
+                          "type": "string",
+                          "description": "Default locale for the directory."
+                        },
+                        "time_zone": {
+                          "type": "string",
+                          "description": "Default time zone for the directory."
+                        },
+                        "paypal_email": {
+                          "type": "string",
+                          "description": "PayPal email for the directory."
+                        },
+                        "rev_share": {
+                          "type": "number",
+                          "description": "Revenue share percentage (e.g., 20)."
+                        },
+                        "rev_share_tier2": {
+                          "type": "number",
+                          "description": "Revenue share percentage for tier 2.",
+                          "nullable": true
+                        },
+                        "only_owner_login_redirect": {
+                          "type": "boolean",
+                          "description": "When true, only the business owner is redirected to the logout URL on logout. When false and logout URL is defined, all logged-out users are redirected."
+                        },
+                        "paid_total": {
+                          "type": "string",
+                          "description": "Total paid amount."
+                        },
+                        "custom_sms_sending_phone_number": {
+                          "type": "string",
+                          "description": "Custom SMS sending phone number."
+                        },
+                        "features": {
+                          "type": "object",
+                          "description": "Feature flags for the directory."
+                        },
+                        "features_info": {
+                          "type": "object",
+                          "description": "Additional feature information."
+                        },
+                        "settings": {
+                          "type": "object",
+                          "description": "Directory settings and configuration options.",
+                          "properties": {
+                            "block_external_app_uninstall": {
+                              "type": "boolean",
+                              "description": "When enabled, apps purchased via API (payment_type: external) cannot be uninstalled from the App Market."
+                            },
+                            "static_page_data": {
+                              "oneOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "url": {
+                                      "type": "string"
+                                    },
+                                    "url_params": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                }
+                              ],
+                              "description": "Static page configuration data. Must use the same subdomain as the directory."
+                            },
+                            "myaccount_page_url": {
+                              "type": "string",
+                              "description": "My account page URL."
+                            },
+                            "managed_login_url": {
+                              "type": "string",
+                              "description": "Managed login URL for SSO (e.g., \"https://one.samplepartner.com/authbridge/oauth/login\")."
+                            },
+                            "new_staff_url": {
+                              "type": "string",
+                              "description": "URL for adding new staff members."
+                            },
+                            "change_password_url": {
+                              "type": "string",
+                              "description": "URL for password change (e.g., \"https://auth.samplepartner.com/forgot_password?origin_uri=https://one.samplepartner.com/\")."
+                            },
+                            "use_login_with_code": {
+                              "type": "boolean",
+                              "description": "Whether login with code is enabled."
+                            },
+                            "op_support_url": {
+                              "type": "string",
+                              "description": "Operator support page URL."
+                            },
+                            "privacy_policy": {
+                              "type": "string",
+                              "description": "Privacy policy URL. If left blank, the default URL is intandem.vcita.com/privacy-policy."
+                            },
+                            "terms_of_service": {
+                              "type": "string",
+                              "description": "Terms of service URL. If left blank, the default URL is intandem.vcita.com/terms-of-service."
+                            },
+                            "compliance_in_billing_app": {
+                              "type": "boolean",
+                              "description": "Whether TOS and privacy policy are visible in the billing app."
+                            },
+                            "enable_upgrade_page_tab": {
+                              "type": "string",
+                              "description": "Whether the upgrade page opens in a new tab (\"0\" = disabled, \"1\" = enabled)."
+                            },
+                            "enable_separate_payment_method": {
+                              "type": "string",
+                              "description": "Whether a separate payment method section is enabled for add-on purchases. Hides the payment method tab and adds a section on the purchased add-ons page (\"0\" = disabled, \"1\" = enabled)."
+                            },
+                            "external_review_site": {
+                              "type": "object",
+                              "description": "External review site configuration.",
+                              "properties": {
+                                "url": {
+                                  "type": "string",
+                                  "description": "Review site URL."
+                                },
+                                "label": {
+                                  "type": "string",
+                                  "description": "Review site display name."
+                                }
+                              }
+                            },
+                            "revshare_coupon": {
+                              "type": "string",
+                              "description": "Revenue share coupon code."
+                            },
+                            "app_market_url": {
+                              "type": "string",
+                              "description": "Custom app market URL."
+                            },
+                            "ada_handle": {
+                              "type": "string",
+                              "description": "ADA chatbot handle code configured in ada.support. Each partner has a separate ADA dashboard (e.g., \"samplepartner\")."
+                            },
+                            "pendo": {
+                              "type": "string",
+                              "description": "Pendo analytics data/configuration for the directory.",
+                              "nullable": true
+                            },
+                            "chatbot": {
+                              "type": "string",
+                              "description": "Custom chatbot HTML snippet injected into the directory pages.",
+                              "nullable": true
+                            }
+                          }
+                        },
+                        "welcome_engagement_params": {
+                          "type": "object",
+                          "description": "Welcome engagement parameters.",
+                          "nullable": true
+                        },
+                        "invite_subject": {
+                          "type": "string",
+                          "description": "Email subject for invitations."
+                        },
+                        "invite_body": {
+                          "type": "string",
+                          "description": "Email body for invitations."
+                        },
+                        "is_unsubscribe_sms": {
+                          "type": "boolean",
+                          "description": "Indicates if unsubscribe text is added to SMS messages."
+                        },
+                        "is_disable_analytics": {
+                          "type": "boolean",
+                          "description": "Indicates if analytics are disabled."
+                        },
+                        "content_business_id": {
+                          "type": "integer",
+                          "description": "Content business ID."
+                        },
+                        "is_content_manager_enabled": {
+                          "type": "boolean",
+                          "description": "Indicates if the directory is added to Verticalization (content manager)."
+                        },
+                        "is_user_identity_manager_enabled": {
+                          "type": "boolean",
+                          "description": "Indicates if the directory manages user identities."
+                        },
+                        "ultimate_monthly_subscription_id": {
+                          "type": "integer",
+                          "description": "Ultimate monthly subscription ID."
+                        },
+                        "ultimate_annual_subscription_id": {
+                          "type": "integer",
+                          "description": "Ultimate annual subscription ID."
+                        },
+                        "subscriptions_mismatch_at": {
+                          "type": "string",
+                          "format": "date-time",
+                          "description": "Timestamp of subscription mismatch."
+                        },
+                        "white_label_subscription_id": {
+                          "type": "integer",
+                          "description": "White label subscription ID."
+                        },
+                        "current_subscription_id": {
+                          "type": "integer",
+                          "description": "Current subscription ID."
+                        },
+                        "pending_member_id": {
+                          "type": "integer",
+                          "description": "Pending member ID."
+                        },
+                        "default_package_id": {
+                          "type": "integer",
+                          "description": "Default package ID assigned to new businesses in this directory."
+                        },
+                        "is_default_self_paid": {
+                          "type": "boolean",
+                          "description": "Indicates if default self paid is enabled."
+                        },
+                        "redeem_state": {
+                          "type": "string",
+                          "description": "Redeem state."
+                        },
+                        "mobile_app_name": {
+                          "type": "string",
+                          "description": "Mobile app name."
+                        },
+                        "mobile_app_ios": {
+                          "type": "string",
+                          "description": "iOS mobile app URL."
+                        },
+                        "mobile_app_android": {
+                          "type": "string",
+                          "description": "Android mobile app URL."
+                        },
+                        "email_template_owner_uid": {
+                          "type": "string",
+                          "description": "Email template owner UID."
+                        },
+                        "urls": {
+                          "type": "object",
+                          "description": "Collection of setup URLs related to the directory.",
+                          "properties": {
+                            "home_url": {
+                              "type": "string",
+                              "description": "Home URL for the directory (e.g., \"https://www.samplepartner.com/\")."
+                            },
+                            "support_url": {
+                              "type": "string",
+                              "description": "Support URL for the directory."
+                            },
+                            "faq_url": {
+                              "type": "string",
+                              "description": "FAQ URL for the directory."
+                            },
+                            "login_url": {
+                              "type": "string",
+                              "description": "Logout redirect URL for the directory. Despite the field name, this is the URL users are redirected to upon logout."
+                            },
+                            "signup_url": {
+                              "type": "string",
+                              "description": "Signup URL for the directory."
+                            },
+                            "upgrade_page_url": {
+                              "type": "string",
+                              "description": "Upgrade page URL for the directory."
+                            },
+                            "cancel_page_url": {
+                              "type": "string",
+                              "description": "Cancel page URL for the directory."
+                            },
+                            "sms_purchase_url": {
+                              "type": "string",
+                              "description": "SMS purchase URL for the directory."
+                            },
+                            "backoffice_url": {
+                              "type": "string",
+                              "description": "Operator Portal Backoffice URL for the directory."
+                            }
+                          }
+                        },
+                        "domain_hosting": {
+                          "type": "object",
+                          "description": "Domain and hosting configuration for the directory's whitelabel setup.",
+                          "properties": {
+                            "subdomain": {
+                              "type": "string",
+                              "description": "The subdomain for the directory. Available at subdomain.vcita.com (or subdomain.myclients.io). Required in order to configure host-mapping DNS (e.g., \"samplepartner\")."
+                            },
+                            "whitelabel_subdomain": {
+                              "type": "boolean",
+                              "description": "When true, forces the whitelabel domain (subdomain.myclients.io) if host mapping is not configured."
+                            },
+                            "host_mapping": {
+                              "type": "string",
+                              "description": "The whitelabel host for the directory. The vendor must configure the DNS record to point to the configured subdomain.vcita.com or subdomain.myclients.io (e.g., \"www.samplepartner.ch\").",
+                              "nullable": true
+                            },
+                            "ssl_enabled": {
+                              "type": "boolean",
+                              "description": "When true, an SSL certificate has been deployed for the host mapping and all traffic is force-redirected to HTTPS."
+                            },
+                            "old_host_mapping": {
+                              "type": "string",
+                              "description": "The previous whitelabel host mapping. Used to redirect to myclients.io when the host mapping is removed.",
+                              "nullable": true
+                            },
+                            "host_mapping_verified_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "description": "Timestamp when the host mapping DNS was last verified.",
+                              "nullable": true
+                            }
+                          }
+                        },
+                        "configs": {
+                          "type": "array",
+                          "description": "Directory-level configuration flags that control behavior and categorization.",
+                          "items": {
+                            "type": "string",
+                            "enum": [
+                              "is_vcita_marketing",
+                              "is_vcita_sales",
+                              "is_vcita_cs",
+                              "is_vcita_support",
+                              "is_default_rollout",
+                              "is_managed_partner",
+                              "is_sandbox",
+                              "send_confirmation_email"
+                            ]
+                          },
+                          "uniqueItems": true
+                        },
+                        "created_at": {
+                          "type": "string",
+                          "format": "date-time",
+                          "description": "Timestamp when the directory was created."
+                        },
+                        "updated_at": {
+                          "type": "string",
+                          "format": "date-time",
+                          "description": "Timestamp when the directory was last updated."
+                        }
+                      },
+                      "required": [
+                        "uid",
+                        "name",
+                        "created_at",
+                        "updated_at"
+                      ],
+                      "example": {
+                        "id": 20338,
+                        "uid": "dir-20338",
+                        "name": "samplepartner",
+                        "partner_name": "samplepartner",
+                        "parent_directory_id": null,
+                        "admin_email": "samplepartner@vcita.com",
+                        "billing_type": "manual",
+                        "manual_type": "co_branded",
+                        "configuration_key": "samplepartner",
+                        "branding_theme_id": null,
+                        "management_theme_id": "2366701",
+                        "management_theme_attributes": {
+                          "id": "2366701",
+                          "logo_url": ""
+                        },
+                        "is_managed": true,
+                        "is_deprecated": false,
+                        "is_slim_register_enabled": false,
+                        "locale": "en",
+                        "time_zone": "America/New_York",
+                        "paypal_email": "",
+                        "rev_share": 20,
+                        "rev_share_tier2": null,
+                        "only_owner_login_redirect": false,
+                        "paid_total": null,
+                        "custom_sms_sending_phone_number": null,
+                        "features": null,
+                        "features_info": {
+                          "524": "available",
+                          "649": "available"
+                        },
+                        "settings": {
+                          "static_page_data": "",
+                          "myaccount_page_url": "",
+                          "managed_login_url": "https://one.samplepartner.com/authbridge/oauth/login",
+                          "new_staff_url": "",
+                          "change_password_url": "https://auth.samplepartner.com/forgot_password?origin_uri=https://one.samplepartner.com/",
+                          "use_login_with_code": false,
+                          "op_support_url": "",
+                          "privacy_policy": "",
+                          "terms_of_service": "",
+                          "compliance_in_billing_app": true,
+                          "enable_upgrade_page_tab": "1",
+                          "enable_separate_payment_method": "0",
+                          "external_review_site": null,
+                          "ada_handle": "samplepartner",
+                          "revshare_coupon": "PARTNER20OFF",
+                          "app_market_url": "https://apps.samplepartner.com/market",
+                          "block_external_app_uninstall": false,
+                          "pendo": "",
+                          "chatbot": ""
+                        },
+                        "welcome_engagement_params": null,
+                        "invite_subject": null,
+                        "invite_body": null,
+                        "is_unsubscribe_sms": false,
+                        "is_disable_analytics": null,
+                        "content_business_id": null,
+                        "is_content_manager_enabled": false,
+                        "is_user_identity_manager_enabled": true,
+                        "ultimate_monthly_subscription_id": null,
+                        "ultimate_annual_subscription_id": null,
+                        "subscriptions_mismatch_at": null,
+                        "white_label_subscription_id": null,
+                        "current_subscription_id": null,
+                        "pending_member_id": null,
+                        "default_package_id": 243,
+                        "is_default_self_paid": true,
+                        "redeem_state": null,
+                        "mobile_app_name": "",
+                        "mobile_app_ios": "",
+                        "mobile_app_android": "",
+                        "email_template_owner_uid": "",
+                        "urls": {
+                          "home_url": "https://home.example.com",
+                          "support_url": "https://support.example.com",
+                          "faq_url": "https://faq.example.com",
+                          "login_url": "https://login.example.com",
+                          "signup_url": "https://signup.example.com",
+                          "upgrade_page_url": "https://upgrade.example.com",
+                          "cancel_page_url": "https://cancel.example.com",
+                          "sms_purchase_url": "https://sms.example.com",
+                          "backoffice_url": "https://backoffice.example.com"
+                        },
+                        "domain_hosting": {
+                          "subdomain": "samplepartner",
+                          "whitelabel_subdomain": true,
+                          "host_mapping": "one.samplepartner.com",
+                          "ssl_enabled": true,
+                          "old_host_mapping": null,
+                          "host_mapping_verified_at": "2025-01-20T17:56:00Z"
+                        },
+                        "configs": [
+                          "is_vcita_marketing",
+                          "is_default_rollout",
+                          "is_managed_partner"
+                        ],
+                        "created_at": "2023-08-01T12:00:00Z",
+                        "updated_at": "2023-10-01T12:00:00Z"
+                      }
                     }
                   }
                 }
@@ -6681,7 +10921,545 @@
                       "description": "Whether the API request was successful"
                     },
                     "data": {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/business_administration/directory.json"
+                      "type": "object",
+                      "description": "Defines a partner directory (brand/tenant) and its core configuration and URLs.",
+                      "properties": {
+                        "id": {
+                          "type": "integer",
+                          "description": "Internal ID for the directory."
+                        },
+                        "uid": {
+                          "type": "string",
+                          "description": "Unique identifier for the directory."
+                        },
+                        "name": {
+                          "type": "string",
+                          "description": "Name of the directory. Used only internally."
+                        },
+                        "partner_name": {
+                          "type": "string",
+                          "description": "Partner-facing display name for the directory (e.g., \"samplepartner\")."
+                        },
+                        "parent_directory_id": {
+                          "type": "integer",
+                          "description": "ID of the parent directory, if this directory is a child of another directory. Null if top-level.",
+                          "nullable": true
+                        },
+                        "admin_email": {
+                          "type": "string",
+                          "format": "email",
+                          "description": "Administrative contact email for the directory (e.g., \"samplepartner@vcita.com\")."
+                        },
+                        "billing_type": {
+                          "type": "string",
+                          "description": "Billing type for the directory.",
+                          "enum": [
+                            "recurly",
+                            "manual"
+                          ]
+                        },
+                        "manual_type": {
+                          "type": "string",
+                          "description": "Manual type of the directory. Use this to ensure Solution Provider / White Label features even if the directory owner didn't pay for it or there was a payment issue.",
+                          "enum": [
+                            "solution_provider",
+                            "white_label",
+                            "co_branded"
+                          ],
+                          "nullable": true
+                        },
+                        "configuration_key": {
+                          "type": "string",
+                          "description": "Configuration key for the directory."
+                        },
+                        "branding_theme_id": {
+                          "type": "string",
+                          "description": "ID of the branding theme applied to the directory.",
+                          "nullable": true
+                        },
+                        "management_theme_id": {
+                          "type": "string",
+                          "description": "ID of the management theme applied to the directory (e.g., \"2366701\").",
+                          "nullable": true
+                        },
+                        "management_theme_attributes": {
+                          "type": "object",
+                          "description": "Attributes for the management theme associated with the directory.",
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "description": "ID of the management theme."
+                            },
+                            "logo_url": {
+                              "type": "string",
+                              "description": "URL of the logo used in the management theme.",
+                              "nullable": true
+                            }
+                          }
+                        },
+                        "is_managed": {
+                          "type": "boolean",
+                          "description": "Indicates if the directory is managed by a partner. Relevant for reports only."
+                        },
+                        "is_deprecated": {
+                          "type": "boolean",
+                          "description": "Indicates if the directory is deprecated."
+                        },
+                        "is_slim_register_enabled": {
+                          "type": "boolean",
+                          "description": "Indicates if slim registration mode is enabled during onboarding."
+                        },
+                        "locale": {
+                          "type": "string",
+                          "description": "Default locale for the directory."
+                        },
+                        "time_zone": {
+                          "type": "string",
+                          "description": "Default time zone for the directory."
+                        },
+                        "paypal_email": {
+                          "type": "string",
+                          "description": "PayPal email for the directory."
+                        },
+                        "rev_share": {
+                          "type": "number",
+                          "description": "Revenue share percentage (e.g., 20)."
+                        },
+                        "rev_share_tier2": {
+                          "type": "number",
+                          "description": "Revenue share percentage for tier 2.",
+                          "nullable": true
+                        },
+                        "only_owner_login_redirect": {
+                          "type": "boolean",
+                          "description": "When true, only the business owner is redirected to the logout URL on logout. When false and logout URL is defined, all logged-out users are redirected."
+                        },
+                        "paid_total": {
+                          "type": "string",
+                          "description": "Total paid amount."
+                        },
+                        "custom_sms_sending_phone_number": {
+                          "type": "string",
+                          "description": "Custom SMS sending phone number."
+                        },
+                        "features": {
+                          "type": "object",
+                          "description": "Feature flags for the directory."
+                        },
+                        "features_info": {
+                          "type": "object",
+                          "description": "Additional feature information."
+                        },
+                        "settings": {
+                          "type": "object",
+                          "description": "Directory settings and configuration options.",
+                          "properties": {
+                            "block_external_app_uninstall": {
+                              "type": "boolean",
+                              "description": "When enabled, apps purchased via API (payment_type: external) cannot be uninstalled from the App Market."
+                            },
+                            "static_page_data": {
+                              "oneOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "url": {
+                                      "type": "string"
+                                    },
+                                    "url_params": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                }
+                              ],
+                              "description": "Static page configuration data. Must use the same subdomain as the directory."
+                            },
+                            "myaccount_page_url": {
+                              "type": "string",
+                              "description": "My account page URL."
+                            },
+                            "managed_login_url": {
+                              "type": "string",
+                              "description": "Managed login URL for SSO (e.g., \"https://one.samplepartner.com/authbridge/oauth/login\")."
+                            },
+                            "new_staff_url": {
+                              "type": "string",
+                              "description": "URL for adding new staff members."
+                            },
+                            "change_password_url": {
+                              "type": "string",
+                              "description": "URL for password change (e.g., \"https://auth.samplepartner.com/forgot_password?origin_uri=https://one.samplepartner.com/\")."
+                            },
+                            "use_login_with_code": {
+                              "type": "boolean",
+                              "description": "Whether login with code is enabled."
+                            },
+                            "op_support_url": {
+                              "type": "string",
+                              "description": "Operator support page URL."
+                            },
+                            "privacy_policy": {
+                              "type": "string",
+                              "description": "Privacy policy URL. If left blank, the default URL is intandem.vcita.com/privacy-policy."
+                            },
+                            "terms_of_service": {
+                              "type": "string",
+                              "description": "Terms of service URL. If left blank, the default URL is intandem.vcita.com/terms-of-service."
+                            },
+                            "compliance_in_billing_app": {
+                              "type": "boolean",
+                              "description": "Whether TOS and privacy policy are visible in the billing app."
+                            },
+                            "enable_upgrade_page_tab": {
+                              "type": "string",
+                              "description": "Whether the upgrade page opens in a new tab (\"0\" = disabled, \"1\" = enabled)."
+                            },
+                            "enable_separate_payment_method": {
+                              "type": "string",
+                              "description": "Whether a separate payment method section is enabled for add-on purchases. Hides the payment method tab and adds a section on the purchased add-ons page (\"0\" = disabled, \"1\" = enabled)."
+                            },
+                            "external_review_site": {
+                              "type": "object",
+                              "description": "External review site configuration.",
+                              "properties": {
+                                "url": {
+                                  "type": "string",
+                                  "description": "Review site URL."
+                                },
+                                "label": {
+                                  "type": "string",
+                                  "description": "Review site display name."
+                                }
+                              }
+                            },
+                            "revshare_coupon": {
+                              "type": "string",
+                              "description": "Revenue share coupon code."
+                            },
+                            "app_market_url": {
+                              "type": "string",
+                              "description": "Custom app market URL."
+                            },
+                            "ada_handle": {
+                              "type": "string",
+                              "description": "ADA chatbot handle code configured in ada.support. Each partner has a separate ADA dashboard (e.g., \"samplepartner\")."
+                            },
+                            "pendo": {
+                              "type": "string",
+                              "description": "Pendo analytics data/configuration for the directory.",
+                              "nullable": true
+                            },
+                            "chatbot": {
+                              "type": "string",
+                              "description": "Custom chatbot HTML snippet injected into the directory pages.",
+                              "nullable": true
+                            }
+                          }
+                        },
+                        "welcome_engagement_params": {
+                          "type": "object",
+                          "description": "Welcome engagement parameters.",
+                          "nullable": true
+                        },
+                        "invite_subject": {
+                          "type": "string",
+                          "description": "Email subject for invitations."
+                        },
+                        "invite_body": {
+                          "type": "string",
+                          "description": "Email body for invitations."
+                        },
+                        "is_unsubscribe_sms": {
+                          "type": "boolean",
+                          "description": "Indicates if unsubscribe text is added to SMS messages."
+                        },
+                        "is_disable_analytics": {
+                          "type": "boolean",
+                          "description": "Indicates if analytics are disabled."
+                        },
+                        "content_business_id": {
+                          "type": "integer",
+                          "description": "Content business ID."
+                        },
+                        "is_content_manager_enabled": {
+                          "type": "boolean",
+                          "description": "Indicates if the directory is added to Verticalization (content manager)."
+                        },
+                        "is_user_identity_manager_enabled": {
+                          "type": "boolean",
+                          "description": "Indicates if the directory manages user identities."
+                        },
+                        "ultimate_monthly_subscription_id": {
+                          "type": "integer",
+                          "description": "Ultimate monthly subscription ID."
+                        },
+                        "ultimate_annual_subscription_id": {
+                          "type": "integer",
+                          "description": "Ultimate annual subscription ID."
+                        },
+                        "subscriptions_mismatch_at": {
+                          "type": "string",
+                          "format": "date-time",
+                          "description": "Timestamp of subscription mismatch."
+                        },
+                        "white_label_subscription_id": {
+                          "type": "integer",
+                          "description": "White label subscription ID."
+                        },
+                        "current_subscription_id": {
+                          "type": "integer",
+                          "description": "Current subscription ID."
+                        },
+                        "pending_member_id": {
+                          "type": "integer",
+                          "description": "Pending member ID."
+                        },
+                        "default_package_id": {
+                          "type": "integer",
+                          "description": "Default package ID assigned to new businesses in this directory."
+                        },
+                        "is_default_self_paid": {
+                          "type": "boolean",
+                          "description": "Indicates if default self paid is enabled."
+                        },
+                        "redeem_state": {
+                          "type": "string",
+                          "description": "Redeem state."
+                        },
+                        "mobile_app_name": {
+                          "type": "string",
+                          "description": "Mobile app name."
+                        },
+                        "mobile_app_ios": {
+                          "type": "string",
+                          "description": "iOS mobile app URL."
+                        },
+                        "mobile_app_android": {
+                          "type": "string",
+                          "description": "Android mobile app URL."
+                        },
+                        "email_template_owner_uid": {
+                          "type": "string",
+                          "description": "Email template owner UID."
+                        },
+                        "urls": {
+                          "type": "object",
+                          "description": "Collection of setup URLs related to the directory.",
+                          "properties": {
+                            "home_url": {
+                              "type": "string",
+                              "description": "Home URL for the directory (e.g., \"https://www.samplepartner.com/\")."
+                            },
+                            "support_url": {
+                              "type": "string",
+                              "description": "Support URL for the directory."
+                            },
+                            "faq_url": {
+                              "type": "string",
+                              "description": "FAQ URL for the directory."
+                            },
+                            "login_url": {
+                              "type": "string",
+                              "description": "Logout redirect URL for the directory. Despite the field name, this is the URL users are redirected to upon logout."
+                            },
+                            "signup_url": {
+                              "type": "string",
+                              "description": "Signup URL for the directory."
+                            },
+                            "upgrade_page_url": {
+                              "type": "string",
+                              "description": "Upgrade page URL for the directory."
+                            },
+                            "cancel_page_url": {
+                              "type": "string",
+                              "description": "Cancel page URL for the directory."
+                            },
+                            "sms_purchase_url": {
+                              "type": "string",
+                              "description": "SMS purchase URL for the directory."
+                            },
+                            "backoffice_url": {
+                              "type": "string",
+                              "description": "Operator Portal Backoffice URL for the directory."
+                            }
+                          }
+                        },
+                        "domain_hosting": {
+                          "type": "object",
+                          "description": "Domain and hosting configuration for the directory's whitelabel setup.",
+                          "properties": {
+                            "subdomain": {
+                              "type": "string",
+                              "description": "The subdomain for the directory. Available at subdomain.vcita.com (or subdomain.myclients.io). Required in order to configure host-mapping DNS (e.g., \"samplepartner\")."
+                            },
+                            "whitelabel_subdomain": {
+                              "type": "boolean",
+                              "description": "When true, forces the whitelabel domain (subdomain.myclients.io) if host mapping is not configured."
+                            },
+                            "host_mapping": {
+                              "type": "string",
+                              "description": "The whitelabel host for the directory. The vendor must configure the DNS record to point to the configured subdomain.vcita.com or subdomain.myclients.io (e.g., \"www.samplepartner.ch\").",
+                              "nullable": true
+                            },
+                            "ssl_enabled": {
+                              "type": "boolean",
+                              "description": "When true, an SSL certificate has been deployed for the host mapping and all traffic is force-redirected to HTTPS."
+                            },
+                            "old_host_mapping": {
+                              "type": "string",
+                              "description": "The previous whitelabel host mapping. Used to redirect to myclients.io when the host mapping is removed.",
+                              "nullable": true
+                            },
+                            "host_mapping_verified_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "description": "Timestamp when the host mapping DNS was last verified.",
+                              "nullable": true
+                            }
+                          }
+                        },
+                        "configs": {
+                          "type": "array",
+                          "description": "Directory-level configuration flags that control behavior and categorization.",
+                          "items": {
+                            "type": "string",
+                            "enum": [
+                              "is_vcita_marketing",
+                              "is_vcita_sales",
+                              "is_vcita_cs",
+                              "is_vcita_support",
+                              "is_default_rollout",
+                              "is_managed_partner",
+                              "is_sandbox",
+                              "send_confirmation_email"
+                            ]
+                          },
+                          "uniqueItems": true
+                        },
+                        "created_at": {
+                          "type": "string",
+                          "format": "date-time",
+                          "description": "Timestamp when the directory was created."
+                        },
+                        "updated_at": {
+                          "type": "string",
+                          "format": "date-time",
+                          "description": "Timestamp when the directory was last updated."
+                        }
+                      },
+                      "required": [
+                        "uid",
+                        "name",
+                        "created_at",
+                        "updated_at"
+                      ],
+                      "example": {
+                        "id": 20338,
+                        "uid": "dir-20338",
+                        "name": "samplepartner",
+                        "partner_name": "samplepartner",
+                        "parent_directory_id": null,
+                        "admin_email": "samplepartner@vcita.com",
+                        "billing_type": "manual",
+                        "manual_type": "co_branded",
+                        "configuration_key": "samplepartner",
+                        "branding_theme_id": null,
+                        "management_theme_id": "2366701",
+                        "management_theme_attributes": {
+                          "id": "2366701",
+                          "logo_url": ""
+                        },
+                        "is_managed": true,
+                        "is_deprecated": false,
+                        "is_slim_register_enabled": false,
+                        "locale": "en",
+                        "time_zone": "America/New_York",
+                        "paypal_email": "",
+                        "rev_share": 20,
+                        "rev_share_tier2": null,
+                        "only_owner_login_redirect": false,
+                        "paid_total": null,
+                        "custom_sms_sending_phone_number": null,
+                        "features": null,
+                        "features_info": {
+                          "524": "available",
+                          "649": "available"
+                        },
+                        "settings": {
+                          "static_page_data": "",
+                          "myaccount_page_url": "",
+                          "managed_login_url": "https://one.samplepartner.com/authbridge/oauth/login",
+                          "new_staff_url": "",
+                          "change_password_url": "https://auth.samplepartner.com/forgot_password?origin_uri=https://one.samplepartner.com/",
+                          "use_login_with_code": false,
+                          "op_support_url": "",
+                          "privacy_policy": "",
+                          "terms_of_service": "",
+                          "compliance_in_billing_app": true,
+                          "enable_upgrade_page_tab": "1",
+                          "enable_separate_payment_method": "0",
+                          "external_review_site": null,
+                          "ada_handle": "samplepartner",
+                          "revshare_coupon": "PARTNER20OFF",
+                          "app_market_url": "https://apps.samplepartner.com/market",
+                          "block_external_app_uninstall": false,
+                          "pendo": "",
+                          "chatbot": ""
+                        },
+                        "welcome_engagement_params": null,
+                        "invite_subject": null,
+                        "invite_body": null,
+                        "is_unsubscribe_sms": false,
+                        "is_disable_analytics": null,
+                        "content_business_id": null,
+                        "is_content_manager_enabled": false,
+                        "is_user_identity_manager_enabled": true,
+                        "ultimate_monthly_subscription_id": null,
+                        "ultimate_annual_subscription_id": null,
+                        "subscriptions_mismatch_at": null,
+                        "white_label_subscription_id": null,
+                        "current_subscription_id": null,
+                        "pending_member_id": null,
+                        "default_package_id": 243,
+                        "is_default_self_paid": true,
+                        "redeem_state": null,
+                        "mobile_app_name": "",
+                        "mobile_app_ios": "",
+                        "mobile_app_android": "",
+                        "email_template_owner_uid": "",
+                        "urls": {
+                          "home_url": "https://home.example.com",
+                          "support_url": "https://support.example.com",
+                          "faq_url": "https://faq.example.com",
+                          "login_url": "https://login.example.com",
+                          "signup_url": "https://signup.example.com",
+                          "upgrade_page_url": "https://upgrade.example.com",
+                          "cancel_page_url": "https://cancel.example.com",
+                          "sms_purchase_url": "https://sms.example.com",
+                          "backoffice_url": "https://backoffice.example.com"
+                        },
+                        "domain_hosting": {
+                          "subdomain": "samplepartner",
+                          "whitelabel_subdomain": true,
+                          "host_mapping": "one.samplepartner.com",
+                          "ssl_enabled": true,
+                          "old_host_mapping": null,
+                          "host_mapping_verified_at": "2025-01-20T17:56:00Z"
+                        },
+                        "configs": [
+                          "is_vcita_marketing",
+                          "is_default_rollout",
+                          "is_managed_partner"
+                        ],
+                        "created_at": "2023-08-01T12:00:00Z",
+                        "updated_at": "2023-10-01T12:00:00Z"
+                      }
                     }
                   }
                 },
@@ -6691,7 +11469,105 @@
                     "value": {
                       "success": true,
                       "data": {
-                        "$ref": "https://vcita.github.io/developers-hub/entities/business_administration/directory.json#/example"
+                        "id": 20338,
+                        "uid": "dir-20338",
+                        "name": "samplepartner",
+                        "partner_name": "samplepartner",
+                        "parent_directory_id": null,
+                        "admin_email": "samplepartner@vcita.com",
+                        "billing_type": "manual",
+                        "manual_type": "co_branded",
+                        "configuration_key": "samplepartner",
+                        "branding_theme_id": null,
+                        "management_theme_id": "2366701",
+                        "management_theme_attributes": {
+                          "id": "2366701",
+                          "logo_url": ""
+                        },
+                        "is_managed": true,
+                        "is_deprecated": false,
+                        "is_slim_register_enabled": false,
+                        "locale": "en",
+                        "time_zone": "America/New_York",
+                        "paypal_email": "",
+                        "rev_share": 20,
+                        "rev_share_tier2": null,
+                        "only_owner_login_redirect": false,
+                        "paid_total": null,
+                        "custom_sms_sending_phone_number": null,
+                        "features": null,
+                        "features_info": {
+                          "524": "available",
+                          "649": "available"
+                        },
+                        "settings": {
+                          "static_page_data": "",
+                          "myaccount_page_url": "",
+                          "managed_login_url": "https://one.samplepartner.com/authbridge/oauth/login",
+                          "new_staff_url": "",
+                          "change_password_url": "https://auth.samplepartner.com/forgot_password?origin_uri=https://one.samplepartner.com/",
+                          "use_login_with_code": false,
+                          "op_support_url": "",
+                          "privacy_policy": "",
+                          "terms_of_service": "",
+                          "compliance_in_billing_app": true,
+                          "enable_upgrade_page_tab": "1",
+                          "enable_separate_payment_method": "0",
+                          "external_review_site": null,
+                          "ada_handle": "samplepartner",
+                          "revshare_coupon": "PARTNER20OFF",
+                          "app_market_url": "https://apps.samplepartner.com/market",
+                          "block_external_app_uninstall": false,
+                          "pendo": "",
+                          "chatbot": ""
+                        },
+                        "welcome_engagement_params": null,
+                        "invite_subject": null,
+                        "invite_body": null,
+                        "is_unsubscribe_sms": false,
+                        "is_disable_analytics": null,
+                        "content_business_id": null,
+                        "is_content_manager_enabled": false,
+                        "is_user_identity_manager_enabled": true,
+                        "ultimate_monthly_subscription_id": null,
+                        "ultimate_annual_subscription_id": null,
+                        "subscriptions_mismatch_at": null,
+                        "white_label_subscription_id": null,
+                        "current_subscription_id": null,
+                        "pending_member_id": null,
+                        "default_package_id": 243,
+                        "is_default_self_paid": true,
+                        "redeem_state": null,
+                        "mobile_app_name": "",
+                        "mobile_app_ios": "",
+                        "mobile_app_android": "",
+                        "email_template_owner_uid": "",
+                        "urls": {
+                          "home_url": "https://home.example.com",
+                          "support_url": "https://support.example.com",
+                          "faq_url": "https://faq.example.com",
+                          "login_url": "https://login.example.com",
+                          "signup_url": "https://signup.example.com",
+                          "upgrade_page_url": "https://upgrade.example.com",
+                          "cancel_page_url": "https://cancel.example.com",
+                          "sms_purchase_url": "https://sms.example.com",
+                          "backoffice_url": "https://backoffice.example.com"
+                        },
+                        "domain_hosting": {
+                          "subdomain": "samplepartner",
+                          "whitelabel_subdomain": true,
+                          "host_mapping": "one.samplepartner.com",
+                          "ssl_enabled": true,
+                          "old_host_mapping": null,
+                          "host_mapping_verified_at": "2025-01-20T17:56:00Z"
+                        },
+                        "configs": [
+                          "is_vcita_marketing",
+                          "is_default_rollout",
+                          "is_managed_partner"
+                        ],
+                        "created_at": "2023-08-01T12:00:00Z",
+                        "updated_at": "2023-10-01T12:00:00Z"
                       }
                     }
                   },
@@ -7067,7 +11943,167 @@
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/business_administration/staff_member.json"
+                          "required": [
+                            "business_uid",
+                            "first_name",
+                            "email",
+                            "role"
+                          ],
+                          "type": "object",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "readOnly": true,
+                              "description": "The unique identifier of the staff member."
+                            },
+                            "first_name": {
+                              "type": "string",
+                              "description": "The first name of the staff member."
+                            },
+                            "last_name": {
+                              "type": [
+                                "string",
+                                "null"
+                              ],
+                              "description": "The last name of the staff member."
+                            },
+                            "display_name": {
+                              "type": [
+                                "string",
+                                "null"
+                              ],
+                              "description": "The display name of the staff member used for public facing interfaces."
+                            },
+                            "email": {
+                              "type": "string",
+                              "description": "The email address of the staff member."
+                            },
+                            "professional_title": {
+                              "type": [
+                                "string",
+                                "null"
+                              ],
+                              "description": "The professional title or position of the staff member (e.g., \"Senior Consultant\", \"Medical Director\")."
+                            },
+                            "business_uid": {
+                              "type": "string",
+                              "readOnly": true,
+                              "description": "The unique identifier of the business the staff member belongs to."
+                            },
+                            "country_name": {
+                              "type": [
+                                "string",
+                                "null"
+                              ],
+                              "description": "The country name for the staff member's mobile number (e.g., \"United States\", \"United Kingdom\")."
+                            },
+                            "mobile_number": {
+                              "type": [
+                                "string",
+                                "null"
+                              ],
+                              "description": "The mobile number of the staff member without country code (e.g., \"2345678901\")."
+                            },
+                            "photo_url": {
+                              "type": [
+                                "string",
+                                "null"
+                              ],
+                              "description": "The URL to the staff member's profile photo."
+                            },
+                            "default_homepage": {
+                              "type": [
+                                "string",
+                                "null"
+                              ],
+                              "description": "The default page to navigate to when the staff member logs in. When null, the system default is used.",
+                              "enum": [
+                                "dashboard",
+                                "inbox",
+                                "calendar",
+                                "clients",
+                                "pos",
+                                null
+                              ]
+                            },
+                            "role": {
+                              "type": "string",
+                              "description": "The role or permission level of the staff member (e.g., \"admin\", \"user\", \"manager\", \"marketing\", \"collaborator\")."
+                            },
+                            "email_signature": {
+                              "type": [
+                                "string",
+                                "null"
+                              ],
+                              "description": "The email signature used by the staff member in communications."
+                            },
+                            "business_role_display_name": {
+                              "type": [
+                                "string",
+                                "null"
+                              ],
+                              "description": "The display name of the staff member's role within the business."
+                            },
+                            "owner": {
+                              "type": "boolean",
+                              "readOnly": true,
+                              "description": "Indicates whether the staff member is an owner of the business."
+                            },
+                            "active": {
+                              "type": "boolean",
+                              "readOnly": true,
+                              "description": "Indicates whether the staff member account is active."
+                            },
+                            "deleted": {
+                              "type": "boolean",
+                              "readOnly": true,
+                              "description": "Indicates whether the staff member has been soft-deleted. Deleted staff members are retained for historical records but are no longer active."
+                            },
+                            "blocked_at": {
+                              "type": [
+                                "string",
+                                "null"
+                              ],
+                              "format": "date-time",
+                              "readOnly": true,
+                              "description": "The date and time when the staff member was blocked, in ISO 8601 format. Null if the staff member is not blocked."
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "readOnly": true,
+                              "description": "The date and time when the staff member was created, in ISO 8601 format."
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "readOnly": true,
+                              "description": "The date and time when the staff member was last updated, in ISO 8601 format."
+                            }
+                          },
+                          "example": {
+                            "uid": "staff-12345",
+                            "first_name": "John",
+                            "last_name": "Doe",
+                            "display_name": "Dr. John Doe",
+                            "email": "john.doe@example.com",
+                            "professional_title": "Senior Consultant",
+                            "business_uid": "business-12345",
+                            "country_name": "United States",
+                            "mobile_number": "2345678901",
+                            "photo_url": "https://storage.example.com/staff/profile/12345.jpg",
+                            "default_homepage": "dashboard",
+                            "role": "admin",
+                            "email_signature": "Best regards,\nJohn Doe\nSenior Consultant",
+                            "business_role_display_name": "Business Administrator",
+                            "owner": true,
+                            "active": true,
+                            "deleted": false,
+                            "blocked_at": null,
+                            "created_at": "2023-01-01T12:00:00Z",
+                            "updated_at": "2023-01-15T09:30:00Z"
+                          },
+                          "description": "Represents a staff member profile within a business, including identity and settings."
                         }
                       }
                     }
@@ -7148,7 +12184,167 @@
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/business_administration/staff_member.json"
+                          "required": [
+                            "business_uid",
+                            "first_name",
+                            "email",
+                            "role"
+                          ],
+                          "type": "object",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "readOnly": true,
+                              "description": "The unique identifier of the staff member."
+                            },
+                            "first_name": {
+                              "type": "string",
+                              "description": "The first name of the staff member."
+                            },
+                            "last_name": {
+                              "type": [
+                                "string",
+                                "null"
+                              ],
+                              "description": "The last name of the staff member."
+                            },
+                            "display_name": {
+                              "type": [
+                                "string",
+                                "null"
+                              ],
+                              "description": "The display name of the staff member used for public facing interfaces."
+                            },
+                            "email": {
+                              "type": "string",
+                              "description": "The email address of the staff member."
+                            },
+                            "professional_title": {
+                              "type": [
+                                "string",
+                                "null"
+                              ],
+                              "description": "The professional title or position of the staff member (e.g., \"Senior Consultant\", \"Medical Director\")."
+                            },
+                            "business_uid": {
+                              "type": "string",
+                              "readOnly": true,
+                              "description": "The unique identifier of the business the staff member belongs to."
+                            },
+                            "country_name": {
+                              "type": [
+                                "string",
+                                "null"
+                              ],
+                              "description": "The country name for the staff member's mobile number (e.g., \"United States\", \"United Kingdom\")."
+                            },
+                            "mobile_number": {
+                              "type": [
+                                "string",
+                                "null"
+                              ],
+                              "description": "The mobile number of the staff member without country code (e.g., \"2345678901\")."
+                            },
+                            "photo_url": {
+                              "type": [
+                                "string",
+                                "null"
+                              ],
+                              "description": "The URL to the staff member's profile photo."
+                            },
+                            "default_homepage": {
+                              "type": [
+                                "string",
+                                "null"
+                              ],
+                              "description": "The default page to navigate to when the staff member logs in. When null, the system default is used.",
+                              "enum": [
+                                "dashboard",
+                                "inbox",
+                                "calendar",
+                                "clients",
+                                "pos",
+                                null
+                              ]
+                            },
+                            "role": {
+                              "type": "string",
+                              "description": "The role or permission level of the staff member (e.g., \"admin\", \"user\", \"manager\", \"marketing\", \"collaborator\")."
+                            },
+                            "email_signature": {
+                              "type": [
+                                "string",
+                                "null"
+                              ],
+                              "description": "The email signature used by the staff member in communications."
+                            },
+                            "business_role_display_name": {
+                              "type": [
+                                "string",
+                                "null"
+                              ],
+                              "description": "The display name of the staff member's role within the business."
+                            },
+                            "owner": {
+                              "type": "boolean",
+                              "readOnly": true,
+                              "description": "Indicates whether the staff member is an owner of the business."
+                            },
+                            "active": {
+                              "type": "boolean",
+                              "readOnly": true,
+                              "description": "Indicates whether the staff member account is active."
+                            },
+                            "deleted": {
+                              "type": "boolean",
+                              "readOnly": true,
+                              "description": "Indicates whether the staff member has been soft-deleted. Deleted staff members are retained for historical records but are no longer active."
+                            },
+                            "blocked_at": {
+                              "type": [
+                                "string",
+                                "null"
+                              ],
+                              "format": "date-time",
+                              "readOnly": true,
+                              "description": "The date and time when the staff member was blocked, in ISO 8601 format. Null if the staff member is not blocked."
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "readOnly": true,
+                              "description": "The date and time when the staff member was created, in ISO 8601 format."
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "readOnly": true,
+                              "description": "The date and time when the staff member was last updated, in ISO 8601 format."
+                            }
+                          },
+                          "example": {
+                            "uid": "staff-12345",
+                            "first_name": "John",
+                            "last_name": "Doe",
+                            "display_name": "Dr. John Doe",
+                            "email": "john.doe@example.com",
+                            "professional_title": "Senior Consultant",
+                            "business_uid": "business-12345",
+                            "country_name": "United States",
+                            "mobile_number": "2345678901",
+                            "photo_url": "https://storage.example.com/staff/profile/12345.jpg",
+                            "default_homepage": "dashboard",
+                            "role": "admin",
+                            "email_signature": "Best regards,\nJohn Doe\nSenior Consultant",
+                            "business_role_display_name": "Business Administrator",
+                            "owner": true,
+                            "active": true,
+                            "deleted": false,
+                            "blocked_at": null,
+                            "created_at": "2023-01-01T12:00:00Z",
+                            "updated_at": "2023-01-15T09:30:00Z"
+                          },
+                          "description": "Represents a staff member profile within a business, including identity and settings."
                         }
                       }
                     }
@@ -7391,7 +12587,50 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
@@ -7401,7 +12640,58 @@
                             "online_profile": {
                               "oneOf": [
                                 {
-                                  "$ref": "https://vcita.github.io/developers-hub/entities/business_administration/onlineProfile.json"
+                                  "type": "object",
+                                  "description": "Online profile configuration for a business. Contains settings for client-facing features like supported languages and privacy policy used by the Client Portal. This is a singleton resource - each business has at most one online profile.",
+                                  "properties": {
+                                    "uid": {
+                                      "type": "string",
+                                      "readOnly": true,
+                                      "description": "Unique identifier for the online profile record."
+                                    },
+                                    "business_uid": {
+                                      "type": "string",
+                                      "description": "Unique identifier of the business that owns this online profile."
+                                    },
+                                    "supported_languages": {
+                                      "type": "array",
+                                      "description": "List of ISO 639-1 language/locale codes supported by the business for client-facing content (e.g., [\"en\", \"es\", \"en-GB\"]).",
+                                      "items": {
+                                        "type": "string",
+                                        "pattern": "^[a-z]{2}(-[A-Z]{2})?$"
+                                      },
+                                      "uniqueItems": true
+                                    },
+                                    "privacy_policy_url": {
+                                      "type": "string",
+                                      "maxLength": 2048,
+                                      "format": "uri",
+                                      "nullable": true,
+                                      "description": "External URL to the business's privacy policy page (e.g., \"https://example.com/privacy\"). Null if not configured."
+                                    },
+                                    "created_at": {
+                                      "type": "string",
+                                      "format": "date-time",
+                                      "readOnly": true,
+                                      "description": "The date and time when the online profile was created, in ISO 8601 format."
+                                    },
+                                    "updated_at": {
+                                      "type": "string",
+                                      "format": "date-time",
+                                      "readOnly": true,
+                                      "description": "The date and time when the online profile was last updated, in ISO 8601 format."
+                                    }
+                                  },
+                                  "example": {
+                                    "uid": "abc123",
+                                    "business_uid": "d290f1ee26c54",
+                                    "supported_languages": [
+                                      "en",
+                                      "es"
+                                    ],
+                                    "privacy_policy_url": "https://example.com/privacy",
+                                    "created_at": "2026-01-12T10:30:00Z",
+                                    "updated_at": "2026-01-12T10:30:00Z"
+                                  }
                                 },
                                 {
                                   "type": "null"
@@ -7500,7 +12790,58 @@
                             {
                               "type": "array",
                               "items": {
-                                "$ref": "https://vcita.github.io/developers-hub/entities/business_administration/onlineProfile.json"
+                                "type": "object",
+                                "description": "Online profile configuration for a business. Contains settings for client-facing features like supported languages and privacy policy used by the Client Portal. This is a singleton resource - each business has at most one online profile.",
+                                "properties": {
+                                  "uid": {
+                                    "type": "string",
+                                    "readOnly": true,
+                                    "description": "Unique identifier for the online profile record."
+                                  },
+                                  "business_uid": {
+                                    "type": "string",
+                                    "description": "Unique identifier of the business that owns this online profile."
+                                  },
+                                  "supported_languages": {
+                                    "type": "array",
+                                    "description": "List of ISO 639-1 language/locale codes supported by the business for client-facing content (e.g., [\"en\", \"es\", \"en-GB\"]).",
+                                    "items": {
+                                      "type": "string",
+                                      "pattern": "^[a-z]{2}(-[A-Z]{2})?$"
+                                    },
+                                    "uniqueItems": true
+                                  },
+                                  "privacy_policy_url": {
+                                    "type": "string",
+                                    "maxLength": 2048,
+                                    "format": "uri",
+                                    "nullable": true,
+                                    "description": "External URL to the business's privacy policy page (e.g., \"https://example.com/privacy\"). Null if not configured."
+                                  },
+                                  "created_at": {
+                                    "type": "string",
+                                    "format": "date-time",
+                                    "readOnly": true,
+                                    "description": "The date and time when the online profile was created, in ISO 8601 format."
+                                  },
+                                  "updated_at": {
+                                    "type": "string",
+                                    "format": "date-time",
+                                    "readOnly": true,
+                                    "description": "The date and time when the online profile was last updated, in ISO 8601 format."
+                                  }
+                                },
+                                "example": {
+                                  "uid": "abc123",
+                                  "business_uid": "d290f1ee26c54",
+                                  "supported_languages": [
+                                    "en",
+                                    "es"
+                                  ],
+                                  "privacy_policy_url": "https://example.com/privacy",
+                                  "created_at": "2026-01-12T10:30:00Z",
+                                  "updated_at": "2026-01-12T10:30:00Z"
+                                }
                               }
                             },
                             {
@@ -7619,12 +12960,106 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/business_administration/onlineProfile.json"
+                          "type": "object",
+                          "description": "Online profile configuration for a business. Contains settings for client-facing features like supported languages and privacy policy used by the Client Portal. This is a singleton resource - each business has at most one online profile.",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "readOnly": true,
+                              "description": "Unique identifier for the online profile record."
+                            },
+                            "business_uid": {
+                              "type": "string",
+                              "description": "Unique identifier of the business that owns this online profile."
+                            },
+                            "supported_languages": {
+                              "type": "array",
+                              "description": "List of ISO 639-1 language/locale codes supported by the business for client-facing content (e.g., [\"en\", \"es\", \"en-GB\"]).",
+                              "items": {
+                                "type": "string",
+                                "pattern": "^[a-z]{2}(-[A-Z]{2})?$"
+                              },
+                              "uniqueItems": true
+                            },
+                            "privacy_policy_url": {
+                              "type": "string",
+                              "maxLength": 2048,
+                              "format": "uri",
+                              "nullable": true,
+                              "description": "External URL to the business's privacy policy page (e.g., \"https://example.com/privacy\"). Null if not configured."
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "readOnly": true,
+                              "description": "The date and time when the online profile was created, in ISO 8601 format."
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "readOnly": true,
+                              "description": "The date and time when the online profile was last updated, in ISO 8601 format."
+                            }
+                          },
+                          "example": {
+                            "uid": "abc123",
+                            "business_uid": "d290f1ee26c54",
+                            "supported_languages": [
+                              "en",
+                              "es"
+                            ],
+                            "privacy_policy_url": "https://example.com/privacy",
+                            "created_at": "2026-01-12T10:30:00Z",
+                            "updated_at": "2026-01-12T10:30:00Z"
+                          }
                         }
                       }
                     }
@@ -7818,12 +13253,106 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/business_administration/onlineProfile.json"
+                          "type": "object",
+                          "description": "Online profile configuration for a business. Contains settings for client-facing features like supported languages and privacy policy used by the Client Portal. This is a singleton resource - each business has at most one online profile.",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "readOnly": true,
+                              "description": "Unique identifier for the online profile record."
+                            },
+                            "business_uid": {
+                              "type": "string",
+                              "description": "Unique identifier of the business that owns this online profile."
+                            },
+                            "supported_languages": {
+                              "type": "array",
+                              "description": "List of ISO 639-1 language/locale codes supported by the business for client-facing content (e.g., [\"en\", \"es\", \"en-GB\"]).",
+                              "items": {
+                                "type": "string",
+                                "pattern": "^[a-z]{2}(-[A-Z]{2})?$"
+                              },
+                              "uniqueItems": true
+                            },
+                            "privacy_policy_url": {
+                              "type": "string",
+                              "maxLength": 2048,
+                              "format": "uri",
+                              "nullable": true,
+                              "description": "External URL to the business's privacy policy page (e.g., \"https://example.com/privacy\"). Null if not configured."
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "readOnly": true,
+                              "description": "The date and time when the online profile was created, in ISO 8601 format."
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "readOnly": true,
+                              "description": "The date and time when the online profile was last updated, in ISO 8601 format."
+                            }
+                          },
+                          "example": {
+                            "uid": "abc123",
+                            "business_uid": "d290f1ee26c54",
+                            "supported_languages": [
+                              "en",
+                              "es"
+                            ],
+                            "privacy_policy_url": "https://example.com/privacy",
+                            "created_at": "2026-01-12T10:30:00Z",
+                            "updated_at": "2026-01-12T10:30:00Z"
+                          }
                         }
                       }
                     }
@@ -9214,7 +14743,50 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
@@ -9375,7 +14947,50 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
@@ -9501,7 +15116,50 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
@@ -9621,12 +15279,138 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/access_control/businessRole.json"
+                          "type": "object",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "description": "The unique identifier (UID) of the BusinessRole"
+                            },
+                            "code": {
+                              "type": "string",
+                              "description": "A unique readable code for the role"
+                            },
+                            "name": {
+                              "type": "string",
+                              "description": "The role name as it's presented in the UI. By default, it will be assigned from the original permission, but can be overridden for a specific business"
+                            },
+                            "description": {
+                              "type": "string",
+                              "description": "The role description as it’s presented in the UI. By default, it will be assigned from the original permission, but can be overridden for a specific business"
+                            },
+                            "permissions": {
+                              "type": "array",
+                              "description": "A list of permissions that are assigned to the role by default",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "key": {
+                                    "type": "string",
+                                    "description": "The unique identifier (UID) of the Permission"
+                                  },
+                                  "allow": {
+                                    "type": "boolean",
+                                    "description": "A flag indicating if this permission is by default assigned to the role"
+                                  }
+                                }
+                              }
+                            },
+                            "is_editable": {
+                              "type": "boolean",
+                              "description": "A flag to indicate if the role can be edited by the business. By default, system roles are not editable",
+                              "default": true
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "format": "string",
+                              "description": "Date the BusinessRole was created"
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "format": "string",
+                              "description": "Date the BusinessRole was last updated"
+                            }
+                          },
+                          "required": [
+                            "uid",
+                            "name",
+                            "description",
+                            "permissions",
+                            "created_at",
+                            "updated_at"
+                          ],
+                          "example": {
+                            "uid": "d290f1ee-6c54-4b01-90e6-d701748f0851",
+                            "business_uid": "b290f1ee-6c54-4b01-90e6-d701748f0851",
+                            "code": "admin",
+                            "name": "Admin",
+                            "description": "Admin role. Typically has access to all features in the system",
+                            "is_editable": true,
+                            "permissions": [
+                              {
+                                "key": "payments.invoices.export",
+                                "allow": true
+                              },
+                              {
+                                "key": "payments.manage",
+                                "allow": true
+                              },
+                              {
+                                "key": "reports.manage",
+                                "allow": true
+                              }
+                            ],
+                            "created_at": "2021-07-20T14:00:00.000Z",
+                            "updated_at": "2021-07-20T14:00:00.000Z"
+                          },
+                          "description": "A role is a named set of default permissions for a business account. For example, admin, manager etc."
                         }
                       }
                     }
@@ -9792,12 +15576,138 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/access_control/businessRole.json"
+                          "type": "object",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "description": "The unique identifier (UID) of the BusinessRole"
+                            },
+                            "code": {
+                              "type": "string",
+                              "description": "A unique readable code for the role"
+                            },
+                            "name": {
+                              "type": "string",
+                              "description": "The role name as it's presented in the UI. By default, it will be assigned from the original permission, but can be overridden for a specific business"
+                            },
+                            "description": {
+                              "type": "string",
+                              "description": "The role description as it’s presented in the UI. By default, it will be assigned from the original permission, but can be overridden for a specific business"
+                            },
+                            "permissions": {
+                              "type": "array",
+                              "description": "A list of permissions that are assigned to the role by default",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "key": {
+                                    "type": "string",
+                                    "description": "The unique identifier (UID) of the Permission"
+                                  },
+                                  "allow": {
+                                    "type": "boolean",
+                                    "description": "A flag indicating if this permission is by default assigned to the role"
+                                  }
+                                }
+                              }
+                            },
+                            "is_editable": {
+                              "type": "boolean",
+                              "description": "A flag to indicate if the role can be edited by the business. By default, system roles are not editable",
+                              "default": true
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "format": "string",
+                              "description": "Date the BusinessRole was created"
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "format": "string",
+                              "description": "Date the BusinessRole was last updated"
+                            }
+                          },
+                          "required": [
+                            "uid",
+                            "name",
+                            "description",
+                            "permissions",
+                            "created_at",
+                            "updated_at"
+                          ],
+                          "example": {
+                            "uid": "d290f1ee-6c54-4b01-90e6-d701748f0851",
+                            "business_uid": "b290f1ee-6c54-4b01-90e6-d701748f0851",
+                            "code": "admin",
+                            "name": "Admin",
+                            "description": "Admin role. Typically has access to all features in the system",
+                            "is_editable": true,
+                            "permissions": [
+                              {
+                                "key": "payments.invoices.export",
+                                "allow": true
+                              },
+                              {
+                                "key": "payments.manage",
+                                "allow": true
+                              },
+                              {
+                                "key": "reports.manage",
+                                "allow": true
+                              }
+                            ],
+                            "created_at": "2021-07-20T14:00:00.000Z",
+                            "updated_at": "2021-07-20T14:00:00.000Z"
+                          },
+                          "description": "A role is a named set of default permissions for a business account. For example, admin, manager etc."
                         }
                       }
                     }
@@ -9878,12 +15788,138 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/access_control/businessRole.json"
+                          "type": "object",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "description": "The unique identifier (UID) of the BusinessRole"
+                            },
+                            "code": {
+                              "type": "string",
+                              "description": "A unique readable code for the role"
+                            },
+                            "name": {
+                              "type": "string",
+                              "description": "The role name as it's presented in the UI. By default, it will be assigned from the original permission, but can be overridden for a specific business"
+                            },
+                            "description": {
+                              "type": "string",
+                              "description": "The role description as it’s presented in the UI. By default, it will be assigned from the original permission, but can be overridden for a specific business"
+                            },
+                            "permissions": {
+                              "type": "array",
+                              "description": "A list of permissions that are assigned to the role by default",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "key": {
+                                    "type": "string",
+                                    "description": "The unique identifier (UID) of the Permission"
+                                  },
+                                  "allow": {
+                                    "type": "boolean",
+                                    "description": "A flag indicating if this permission is by default assigned to the role"
+                                  }
+                                }
+                              }
+                            },
+                            "is_editable": {
+                              "type": "boolean",
+                              "description": "A flag to indicate if the role can be edited by the business. By default, system roles are not editable",
+                              "default": true
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "format": "string",
+                              "description": "Date the BusinessRole was created"
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "format": "string",
+                              "description": "Date the BusinessRole was last updated"
+                            }
+                          },
+                          "required": [
+                            "uid",
+                            "name",
+                            "description",
+                            "permissions",
+                            "created_at",
+                            "updated_at"
+                          ],
+                          "example": {
+                            "uid": "d290f1ee-6c54-4b01-90e6-d701748f0851",
+                            "business_uid": "b290f1ee-6c54-4b01-90e6-d701748f0851",
+                            "code": "admin",
+                            "name": "Admin",
+                            "description": "Admin role. Typically has access to all features in the system",
+                            "is_editable": true,
+                            "permissions": [
+                              {
+                                "key": "payments.invoices.export",
+                                "allow": true
+                              },
+                              {
+                                "key": "payments.manage",
+                                "allow": true
+                              },
+                              {
+                                "key": "reports.manage",
+                                "allow": true
+                              }
+                            ],
+                            "created_at": "2021-07-20T14:00:00.000Z",
+                            "updated_at": "2021-07-20T14:00:00.000Z"
+                          },
+                          "description": "A role is a named set of default permissions for a business account. For example, admin, manager etc."
                         }
                       }
                     }
@@ -9925,7 +15961,50 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     }
                   ]
                 }
@@ -9991,7 +16070,50 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
@@ -10082,7 +16204,50 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
@@ -10146,12 +16311,86 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/access_control/staffBusinessRole.json"
+                          "type": "object",
+                          "properties": {
+                            "staff_uid": {
+                              "type": "string",
+                              "description": "The unique identifier (UID) of the staff member"
+                            },
+                            "business_role_uid": {
+                              "type": "string",
+                              "description": "A unique identifier (UID) of the associated BusinessRole"
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "description": "Date the StaffBusinessRole was created"
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "description": "Date the StaffBuinsessRole was last updated"
+                            }
+                          },
+                          "required": [
+                            "staff_uid",
+                            "business_role_uid",
+                            "created_at",
+                            "updated_at"
+                          ],
+                          "example": {
+                            "staff_uid": "d290f1ee-6c54-4b01-90e6-d701748f0851",
+                            "business_role_uid": "d290f1ee-6c54-4b01-90e6-d701748f0851",
+                            "created_at": "2021-07-20T14:00:00.000Z",
+                            "updated_at": "2021-07-20T14:00:00.000Z"
+                          },
+                          "description": "A StaffBusinessRole is an assignment of a BusinessRole to a staff member, defining their permissions within a business account. For example, admin, manager etc."
                         }
                       }
                     }
@@ -10195,12 +16434,86 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/access_control/staffBusinessRole.json"
+                          "type": "object",
+                          "properties": {
+                            "staff_uid": {
+                              "type": "string",
+                              "description": "The unique identifier (UID) of the staff member"
+                            },
+                            "business_role_uid": {
+                              "type": "string",
+                              "description": "A unique identifier (UID) of the associated BusinessRole"
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "description": "Date the StaffBusinessRole was created"
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "description": "Date the StaffBuinsessRole was last updated"
+                            }
+                          },
+                          "required": [
+                            "staff_uid",
+                            "business_role_uid",
+                            "created_at",
+                            "updated_at"
+                          ],
+                          "example": {
+                            "staff_uid": "d290f1ee-6c54-4b01-90e6-d701748f0851",
+                            "business_role_uid": "d290f1ee-6c54-4b01-90e6-d701748f0851",
+                            "created_at": "2021-07-20T14:00:00.000Z",
+                            "updated_at": "2021-07-20T14:00:00.000Z"
+                          },
+                          "description": "A StaffBusinessRole is an assignment of a BusinessRole to a staff member, defining their permissions within a business account. For example, admin, manager etc."
                         }
                       }
                     }
@@ -10265,12 +16578,86 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/access_control/staffBusinessRole.json"
+                          "type": "object",
+                          "properties": {
+                            "staff_uid": {
+                              "type": "string",
+                              "description": "The unique identifier (UID) of the staff member"
+                            },
+                            "business_role_uid": {
+                              "type": "string",
+                              "description": "A unique identifier (UID) of the associated BusinessRole"
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "description": "Date the StaffBusinessRole was created"
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "description": "Date the StaffBuinsessRole was last updated"
+                            }
+                          },
+                          "required": [
+                            "staff_uid",
+                            "business_role_uid",
+                            "created_at",
+                            "updated_at"
+                          ],
+                          "example": {
+                            "staff_uid": "d290f1ee-6c54-4b01-90e6-d701748f0851",
+                            "business_role_uid": "d290f1ee-6c54-4b01-90e6-d701748f0851",
+                            "created_at": "2021-07-20T14:00:00.000Z",
+                            "updated_at": "2021-07-20T14:00:00.000Z"
+                          },
+                          "description": "A StaffBusinessRole is an assignment of a BusinessRole to a staff member, defining their permissions within a business account. For example, admin, manager etc."
                         }
                       }
                     }
@@ -10314,12 +16701,124 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/access_control/staffPermissionOverridesList.json"
+                          "type": "object",
+                          "properties": {
+                            "staff_uid": {
+                              "type": "string",
+                              "description": ""
+                            },
+                            "permissions": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "key": {
+                                    "type": "string",
+                                    "description": "The unique identifier (UID) of the Permission"
+                                  },
+                                  "state": {
+                                    "type": "string",
+                                    "description": "an enum value of 'allow', 'deny'. Note, when updating the field to 'inherit' the overide is removed and the default permission from the BusinessRole is used",
+                                    "enum": [
+                                      "allow",
+                                      "deny"
+                                    ]
+                                  }
+                                }
+                              },
+                              "description": "An entity holding the list of permissions that override the default permissions of the BusinessRole assigned to the staff member. When empty, role defaults are assigned to the user."
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "description": "Date the BusinessRole was created"
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "description": "Date the BuinsessRole was last updated"
+                            }
+                          },
+                          "required": [
+                            "staff_uid",
+                            "permissions",
+                            "created_at",
+                            "updated_at"
+                          ],
+                          "example": {
+                            "staff_uid": "d290f1ee-6c54-4b01-90e6-d701748f0851",
+                            "permissions": [
+                              {
+                                "key": "payments.invoices.export",
+                                "state": "allow"
+                              },
+                              {
+                                "key": "payments.invoices.import",
+                                "state": "allow"
+                              },
+                              {
+                                "key": "payments.invoices.view",
+                                "state": "deny"
+                              },
+                              {
+                                "key": "payments.invoices.delete",
+                                "state": "deny"
+                              },
+                              {
+                                "key": "payments.invoices.create",
+                                "state": "allow"
+                              }
+                            ],
+                            "created_at": "2021-07-20T14:00:00.000Z",
+                            "updated_at": "2021-07-20T14:00:00.000Z"
+                          },
+                          "description": "An entity holding the list of permissions that override the default permissions of the BusinessRole assigned to the staff member. When empty role defaults are assigned to the user"
                         }
                       }
                     }
@@ -10423,12 +16922,124 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/access_control/staffPermissionOverridesList.json"
+                          "type": "object",
+                          "properties": {
+                            "staff_uid": {
+                              "type": "string",
+                              "description": ""
+                            },
+                            "permissions": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "key": {
+                                    "type": "string",
+                                    "description": "The unique identifier (UID) of the Permission"
+                                  },
+                                  "state": {
+                                    "type": "string",
+                                    "description": "an enum value of 'allow', 'deny'. Note, when updating the field to 'inherit' the overide is removed and the default permission from the BusinessRole is used",
+                                    "enum": [
+                                      "allow",
+                                      "deny"
+                                    ]
+                                  }
+                                }
+                              },
+                              "description": "An entity holding the list of permissions that override the default permissions of the BusinessRole assigned to the staff member. When empty, role defaults are assigned to the user."
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "description": "Date the BusinessRole was created"
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "description": "Date the BuinsessRole was last updated"
+                            }
+                          },
+                          "required": [
+                            "staff_uid",
+                            "permissions",
+                            "created_at",
+                            "updated_at"
+                          ],
+                          "example": {
+                            "staff_uid": "d290f1ee-6c54-4b01-90e6-d701748f0851",
+                            "permissions": [
+                              {
+                                "key": "payments.invoices.export",
+                                "state": "allow"
+                              },
+                              {
+                                "key": "payments.invoices.import",
+                                "state": "allow"
+                              },
+                              {
+                                "key": "payments.invoices.view",
+                                "state": "deny"
+                              },
+                              {
+                                "key": "payments.invoices.delete",
+                                "state": "deny"
+                              },
+                              {
+                                "key": "payments.invoices.create",
+                                "state": "allow"
+                              }
+                            ],
+                            "created_at": "2021-07-20T14:00:00.000Z",
+                            "updated_at": "2021-07-20T14:00:00.000Z"
+                          },
+                          "description": "An entity holding the list of permissions that override the default permissions of the BusinessRole assigned to the staff member. When empty role defaults are assigned to the user"
                         }
                       }
                     }
@@ -10470,7 +17081,50 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     }
                   ]
                 }
@@ -10536,7 +17190,50 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
@@ -10588,7 +17285,50 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
@@ -11186,7 +17926,192 @@
             "description": "List of Features Packages",
             "type": "array",
             "items": {
-              "$ref": "https://vcita.github.io/developers-hub/entities/license/featuresPackage.json"
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "integer",
+                  "readOnly": true,
+                  "description": "Unique identifier for the plan package."
+                },
+                "uid": {
+                  "type": "string",
+                  "readOnly": true,
+                  "description": "Unique identifier for the plan package (string format)."
+                },
+                "name": {
+                  "type": "string",
+                  "description": "Internal name of the plan package."
+                },
+                "display_name": {
+                  "type": "string",
+                  "description": "Display name of the plan package shown to users."
+                },
+                "quotas": {
+                  "type": "object",
+                  "description": "Quotas and limits for the plan package.",
+                  "properties": {
+                    "campaign_recipients_monthly_quota": {
+                      "type": "integer",
+                      "description": "Monthly quota for campaign recipients."
+                    },
+                    "invoice_monthly_quota": {
+                      "type": "integer",
+                      "description": "Monthly quota for the number of invoices that can be created in the account. If omitted, the plan package has no limit on the number of invoices."
+                    },
+                    "estimate_monthly_quota": {
+                      "type": "integer",
+                      "description": "Monthly quota for the number of estimates that can be created in the account. If omitted, the plan package has no limit on the number of estimates."
+                    },
+                    "sms_monthly_quota": {
+                      "type": "object",
+                      "description": "Monthly quota for SMS messages. This is an array of objects, each containing a `country_code` and `quota`.",
+                      "properties": {
+                        "us_canada": {
+                          "type": "integer",
+                          "description": "The number of SMS messages allowed for the US and Canada."
+                        },
+                        "other": {
+                          "type": "integer",
+                          "description": "The number of SMS messages allowed for other countries."
+                        }
+                      }
+                    },
+                    "storage_quota": {
+                      "type": "integer",
+                      "description": "Storage quota in megabytes (MB) for the plan package."
+                    },
+                    "clients_credit": {
+                      "type": "integer",
+                      "description": "Monthly quota for the number of clients that can be added to the account. If ommited, the plan package has no limit on the number of clients."
+                    },
+                    "campaigns_credit": {
+                      "type": "integer",
+                      "description": "Monthly quota for the number of campaigns that can be created in the account. If omitted, the plan package has no limit on the number of campaigns."
+                    },
+                    "booking_credit": {
+                      "type": "integer",
+                      "description": "Monthly quota for the number of appointment bookings that can be made in the account. If omitted, the plan package has no limit on the number of bookings."
+                    }
+                  }
+                },
+                "settings": {
+                  "type": "object",
+                  "description": "Settings and configurations for the plan package.",
+                  "properties": {
+                    "disable_add_staff_button": {
+                      "type": [
+                        "boolean",
+                        "string",
+                        "null"
+                      ],
+                      "description": "Whether the add staff button is disabled. May return boolean (true/false) or string values (e.g., \"true\" or \"false\")."
+                    },
+                    "disable_staff_slots": {
+                      "type": [
+                        "boolean",
+                        "string",
+                        "null"
+                      ],
+                      "description": "Whether staff slots are disabled. May return boolean (true/false) or string values (e.g., \"true\" or \"false\")."
+                    },
+                    "disable_sms_purchase_button": {
+                      "type": "boolean",
+                      "description": "Whether the SMS purchase button is disabled."
+                    }
+                  }
+                },
+                "free": {
+                  "type": "boolean",
+                  "description": "Indicates if this is a free plan package.",
+                  "default": false
+                },
+                "created_at": {
+                  "type": "string",
+                  "description": "Timestamp when the plan package was created."
+                },
+                "updated_at": {
+                  "type": "string",
+                  "description": "Timestamp when the plan package was last updated."
+                },
+                "features": {
+                  "type": "array",
+                  "description": "List of features included in the plan package.",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "integer",
+                        "description": "Unique identifier for the feature."
+                      },
+                      "name": {
+                        "type": "string",
+                        "description": "Internal name of the feature."
+                      },
+                      "description": {
+                        "type": "string",
+                        "description": "Description of what the feature provides."
+                      }
+                    },
+                    "required": [
+                      "id",
+                      "name"
+                    ]
+                  }
+                }
+              },
+              "required": [
+                "id",
+                "name",
+                "display_name",
+                "free",
+                "created_at",
+                "updated_at",
+                "features"
+              ],
+              "example": {
+                "id": 1,
+                "name": "scheduling",
+                "display_name": "Online Scheduling",
+                "quotas": {
+                  "campaign_recipients_monthly_quota": 300,
+                  "invoice_monthly_quota": 100,
+                  "estimate_monthly_quota": 50,
+                  "sms_monthly_quota": {
+                    "us_canada": 1000,
+                    "other": 500
+                  },
+                  "storage_quota": 5000,
+                  "clients_credit": 1000,
+                  "campaigns_credit": 10,
+                  "booking_credit": 500
+                },
+                "settings": {
+                  "disable_add_staff_button": "true",
+                  "disable_staff_slots": "true",
+                  "disable_sms_purchase_button": true
+                },
+                "free": true,
+                "created_at": "Wed, May 29, 2013 at 12:21pm",
+                "updated_at": "Tue, June 10 at 11:12am",
+                "features": [
+                  {
+                    "id": 1,
+                    "name": "basic_business_features",
+                    "description": "Privilege to turn on reminder in cliche, email signature in vCita, Allow business to mark message as read/unread"
+                  },
+                  {
+                    "id": 2,
+                    "name": "scheduling_features",
+                    "description": "SMS booking confirmation, scheduling notice, auto follow up hours, meeting auto response, charge type, reminders, client card fields no multiline. if this feature is not on there is only in test quota for online scheduling"
+                  },
+                  {
+                    "id": 3,
+                    "name": "invoicing_features",
+                    "description": "Allow invoicing for an account (payments module sub feature)"
+                  }
+                ]
+              },
+              "description": "Defines a plan package's quotas, settings, and included features."
             }
           }
         }
@@ -11198,7 +18123,226 @@
             "description": "List of Offerings",
             "type": "array",
             "items": {
-              "$ref": "https://vcita.github.io/developers-hub/entities/license/offering.json"
+              "type": "object",
+              "properties": {
+                "uid": {
+                  "type": "string",
+                  "description": "The entity unique identifier"
+                },
+                "created_at": {
+                  "type": "string",
+                  "description": "Timestamp indicating when the entity was created",
+                  "format": "date-time"
+                },
+                "updated_at": {
+                  "type": "string",
+                  "description": "Timestamp of the entity's most recent update",
+                  "format": "date-time"
+                },
+                "type": {
+                  "type": "string",
+                  "description": "Type of the offering. Possible values include: **package** for the main business subscription; **app** for marketplace app subscriptions and **addon** for other SKUs like SMS and staff_seats. A user can have one subscription with package, one subscription per SKU of type apps and any number of subscriptions for any SKU",
+                  "enum": [
+                    "package",
+                    "app",
+                    "addon"
+                  ]
+                },
+                "SKU": {
+                  "type": "string",
+                  "description": "The unique code of the single SKU this offering represents. Offerings support exactly one SKU; to combine multiple SKUs, use a bundledOffering or similar higher-level abstraction."
+                },
+                "display_name": {
+                  "type": "string",
+                  "description": "The SKU's display name"
+                },
+                "quantity": {
+                  "type": "number",
+                  "description": "The number of items included in the offering. Use `-1` to indicate **unlimited** quantity (e.g., unlimited staff seats). When quantity is `-1`, the system treats the resource as uncapped — no usage limit is enforced. This is typically used for `staff_seat` add-on offerings distributed as part of a bundle.",
+                  "default": 1
+                },
+                "payment_type": {
+                  "type": "string",
+                  "description": "The payment type field defines the payment options available for an offering,**external**: Payment is not done by the platform (typically an API call from the partner), **external_single_charge**: A one-time externally-managed payment (typically an API call from the partner) that grants a single credit (e.g., SMS); behaves like external for billing but its quota is counted as purchased; not supported for package offerings, **free**: No payment is required; **single_charge**: A single, one-time payment is required to obtain the offering; **monthly**: A recurring payment made on a monthly basis; **annual**: A recurring payment made on a yearly basis; **bundle**: A subscription bundled with another subscription",
+                  "enum": [
+                    "monthly",
+                    "annualy",
+                    "free",
+                    "single_charge",
+                    "external",
+                    "external_single_charge",
+                    "bundle"
+                  ]
+                },
+                "is_active": {
+                  "type": "boolean",
+                  "description": "Current status of the directory offering",
+                  "default": true
+                },
+                "is_listed": {
+                  "type": "boolean",
+                  "description": "Listing visibility. Defaults to `true` for every offering; when `false` the offering is hidden from listings but remains reachable via a direct link to its info page.",
+                  "default": true
+                },
+                "vendor": {
+                  "type": "string",
+                  "description": "The business entity or vendor that offers this SKU.",
+                  "enum": [
+                    "partner",
+                    "inTandem"
+                  ],
+                  "default": "inTandem"
+                },
+                "prices": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "price": {
+                        "type": "string",
+                        "description": "Cost of the directory offering. Returns as a string value (e.g., \"5.00\")."
+                      },
+                      "currency": {
+                        "type": "string",
+                        "description": "The currency used for the price. Supported currencies include USD, EUR, GBP, CHF, ILS, AUD, CAD, NZD, PLN, MXN, BRL.",
+                        "enum": [
+                          "USD",
+                          "EUR",
+                          "GBP",
+                          "CHF",
+                          "ILS",
+                          "AUD",
+                          "CAD",
+                          "NZD",
+                          "PLN",
+                          "MXN",
+                          "BRL"
+                        ]
+                      }
+                    }
+                  }
+                },
+                "trial_type": {
+                  "type": "string",
+                  "description": "Specifies how the trial option is managed. expire: trial is enabled and subscription will expire after trial_period days. no_trial: no trial period. Future values may include: automatic_charge (auto-charge after trial), manually_charge (stay active without charging).",
+                  "enum": [
+                    "expire",
+                    "no_trial"
+                  ],
+                  "default": "no_trial"
+                },
+                "trial_period": {
+                  "type": "number",
+                  "description": "Number of days for the trial period. If not specified or set to 0, it indicates no trial period is offered."
+                },
+                "reporting_tags": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": [
+                      "base",
+                      "free",
+                      "trial",
+                      "ghost",
+                      "business_management",
+                      "sandbox",
+                      "no_marketing",
+                      "no_payments",
+                      "no_scheduling",
+                      "connect",
+                      "limited-core",
+                      "core",
+                      "core-trial",
+                      "test"
+                    ]
+                  },
+                  "description": "A list of tags to be used for reporting purposes. Tags categorize offerings for analytics and billing reports. Common tags include: **base** for standard base offerings; **free** for free tier offerings; **trial** for trial-period offerings; **ghost** for internal/hidden offerings; **business_management** for business management related offerings; **sandbox** for test environment offerings; **core** for core platform offerings.",
+                  "example": [
+                    "base",
+                    "free"
+                  ]
+                },
+                "availability_rules": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "description": "Availability rules for the offering, keyed by rule type. When present, a business only receives this offering as a bundled item if it satisfies every rule (direct subscription and catalog visibility are not gated). Empty or omitted means available everywhere. The only supported rule is `geo_location` (e.g., { \"geo_location\": { \"allow\": [\"US\"], \"deny\": [] } }).",
+                  "properties": {
+                    "geo_location": {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "description": "Restricts the offering by the business's country (ISO 3166-1 alpha-2). `deny` always wins over `allow`; empty lists mean available in every country; an unresolved business country is treated as not-allowed when any restriction is set (fail-closed) (e.g., { \"allow\": [\"US\", \"CA\"], \"deny\": [\"IR\"] }).",
+                      "required": [
+                        "allow",
+                        "deny"
+                      ],
+                      "properties": {
+                        "allow": {
+                          "type": "array",
+                          "description": "Country codes the offering is available in (e.g., [\"US\", \"CA\"]).",
+                          "items": {
+                            "type": "string",
+                            "pattern": "^[A-Z]{2}$"
+                          }
+                        },
+                        "deny": {
+                          "type": "array",
+                          "description": "Country codes the offering is NOT available in; takes precedence over `allow` (e.g., [\"IR\", \"KP\"]).",
+                          "items": {
+                            "type": "string",
+                            "pattern": "^[A-Z]{2}$"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "required": [
+                "type",
+                "SKU",
+                "display_name",
+                "quantity",
+                "payment_type",
+                "prices"
+              ],
+              "example": {
+                "uid": "bc33f12d-98ee-428f-9f65-18bba589cb95",
+                "created_at": "2024-01-01T09:00:00Z",
+                "updated_at": "2024-03-20T12:34:56Z",
+                "type": "package",
+                "SKU": "premium_10",
+                "display_name": "Premium 10",
+                "quantity": 1,
+                "payment_type": "monthly",
+                "is_active": true,
+                "is_listed": true,
+                "vendor": "inTandem",
+                "prices": [
+                  {
+                    "price": "5.00",
+                    "currency": "USD"
+                  },
+                  {
+                    "price": "5.00",
+                    "currency": "EUR"
+                  }
+                ],
+                "trial_type": "no_trial",
+                "trial_period": 0,
+                "reporting_tags": [
+                  "base",
+                  "no_payments"
+                ],
+                "availability_rules": {
+                  "geo_location": {
+                    "allow": [
+                      "US"
+                    ],
+                    "deny": []
+                  }
+                }
+              },
+              "description": "An Offering represents a commercial agreement in the inTandem platform, describing the various attributes of the commercial terms, including pricing, type, and additional metadata."
             }
           }
         }
@@ -11539,7 +18683,46 @@
             "description": "List of DirectoryOfferings",
             "type": "array",
             "items": {
-              "$ref": "https://vcita.github.io/developers-hub/entities/license/directoryOffering.json"
+              "type": "object",
+              "properties": {
+                "uid": {
+                  "type": "string",
+                  "description": "The entity identifier"
+                },
+                "created_at": {
+                  "type": "string",
+                  "description": "Timestamp indicating when the entity was created",
+                  "format": "date-time"
+                },
+                "updated_at": {
+                  "type": "string",
+                  "description": "Timestamp of the entity's most recent update",
+                  "format": "date-time"
+                },
+                "directory_uid": {
+                  "type": "string",
+                  "description": "Unique identifier for a directory. Defines which directory is authorized to sell this offering.",
+                  "x-reference-to": "directory"
+                },
+                "offering_uid": {
+                  "type": "string",
+                  "description": "Unique identifier for an offering. Defines an offering the directory is authorized to sell.",
+                  "x-reference-to": "offering"
+                }
+              },
+              "required": [
+                "uid",
+                "directory_uid",
+                "offering_uid"
+              ],
+              "example": {
+                "uid": "bc33f12d-98ee-428f-9f65-18bba589cb95",
+                "created_at": "2024-01-01T09:00:00Z",
+                "updated_at": "2024-03-20T12:34:56Z",
+                "directory_uid": "98ees428fq9f65tyh",
+                "offering_uid": "3f12fb61-98ee-428f-9f65-18bba589cb95"
+              },
+              "description": "The directoryOffering represents the association of a directory with an offering, allowing the directory to provide the underlying product to its businesses under a specific commercial agreement."
             }
           }
         }
@@ -11551,7 +18734,49 @@
             "description": "List of BundledOfferings",
             "type": "array",
             "items": {
-              "$ref": "https://vcita.github.io/developers-hub/entities/license/bundledOffering.json"
+              "type": "object",
+              "description": "A bundled offering represents a relationship between two offerings where one (the child) is automatically included when the other (the parent) is purchased. The parent offering must be of type `package` or `app`, while the child offering can be of type `app` or `addon` (but not `package`). This entity does not include bundled staff seats.",
+              "properties": {
+                "uid": {
+                  "type": "string",
+                  "readOnly": true,
+                  "description": "Unique identifier for this bundled offering relationship."
+                },
+                "created_at": {
+                  "type": "string",
+                  "readOnly": true,
+                  "description": "Timestamp indicating when the bundled offering relationship was created, in ISO 8601 format (e.g., \"2024-01-01T09:00:00Z\").",
+                  "format": "date-time"
+                },
+                "updated_at": {
+                  "type": "string",
+                  "readOnly": true,
+                  "description": "Timestamp of the bundled offering relationship's most recent update, in ISO 8601 format (e.g., \"2024-03-20T12:34:56Z\").",
+                  "format": "date-time"
+                },
+                "offering_uid": {
+                  "type": "string",
+                  "description": "Unique identifier of the parent offering. This is the main product that customers purchase. The parent offering must be of type `package` or `app`. Obtain valid offering UIDs from `GET /v3/license/offerings`.",
+                  "x-reference-to": "offering"
+                },
+                "bundled_offering_uid": {
+                  "type": "string",
+                  "description": "Unique identifier of the child offering that is bundled with the parent. When the parent offering is purchased, this offering is automatically included at no additional cost. The child offering must be of type `app` or `addon` (not `package`). Obtain valid offering UIDs from `GET /v3/license/offerings`.",
+                  "x-reference-to": "offering"
+                }
+              },
+              "required": [
+                "uid",
+                "offering_uid",
+                "bundled_offering_uid"
+              ],
+              "example": {
+                "uid": "bc33f12d-98ee-428f-9f65-12bca589cb21",
+                "created_at": "2024-01-01T09:00:00Z",
+                "updated_at": "2024-03-20T12:34:56Z",
+                "offering_uid": "fc33f32c-95ae-4e8f-9f65-18bba589cb43",
+                "bundled_offering_uid": "bc33f12d-98ee-428f-9f65-18bba589cb95"
+              }
             }
           }
         }
@@ -11563,7 +18788,49 @@
             "description": "List of newly created BundldedOfferings (for bulk creation)",
             "type": "array",
             "items": {
-              "$ref": "https://vcita.github.io/developers-hub/entities/license/bundledOffering.json"
+              "type": "object",
+              "description": "A bundled offering represents a relationship between two offerings where one (the child) is automatically included when the other (the parent) is purchased. The parent offering must be of type `package` or `app`, while the child offering can be of type `app` or `addon` (but not `package`). This entity does not include bundled staff seats.",
+              "properties": {
+                "uid": {
+                  "type": "string",
+                  "readOnly": true,
+                  "description": "Unique identifier for this bundled offering relationship."
+                },
+                "created_at": {
+                  "type": "string",
+                  "readOnly": true,
+                  "description": "Timestamp indicating when the bundled offering relationship was created, in ISO 8601 format (e.g., \"2024-01-01T09:00:00Z\").",
+                  "format": "date-time"
+                },
+                "updated_at": {
+                  "type": "string",
+                  "readOnly": true,
+                  "description": "Timestamp of the bundled offering relationship's most recent update, in ISO 8601 format (e.g., \"2024-03-20T12:34:56Z\").",
+                  "format": "date-time"
+                },
+                "offering_uid": {
+                  "type": "string",
+                  "description": "Unique identifier of the parent offering. This is the main product that customers purchase. The parent offering must be of type `package` or `app`. Obtain valid offering UIDs from `GET /v3/license/offerings`.",
+                  "x-reference-to": "offering"
+                },
+                "bundled_offering_uid": {
+                  "type": "string",
+                  "description": "Unique identifier of the child offering that is bundled with the parent. When the parent offering is purchased, this offering is automatically included at no additional cost. The child offering must be of type `app` or `addon` (not `package`). Obtain valid offering UIDs from `GET /v3/license/offerings`.",
+                  "x-reference-to": "offering"
+                }
+              },
+              "required": [
+                "uid",
+                "offering_uid",
+                "bundled_offering_uid"
+              ],
+              "example": {
+                "uid": "bc33f12d-98ee-428f-9f65-12bca589cb21",
+                "created_at": "2024-01-01T09:00:00Z",
+                "updated_at": "2024-03-20T12:34:56Z",
+                "offering_uid": "fc33f32c-95ae-4e8f-9f65-18bba589cb43",
+                "bundled_offering_uid": "bc33f12d-98ee-428f-9f65-18bba589cb95"
+              }
             }
           }
         }
@@ -11575,7 +18842,207 @@
             "description": "List of Subscriptions",
             "type": "array",
             "items": {
-              "$ref": "https://vcita.github.io/developers-hub/entities/license/subscription.json"
+              "type": "object",
+              "properties": {
+                "uid": {
+                  "type": "string",
+                  "description": "The entity unique identifier",
+                  "x-security": [
+                    "Business"
+                  ]
+                },
+                "created_at": {
+                  "type": "string",
+                  "description": "The creation date and time of the object",
+                  "format": "date-time"
+                },
+                "updated_at": {
+                  "type": "string",
+                  "description": "The last updated date and time of the object",
+                  "format": "date-time"
+                },
+                "display_name": {
+                  "type": "string",
+                  "description": "The subscription display name"
+                },
+                "is_active": {
+                  "type": "boolean",
+                  "description": "Calculated active subscription is when the subscription is not canceled and not expired"
+                },
+                "offering_uid": {
+                  "type": "string",
+                  "description": "The underlying directory offering uid"
+                },
+                "offering_type": {
+                  "type": "string",
+                  "description": "Category of the offering. Possible values include: **plan**: For the main business subscription; **app**: for marketplace app subscriptions; **SMS**: For text message offerings; **staff_seat**: For additional business seats.",
+                  "enum": [
+                    "package",
+                    "app",
+                    "sms",
+                    "staff_slot"
+                  ]
+                },
+                "purchase_state": {
+                  "type": "string",
+                  "description": "The current subscription state. **purchased**: The subscription is paid for and active; **suspended**: The subscription is temporarily suspended; **canceled**: The subscription was canceled and will expire on expiration_date; **expired**: The subscription has expired.",
+                  "enum": [
+                    "purchased",
+                    "suspended",
+                    "canceled",
+                    "expired"
+                  ]
+                },
+                "cancellation_date": {
+                  "type": "string",
+                  "description": "The date when subscription was canceled",
+                  "format": "date-time"
+                },
+                "expiration_date": {
+                  "type": "string",
+                  "description": "The date when subscription will expire (or expired)",
+                  "format": "date-time"
+                },
+                "buyer_uid": {
+                  "type": "string",
+                  "description": "The actor of the action. typically, the staff uid"
+                },
+                "business_uid": {
+                  "type": "string",
+                  "description": "The business that the subscription relates to"
+                },
+                "original_price": {
+                  "type": "number",
+                  "description": "The standard offering price before any discounts. This represents the original price of the offering before coupon or discount application."
+                },
+                "purchase_price": {
+                  "type": [
+                    "number",
+                    "string"
+                  ],
+                  "description": "The actual amount charged to the customer at the moment of the subscription was created. When a discount is applied, this will differ from original_price. May return as a number or string (e.g., \"49.99\")."
+                },
+                "purchase_currency": {
+                  "type": "string",
+                  "description": "The purchase currency at the moment of the subscription was created. Currently supported currencies: USD; EUR; GPB.",
+                  "enum": [
+                    "USD",
+                    "EUR",
+                    "GBP"
+                  ]
+                },
+                "payment_type": {
+                  "type": "string",
+                  "description": "The payment type field defines the payment options available for an offering, **free**: No payment is required; **one_time**: A single, one-time payment is required to obtain the offering; **monthly**: A recurring payment made on a monthly basis; **annual**: A recurring payment made on a yearly basis; **bundle**: A subscription bundled with another subscription",
+                  "enum": [
+                    "monthly",
+                    "annual",
+                    "free",
+                    "single_charge",
+                    "bundle",
+                    "external",
+                    "external_single_charge"
+                  ]
+                },
+                "bundled_from_subscription_uid": {
+                  "type": "string",
+                  "description": "The subscription uid that this subscription is bundled from"
+                },
+                "charged_by": {
+                  "type": "string",
+                  "description": "Who charges for this subscription. **partner**: Transaction managed by partner; **platform**: Transaction managed within the platform's integral billing system",
+                  "enum": [
+                    "partner",
+                    "platform"
+                  ]
+                },
+                "trial_type": {
+                  "type": "string",
+                  "description": "Indicates whether this subscription was created with a trial. expire: subscription has a trial period and will expire when it ends. no_trial: subscription was created without a trial. automatic_charge: reserved for future use.",
+                  "enum": [
+                    "no_trial",
+                    "automatic_charge",
+                    "expire"
+                  ],
+                  "default": "no_trial"
+                },
+                "trial_period": {
+                  "type": "number",
+                  "readOnly": true,
+                  "description": "Number of days for the trial period. Copied from the offering at subscription creation time. 0 indicates no trial period.",
+                  "default": 0
+                },
+                "next_charge_date": {
+                  "type": "string",
+                  "format": "date-time",
+                  "description": "The start date of the next billing cycle. This property is `null` if the subscription is set to expire."
+                },
+                "quantity": {
+                  "type": "number",
+                  "description": "The number of units (e.g., staff seats, SMS messages, AI tokens) allocated under this offering, defining the quantity available for use during the subscription period. A value of `-1` indicates **unlimited** quantity — the resource has no usage cap. This value is inherited from the offering at subscription creation time.",
+                  "default": 1
+                },
+                "can_purchase_additional_seats": {
+                  "type": "boolean",
+                  "description": "Indicates if a business can purchase additional seats beyond the bundled subscription (default: True); if False, only the bundled seats are available.",
+                  "default": true
+                },
+                "sku": {
+                  "type": "string",
+                  "description": "The SKU (app/packageaddon unique code name) related to this subscription"
+                },
+                "discount_code_name": {
+                  "type": "string",
+                  "description": "String identifier for the coupon/discount type (e.g., 'percent', 'fixed_amount'). Used for tracking and reporting purposes."
+                },
+                "coupon_code": {
+                  "type": "string",
+                  "description": "Discount identifier used for tracking and Recurly integration. This is the coupon code that was applied to the subscription."
+                }
+              },
+              "required": [
+                "uid",
+                "created_at",
+                "updated_at",
+                "display_name",
+                "offering_uid",
+                "buyer_uid",
+                "business_uid",
+                "purchase_price",
+                "purchase_currency",
+                "payment_type",
+                "charged_by",
+                "sku"
+              ],
+              "example": {
+                "uid": "c33f32c-95ae-4e8f-9f65-18bba589cb43",
+                "created_at": "2024-01-01T09:00:00Z",
+                "updated_at": "2024-03-20T12:34:56Z",
+                "display_name": "Premium 10",
+                "sku": "premium_10",
+                "is_active": true,
+                "offering_uid": "bc33f12d-98ee-428f-9f65-18bba589cb95",
+                "offering_type": "package",
+                "purchase_state": "purchased",
+                "cancellation_date": "",
+                "expiration_date": "",
+                "buyer_uid": "user_12345",
+                "business_uid": "biz_67890",
+                "original_price": 99.99,
+                "purchase_price": 49.99,
+                "purchase_currency": "USD",
+                "payment_type": "monthly",
+                "bundled_from_subscription_uid": "",
+                "charged_by": "platform",
+                "trial_type": "no_trial",
+                "trial_period": 0,
+                "next_charge_date": "2025-03-20T12:34:56Z",
+                "quantity": 1,
+                "can_purchase_additional_seats": true,
+                "discount_code_name": null,
+                "coupon_code": null
+              },
+              "description": "A subscription represents a purchased offering related to a business. It includes details such as the buyer, pricing, trial period, and the subscription's lifecycle state. Supports discounted and free plans using coupons, with tracking of both original and discounted prices."
             }
           }
         }
@@ -11587,7 +19054,86 @@
             "description": "List of BusinessCarts",
             "type": "array",
             "items": {
-              "$ref": "https://vcita.github.io/developers-hub/entities/license/businessCart.json"
+              "type": "object",
+              "properties": {
+                "uid": {
+                  "type": "string",
+                  "description": "Unique identifier for the entity",
+                  "format": "uuid"
+                },
+                "created_at": {
+                  "type": "string",
+                  "description": "Timestamp when the entity was created",
+                  "format": "date-time"
+                },
+                "updated_at": {
+                  "type": "string",
+                  "description": "Timestamp when the entity was last updated",
+                  "format": "date-time"
+                },
+                "business_uid": {
+                  "type": "string",
+                  "description": "Unique identifier of the business",
+                  "maxLength": 16
+                },
+                "business_cart_items": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "uid": {
+                        "type": "string",
+                        "description": "Unique identifier for the entity",
+                        "format": "uuid"
+                      },
+                      "created_at": {
+                        "type": "string",
+                        "description": "Timestamp when the entity was created",
+                        "format": "date-time"
+                      },
+                      "updated_at": {
+                        "type": "string",
+                        "description": "Timestamp when the entity was last updated",
+                        "format": "date-time"
+                      },
+                      "business_cart_uid": {
+                        "type": "string"
+                      },
+                      "offering_uid": {
+                        "type": "string"
+                      },
+                      "price": {
+                        "type": "number"
+                      },
+                      "currency": {
+                        "type": "string"
+                      },
+                      "Payment_type": {
+                        "type": "string"
+                      },
+                      "display_name": {
+                        "type": "string"
+                      },
+                      "subscription_uid": {
+                        "type": "string"
+                      },
+                      "description": "An item within a business cart referencing an offering, price, and subscription linkage."
+                    }
+                  }
+                },
+                "cart_total": {
+                  "type": "number",
+                  "description": "Calculated field"
+                }
+              },
+              "required": [
+                "uid",
+                "business_uid",
+                "created_at",
+                "updated_at",
+                "business_cart_items"
+              ],
+              "description": "A businessCart object represents a temporary collection of products, organized as cart items, that a business plans to purchase."
             }
           }
         }
@@ -11708,7 +19254,51 @@
             "description": "List of SKUs",
             "type": "array",
             "items": {
-              "$ref": "https://vcita.github.io/developers-hub/entities/license/SKU.json"
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "description": "Type of the SKU. Possible values include: 'package' for the main business subscription; 'app' for marketplace app; 'addon' for text message and staff seats.",
+                  "enum": [
+                    "package",
+                    "app",
+                    "addon"
+                  ]
+                },
+                "code_name": {
+                  "type": "string",
+                  "description": "Unique code of the associated underlying SKU e.g., app code name, package code or adddon code name. Available addons are SMS, staff_seat and module (an external module that is a place holder for a service sold by the partner, for example 'Extended support'). "
+                },
+                "display_name": {
+                  "type": "string",
+                  "description": "The SKU's display name"
+                },
+                "created_at": {
+                  "type": "string",
+                  "description": "Timestamp indicating when the entity was created. In some types, this date is hard coded and should not be relyed upon for business logic.",
+                  "format": "date-time"
+                },
+                "updated_at": {
+                  "type": "string",
+                  "description": "Timestamp of the entity's most recent update. In some types, this date is hard coded and should not be relyed upon for business logic.",
+                  "format": "date-time"
+                }
+              },
+              "required": [
+                "created_at",
+                "updated_at",
+                "type",
+                "code_name",
+                "display_name"
+              ],
+              "example": {
+                "type": "package",
+                "code_name": "premium",
+                "display_name": "Premium",
+                "created_at": "2024-01-01T09:00:00Z",
+                "updated_at": "2024-03-20T12:34:56Z"
+              },
+              "description": "The SKU represents a service or a features set that can be offered by inTandem/partners to their users."
             }
           }
         }
@@ -12669,7 +20259,42 @@
             "description": "List of staff quick action lists",
             "type": "array",
             "items": {
-              "$ref": "https://vcita.github.io/developers-hub/entities/staff/staff_quick_action_list.json"
+              "type": "object",
+              "properties": {
+                "staff_uid": {
+                  "type": "string",
+                  "description": "The unique identifier (UID) of the staff member"
+                },
+                "quick_actions": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "description": "Name of the quick action"
+                      },
+                      "order": {
+                        "type": "integer",
+                        "description": "Display order of the quick action"
+                      },
+                      "visible": {
+                        "type": "boolean",
+                        "description": "Visibility status of the quick action"
+                      },
+                      "category": {
+                        "type": "string",
+                        "description": "Category the quick action belongs to"
+                      }
+                    }
+                  },
+                  "required": [
+                    "staff_uid",
+                    "quick_actions"
+                  ]
+                }
+              },
+              "description": "Defines a staff member's quick actions and their order/visibility in the UI."
             }
           }
         }
@@ -12707,7 +20332,90 @@
             "description": "List of BusinessRoles",
             "type": "array",
             "items": {
-              "$ref": "https://vcita.github.io/developers-hub/entities/access_control/businessRole.json"
+              "type": "object",
+              "properties": {
+                "uid": {
+                  "type": "string",
+                  "description": "The unique identifier (UID) of the BusinessRole"
+                },
+                "code": {
+                  "type": "string",
+                  "description": "A unique readable code for the role"
+                },
+                "name": {
+                  "type": "string",
+                  "description": "The role name as it's presented in the UI. By default, it will be assigned from the original permission, but can be overridden for a specific business"
+                },
+                "description": {
+                  "type": "string",
+                  "description": "The role description as it’s presented in the UI. By default, it will be assigned from the original permission, but can be overridden for a specific business"
+                },
+                "permissions": {
+                  "type": "array",
+                  "description": "A list of permissions that are assigned to the role by default",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "key": {
+                        "type": "string",
+                        "description": "The unique identifier (UID) of the Permission"
+                      },
+                      "allow": {
+                        "type": "boolean",
+                        "description": "A flag indicating if this permission is by default assigned to the role"
+                      }
+                    }
+                  }
+                },
+                "is_editable": {
+                  "type": "boolean",
+                  "description": "A flag to indicate if the role can be edited by the business. By default, system roles are not editable",
+                  "default": true
+                },
+                "created_at": {
+                  "type": "string",
+                  "format": "string",
+                  "description": "Date the BusinessRole was created"
+                },
+                "updated_at": {
+                  "type": "string",
+                  "format": "string",
+                  "description": "Date the BusinessRole was last updated"
+                }
+              },
+              "required": [
+                "uid",
+                "name",
+                "description",
+                "permissions",
+                "created_at",
+                "updated_at"
+              ],
+              "example": {
+                "uid": "d290f1ee-6c54-4b01-90e6-d701748f0851",
+                "business_uid": "b290f1ee-6c54-4b01-90e6-d701748f0851",
+                "code": "admin",
+                "name": "Admin",
+                "description": "Admin role. Typically has access to all features in the system",
+                "is_editable": true,
+                "permissions": [
+                  {
+                    "key": "payments.invoices.export",
+                    "allow": true
+                  },
+                  {
+                    "key": "payments.manage",
+                    "allow": true
+                  },
+                  {
+                    "key": "reports.manage",
+                    "allow": true
+                  }
+                ],
+                "created_at": "2021-07-20T14:00:00.000Z",
+                "updated_at": "2021-07-20T14:00:00.000Z"
+              },
+              "description": "A role is a named set of default permissions for a business account. For example, admin, manager etc."
             }
           }
         }
@@ -12719,7 +20427,78 @@
             "description": "List of Permissions",
             "type": "array",
             "items": {
-              "$ref": "https://vcita.github.io/developers-hub/entities/access_control/permission.json"
+              "type": "object",
+              "properties": {
+                "unique_code": {
+                  "type": "string",
+                  "description": "The unique identifier of the Permission. The format determines the permission type: category permissions have two parts (e.g., 'payments.manage'), while extended permissions have three parts (e.g., 'payments.invoices.export')."
+                },
+                "name": {
+                  "type": "string",
+                  "description": "The name of the permission shown to the user in English."
+                },
+                "description": {
+                  "type": "string",
+                  "description": "The description of the permission shown to the user in English."
+                },
+                "permission_type": {
+                  "type": "string",
+                  "enum": [
+                    "category",
+                    "extended"
+                  ],
+                  "description": "The type of permission based on its hierarchy level. 'category' permissions (e.g., 'payments.manage') are parent permissions that must be enabled before their child 'extended' permissions (e.g., 'payments.invoices.export') can be used. Category permissions have two parts in their unique_code, while extended permissions have three parts."
+                },
+                "category_key": {
+                  "type": "string",
+                  "description": "For extended permissions only. The unique_code of the parent category permission that must be enabled for this extended permission to be valid. For example, if unique_code is 'payments.invoices.export', the category_key would be 'payments.manage'."
+                },
+                "position": {
+                  "type": "integer",
+                  "description": "The display position of the permission in the list of permissions."
+                },
+                "is_changable": {
+                  "type": "boolean",
+                  "description": "Deprecated: Use is_changeable instead. A flag to indicate if the permission, after assigned, can be edited by the business.",
+                  "default": true
+                },
+                "is_changeable": {
+                  "type": "boolean",
+                  "description": "A flag to indicate if the permission, after assigned, can be edited by the business. By default, permissions are editable but some permissions like business_management.admin_account.manage can not be changed after assigned.",
+                  "default": true
+                },
+                "created_at": {
+                  "type": "string",
+                  "format": "date-time",
+                  "description": "The date and time when the permission was created, in ISO 8601 format.",
+                  "readOnly": true
+                },
+                "updated_at": {
+                  "type": "string",
+                  "format": "date-time",
+                  "description": "The date and time when the permission was last updated, in ISO 8601 format.",
+                  "readOnly": true
+                }
+              },
+              "required": [
+                "unique_code",
+                "name",
+                "description",
+                "created_at",
+                "updated_at"
+              ],
+              "example": {
+                "unique_code": "payments.invoices.export",
+                "name": "Export Invoices",
+                "description": "Can export invoices",
+                "permission_type": "extended",
+                "category_key": "payments.manage",
+                "position": 1,
+                "is_changeable": true,
+                "created_at": "2021-07-20T14:00:00.000Z",
+                "updated_at": "2021-07-20T14:00:00.000Z"
+              },
+              "description": "An access to capability that can be granted to a Staff member. Permissions follow a hierarchy where category permissions (two-part keys like 'payments.manage') must be enabled before their extended permissions (three-part keys like 'payments.invoices.export') can be used."
             }
           }
         }
@@ -12731,7 +20510,38 @@
             "description": "List of StaffBusinessRoles",
             "type": "array",
             "items": {
-              "$ref": "https://vcita.github.io/developers-hub/entities/access_control/staffBusinessRole.json"
+              "type": "object",
+              "properties": {
+                "staff_uid": {
+                  "type": "string",
+                  "description": "The unique identifier (UID) of the staff member"
+                },
+                "business_role_uid": {
+                  "type": "string",
+                  "description": "A unique identifier (UID) of the associated BusinessRole"
+                },
+                "created_at": {
+                  "type": "string",
+                  "description": "Date the StaffBusinessRole was created"
+                },
+                "updated_at": {
+                  "type": "string",
+                  "description": "Date the StaffBuinsessRole was last updated"
+                }
+              },
+              "required": [
+                "staff_uid",
+                "business_role_uid",
+                "created_at",
+                "updated_at"
+              ],
+              "example": {
+                "staff_uid": "d290f1ee-6c54-4b01-90e6-d701748f0851",
+                "business_role_uid": "d290f1ee-6c54-4b01-90e6-d701748f0851",
+                "created_at": "2021-07-20T14:00:00.000Z",
+                "updated_at": "2021-07-20T14:00:00.000Z"
+              },
+              "description": "A StaffBusinessRole is an assignment of a BusinessRole to a staff member, defining their permissions within a business account. For example, admin, manager etc."
             }
           }
         }
@@ -12743,7 +20553,25 @@
             "description": "List of StaffPermissions",
             "type": "array",
             "items": {
-              "$ref": "https://vcita.github.io/developers-hub/entities/access_control/staffPermission.json"
+              "type": "object",
+              "properties": {
+                "key": {
+                  "type": "string",
+                  "description": "The unique identifier (key) of the StaffPermission"
+                },
+                "allow": {
+                  "type": "boolean",
+                  "description": "A flag indicating if this permission is allowed or denied from this staff member"
+                }
+              },
+              "required": [
+                "key"
+              ],
+              "example": {
+                "key": "payments.invoices.export",
+                "allow": true
+              },
+              "description": "an assiged permission to a staff member"
             }
           }
         }
@@ -12755,7 +20583,76 @@
             "description": "List of StaffPermissionOverrides",
             "type": "array",
             "items": {
-              "$ref": "https://vcita.github.io/developers-hub/entities/access_control/staffPermissionOverridesList.json"
+              "type": "object",
+              "properties": {
+                "staff_uid": {
+                  "type": "string",
+                  "description": ""
+                },
+                "permissions": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "key": {
+                        "type": "string",
+                        "description": "The unique identifier (UID) of the Permission"
+                      },
+                      "state": {
+                        "type": "string",
+                        "description": "an enum value of 'allow', 'deny'. Note, when updating the field to 'inherit' the overide is removed and the default permission from the BusinessRole is used",
+                        "enum": [
+                          "allow",
+                          "deny"
+                        ]
+                      }
+                    }
+                  },
+                  "description": "An entity holding the list of permissions that override the default permissions of the BusinessRole assigned to the staff member. When empty, role defaults are assigned to the user."
+                },
+                "created_at": {
+                  "type": "string",
+                  "description": "Date the BusinessRole was created"
+                },
+                "updated_at": {
+                  "type": "string",
+                  "description": "Date the BuinsessRole was last updated"
+                }
+              },
+              "required": [
+                "staff_uid",
+                "permissions",
+                "created_at",
+                "updated_at"
+              ],
+              "example": {
+                "staff_uid": "d290f1ee-6c54-4b01-90e6-d701748f0851",
+                "permissions": [
+                  {
+                    "key": "payments.invoices.export",
+                    "state": "allow"
+                  },
+                  {
+                    "key": "payments.invoices.import",
+                    "state": "allow"
+                  },
+                  {
+                    "key": "payments.invoices.view",
+                    "state": "deny"
+                  },
+                  {
+                    "key": "payments.invoices.delete",
+                    "state": "deny"
+                  },
+                  {
+                    "key": "payments.invoices.create",
+                    "state": "allow"
+                  }
+                ],
+                "created_at": "2021-07-20T14:00:00.000Z",
+                "updated_at": "2021-07-20T14:00:00.000Z"
+              },
+              "description": "An entity holding the list of permissions that override the default permissions of the BusinessRole assigned to the staff member. When empty role defaults are assigned to the user"
             }
           }
         }

--- a/mcp_swagger/reviews.json
+++ b/mcp_swagger/reviews.json
@@ -45,12 +45,118 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/reviews/businessReviewsSettings.json"
+                          "type": "object",
+                          "properties": {
+                            "business_uid": {
+                              "type": "string",
+                              "description": "The unique identifier (UID) of the business"
+                            },
+                            "external_review_site_url": {
+                              "type": "string",
+                              "description": "Specifies the external review site URL where the review will be shared."
+                            },
+                            "external_review_site_display_name": {
+                              "type": "string",
+                              "description": "Specifies the display name of the external review site receiving the review."
+                            },
+                            "display_platform_review_consent": {
+                              "type": "boolean",
+                              "description": "Whether to prompt clients to leave a public review on Google or Facebook after submitting a review."
+                            },
+                            "display_review_sharing_consent": {
+                              "type": "boolean",
+                              "description": "Enables the client to decide whether their review is shared with that external review site."
+                            },
+                            "platform_id": {
+                              "type": [
+                                "integer",
+                                "null"
+                              ],
+                              "description": "The ID of the external review platform (1=Google, 2=Facebook). Null if no platform is configured."
+                            },
+                            "platform_name": {
+                              "type": [
+                                "string",
+                                "null"
+                              ],
+                              "description": "The name of the external review platform. Null if no platform is configured.",
+                              "enum": [
+                                "Google",
+                                "Facebook",
+                                null
+                              ]
+                            },
+                            "platform_params": {
+                              "type": "object",
+                              "description": "Platform-specific parameters needed to properly route the review"
+                            }
+                          },
+                          "required": [
+                            "business_uid"
+                          ],
+                          "example": {
+                            "business_uid": "d290f1ee26c54",
+                            "display_platform_review_consent": true,
+                            "display_review_sharing_consent": true,
+                            "platform_id": 1,
+                            "platform_name": "Google",
+                            "platform_params": {
+                              "place_id": 173897183
+                            },
+                            "external_review_site_url": "https://external_review_site_url.com",
+                            "external_review_site_display_name": "External Review Site Name",
+                            "created_at": "2021-07-20T14:00:00.000Z",
+                            "updated_at": "2021-07-20T14:00:00.000Z"
+                          },
+                          "description": "Configures external review sharing settings for a business by platform."
                         }
                       }
                     }
@@ -119,12 +225,118 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/reviews/businessReviewsSettings.json"
+                          "type": "object",
+                          "properties": {
+                            "business_uid": {
+                              "type": "string",
+                              "description": "The unique identifier (UID) of the business"
+                            },
+                            "external_review_site_url": {
+                              "type": "string",
+                              "description": "Specifies the external review site URL where the review will be shared."
+                            },
+                            "external_review_site_display_name": {
+                              "type": "string",
+                              "description": "Specifies the display name of the external review site receiving the review."
+                            },
+                            "display_platform_review_consent": {
+                              "type": "boolean",
+                              "description": "Whether to prompt clients to leave a public review on Google or Facebook after submitting a review."
+                            },
+                            "display_review_sharing_consent": {
+                              "type": "boolean",
+                              "description": "Enables the client to decide whether their review is shared with that external review site."
+                            },
+                            "platform_id": {
+                              "type": [
+                                "integer",
+                                "null"
+                              ],
+                              "description": "The ID of the external review platform (1=Google, 2=Facebook). Null if no platform is configured."
+                            },
+                            "platform_name": {
+                              "type": [
+                                "string",
+                                "null"
+                              ],
+                              "description": "The name of the external review platform. Null if no platform is configured.",
+                              "enum": [
+                                "Google",
+                                "Facebook",
+                                null
+                              ]
+                            },
+                            "platform_params": {
+                              "type": "object",
+                              "description": "Platform-specific parameters needed to properly route the review"
+                            }
+                          },
+                          "required": [
+                            "business_uid"
+                          ],
+                          "example": {
+                            "business_uid": "d290f1ee26c54",
+                            "display_platform_review_consent": true,
+                            "display_review_sharing_consent": true,
+                            "platform_id": 1,
+                            "platform_name": "Google",
+                            "platform_params": {
+                              "place_id": 173897183
+                            },
+                            "external_review_site_url": "https://external_review_site_url.com",
+                            "external_review_site_display_name": "External Review Site Name",
+                            "created_at": "2021-07-20T14:00:00.000Z",
+                            "updated_at": "2021-07-20T14:00:00.000Z"
+                          },
+                          "description": "Configures external review sharing settings for a business by platform."
                         }
                       }
                     }
@@ -197,12 +409,118 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/reviews/businessReviewsSettings.json"
+                          "type": "object",
+                          "properties": {
+                            "business_uid": {
+                              "type": "string",
+                              "description": "The unique identifier (UID) of the business"
+                            },
+                            "external_review_site_url": {
+                              "type": "string",
+                              "description": "Specifies the external review site URL where the review will be shared."
+                            },
+                            "external_review_site_display_name": {
+                              "type": "string",
+                              "description": "Specifies the display name of the external review site receiving the review."
+                            },
+                            "display_platform_review_consent": {
+                              "type": "boolean",
+                              "description": "Whether to prompt clients to leave a public review on Google or Facebook after submitting a review."
+                            },
+                            "display_review_sharing_consent": {
+                              "type": "boolean",
+                              "description": "Enables the client to decide whether their review is shared with that external review site."
+                            },
+                            "platform_id": {
+                              "type": [
+                                "integer",
+                                "null"
+                              ],
+                              "description": "The ID of the external review platform (1=Google, 2=Facebook). Null if no platform is configured."
+                            },
+                            "platform_name": {
+                              "type": [
+                                "string",
+                                "null"
+                              ],
+                              "description": "The name of the external review platform. Null if no platform is configured.",
+                              "enum": [
+                                "Google",
+                                "Facebook",
+                                null
+                              ]
+                            },
+                            "platform_params": {
+                              "type": "object",
+                              "description": "Platform-specific parameters needed to properly route the review"
+                            }
+                          },
+                          "required": [
+                            "business_uid"
+                          ],
+                          "example": {
+                            "business_uid": "d290f1ee26c54",
+                            "display_platform_review_consent": true,
+                            "display_review_sharing_consent": true,
+                            "platform_id": 1,
+                            "platform_name": "Google",
+                            "platform_params": {
+                              "place_id": 173897183
+                            },
+                            "external_review_site_url": "https://external_review_site_url.com",
+                            "external_review_site_display_name": "External Review Site Name",
+                            "created_at": "2021-07-20T14:00:00.000Z",
+                            "updated_at": "2021-07-20T14:00:00.000Z"
+                          },
+                          "description": "Configures external review sharing settings for a business by platform."
                         }
                       }
                     }
@@ -268,7 +586,70 @@
             "description": "List of Business Reviews Settings",
             "type": "array",
             "items": {
-              "$ref": "https://vcita.github.io/developers-hub/entities/reviews/businessReviewsSettings.json"
+              "type": "object",
+              "properties": {
+                "business_uid": {
+                  "type": "string",
+                  "description": "The unique identifier (UID) of the business"
+                },
+                "external_review_site_url": {
+                  "type": "string",
+                  "description": "Specifies the external review site URL where the review will be shared."
+                },
+                "external_review_site_display_name": {
+                  "type": "string",
+                  "description": "Specifies the display name of the external review site receiving the review."
+                },
+                "display_platform_review_consent": {
+                  "type": "boolean",
+                  "description": "Whether to prompt clients to leave a public review on Google or Facebook after submitting a review."
+                },
+                "display_review_sharing_consent": {
+                  "type": "boolean",
+                  "description": "Enables the client to decide whether their review is shared with that external review site."
+                },
+                "platform_id": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ],
+                  "description": "The ID of the external review platform (1=Google, 2=Facebook). Null if no platform is configured."
+                },
+                "platform_name": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "description": "The name of the external review platform. Null if no platform is configured.",
+                  "enum": [
+                    "Google",
+                    "Facebook",
+                    null
+                  ]
+                },
+                "platform_params": {
+                  "type": "object",
+                  "description": "Platform-specific parameters needed to properly route the review"
+                }
+              },
+              "required": [
+                "business_uid"
+              ],
+              "example": {
+                "business_uid": "d290f1ee26c54",
+                "display_platform_review_consent": true,
+                "display_review_sharing_consent": true,
+                "platform_id": 1,
+                "platform_name": "Google",
+                "platform_params": {
+                  "place_id": 173897183
+                },
+                "external_review_site_url": "https://external_review_site_url.com",
+                "external_review_site_display_name": "External Review Site Name",
+                "created_at": "2021-07-20T14:00:00.000Z",
+                "updated_at": "2021-07-20T14:00:00.000Z"
+              },
+              "description": "Configures external review sharing settings for a business by platform."
             }
           }
         }

--- a/mcp_swagger/sales.json
+++ b/mcp_swagger/sales.json
@@ -408,7 +408,50 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
@@ -819,12 +862,396 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/payment_processing/payment_gateway.json"
+                          "type": "object",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "description": "The unique identifier (UID) of the payment gateway."
+                            },
+                            "gateway_name": {
+                              "type": "string",
+                              "description": "The unique name of the payment gateway initialized when the owning app was created, provided as the name parameter to the App Creation API."
+                            },
+                            "app_code_name": {
+                              "type": "string",
+                              "description": "The unique code name of the pre-created gateway's app, created via the API- Creates an app, https://api.vcita.biz/platform/v1/apps"
+                            },
+                            "gateway_logo_url": {
+                              "type": "string",
+                              "description": "The URL to the logo of the gateway."
+                            },
+                            "default_locale": {
+                              "type": "string",
+                              "enum": [
+                                "en",
+                                "fr",
+                                "de",
+                                "it",
+                                "pl",
+                                "pt",
+                                "es",
+                                "nl",
+                                "he",
+                                "en_gb",
+                                "lv"
+                              ],
+                              "description": "Specifies the fallback locale for the gateway's textual content. If a translation or string is missing, this locale will be used by default."
+                            },
+                            "gateway_type": {
+                              "type": "string",
+                              "enum": [
+                                "digital_wallet",
+                                "payments_provider"
+                              ],
+                              "description": "Integration type: a payment service provider (e.g., Stripe, Square) that enables merchants to process multiple payment methods, or a digital wallet (e.g., PayPal, Google Pay) that allows consumers to store and use payment credentials"
+                            },
+                            "status": {
+                              "type": "string",
+                              "enum": [
+                                "active",
+                                "disabled",
+                                "deprecated"
+                              ],
+                              "description": "Indicates the current status of the payment gateway: 'active' (available for use), 'disabled' (not available for use), or 'deprecated' (still available but not recommended for new integrations)"
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "description": "The date and time the payment gateway was created."
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "description": "The date and time the payment gateway was last updated."
+                            },
+                            "main_gateway_benefits": {
+                              "type": "array",
+                              "description": "A clear 3-4 bullet list highlighting the unique features and value of the gateway, aimed at encouraging merchants to connect with it. This information is stored per locale. May be an empty array if no benefits are configured.",
+                              "uniqueItems": true,
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "locale": {
+                                    "type": "string",
+                                    "enum": [
+                                      "en",
+                                      "fr",
+                                      "de",
+                                      "it",
+                                      "pl",
+                                      "pt",
+                                      "es",
+                                      "nl",
+                                      "he",
+                                      "en_gb",
+                                      "lv"
+                                    ]
+                                  },
+                                  "benefits": {
+                                    "type": "array",
+                                    "description": "A list of benefits in the specified locale.",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "required": [
+                                  "locale",
+                                  "benefits"
+                                ]
+                              }
+                            },
+                            "brief_benefit_highlights": {
+                              "type": "array",
+                              "description": "A brief, 2-4 word version of the gateway benefits, tailored for compact displays or mobile interfaces. This information is stored per locale. May be an empty array if no highlights are configured.",
+                              "uniqueItems": true,
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "locale": {
+                                    "type": "string",
+                                    "enum": [
+                                      "en",
+                                      "fr",
+                                      "de",
+                                      "it",
+                                      "pl",
+                                      "pt",
+                                      "es",
+                                      "nl",
+                                      "he",
+                                      "en_gb",
+                                      "lv"
+                                    ]
+                                  },
+                                  "highlights": {
+                                    "type": "array",
+                                    "description": "A list of short benefit highlights in the specified locale.",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "required": [
+                                  "locale",
+                                  "highlights"
+                                ]
+                              }
+                            },
+                            "supported_countries": {
+                              "type": "array",
+                              "description": "A list of countries supported by the payment gateway, represented using ISO 3166-1 alpha-2 country codes.",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "supported_currencies": {
+                              "type": "array",
+                              "description": "A list of currencies supported by the payment gateway, represented using ISO 4217 format.",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "minimum_charge_amount": {
+                              "type": [
+                                "string",
+                                "number",
+                                "null"
+                              ],
+                              "description": "The minimum value that can be charged using the payment gateway. May be returned as a string or number depending on the gateway configuration."
+                            },
+                            "payment_methods": {
+                              "type": "object",
+                              "description": "The payment methods supported by the gateway.",
+                              "properties": {
+                                "credit_card": {
+                                  "type": "boolean",
+                                  "description": "Indicates if the gateway supports credit card payments."
+                                },
+                                "ach": {
+                                  "type": "boolean",
+                                  "description": "Indicates if the gateway supports ACH payments."
+                                },
+                                "ideal": {
+                                  "type": "boolean",
+                                  "description": "Indicates if the gateway supports iDeal payments."
+                                },
+                                "bancontact": {
+                                  "type": "boolean",
+                                  "description": "Indicates if the gateway supports Bancontact payments."
+                                },
+                                "twint": {
+                                  "type": "boolean",
+                                  "description": "Indicates if the gateway supports Twint payments."
+                                },
+                                "express_wallets": {
+                                  "type": "boolean",
+                                  "description": "Indicates if the gateway supports Express Wallets, such as Google Pay and Apple Pay."
+                                }
+                              }
+                            },
+                            "processing_features": {
+                              "type": "object",
+                              "description": "The features the payment gateway supports and their current state (enabled/disabled).",
+                              "properties": {
+                                "multi_currency": {
+                                  "type": "boolean",
+                                  "description": "Indicates if the gateway supports multi-currency transactions."
+                                },
+                                "back_office_charge": {
+                                  "type": "boolean",
+                                  "description": "Indicates if the gateway allows the SMB to process charges directly from the back office."
+                                },
+                                "checkout": {
+                                  "type": "boolean",
+                                  "description": "Indicates whether the payment gateway supports a checkout option initiated from the client portal. This value must always be set to true, as client portal checkout is a core feature."
+                                },
+                                "refund": {
+                                  "type": "boolean",
+                                  "description": "Indicates if the gateway supports full online refunds."
+                                },
+                                "partial_refund": {
+                                  "type": "boolean",
+                                  "description": "Indicates if the gateway supports partial online refunds. Requires full refunds to be enabled."
+                                },
+                                "client_save_card_on_checkout": {
+                                  "type": "boolean",
+                                  "description": "Indicates if clients can save cards on file during a payment flow."
+                                },
+                                "client_save_card_standalone": {
+                                  "type": "boolean",
+                                  "description": "Indicates if clients can save cards on file through a standalone flow."
+                                },
+                                "save_card_by_business": {
+                                  "type": "boolean",
+                                  "description": "Indicates if the gateway supports saving cards on file from the business side."
+                                },
+                                "offset_fees": {
+                                  "type": "boolean",
+                                  "description": "Indicates whether the gateway supports offsetting processing fees, as surcharges, convenience fees, or both, while each SMB can enable only one fee type or none."
+                                }
+                              },
+                              "required": [
+                                "multi_currency",
+                                "back_office_charge",
+                                "checkout",
+                                "refund",
+                                "partial_refund",
+                                "client_save_card_on_checkout",
+                                "client_save_card_standalone",
+                                "save_card_by_business",
+                                "offset_fees"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "app_code_name",
+                            "gateway_logo_url",
+                            "default_locale",
+                            "gateway_type",
+                            "status",
+                            "main_gateway_benefits",
+                            "brief_benefit_highlights",
+                            "supported_countries",
+                            "supported_currencies",
+                            "payment_methods",
+                            "processing_features"
+                          ],
+                          "example": {
+                            "uid": "pgw_abc123def456",
+                            "gateway_name": "stripe_payments_v2",
+                            "app_code_name": "stripe_payments_v2",
+                            "gateway_logo_url": "https://cdn.stripe.com/logo.png",
+                            "default_locale": "en",
+                            "gateway_type": "payments_provider",
+                            "status": "active",
+                            "created_at": "2024-01-15T10:30:00.000Z",
+                            "updated_at": "2024-01-20T14:45:00.000Z",
+                            "main_gateway_benefits": [
+                              {
+                                "locale": "en",
+                                "benefits": [
+                                  "Accept payments from 195+ countries",
+                                  "Industry-leading fraud protection",
+                                  "Fast payouts in 2-7 business days",
+                                  "24/7 customer support"
+                                ]
+                              },
+                              {
+                                "locale": "es",
+                                "benefits": [
+                                  "Acepta pagos de más de 195 países",
+                                  "Protección líder contra fraudes",
+                                  "Pagos rápidos en 2-7 días hábiles",
+                                  "Soporte al cliente 24/7"
+                                ]
+                              }
+                            ],
+                            "brief_benefit_highlights": [
+                              {
+                                "locale": "en",
+                                "highlights": [
+                                  "Global reach",
+                                  "Fraud protection",
+                                  "Fast payouts"
+                                ]
+                              },
+                              {
+                                "locale": "es",
+                                "highlights": [
+                                  "Alcance global",
+                                  "Protección fraude",
+                                  "Pagos rápidos"
+                                ]
+                              }
+                            ],
+                            "supported_countries": [
+                              "US",
+                              "CA",
+                              "GB",
+                              "AU",
+                              "DE",
+                              "FR",
+                              "ES",
+                              "IT"
+                            ],
+                            "supported_currencies": [
+                              "USD",
+                              "EUR",
+                              "GBP",
+                              "CAD",
+                              "AUD"
+                            ],
+                            "minimum_charge_amount": 0.5,
+                            "payment_methods": {
+                              "credit_card": true,
+                              "ach": true,
+                              "ideal": true,
+                              "bancontact": false,
+                              "twint": false,
+                              "express_wallets": false
+                            },
+                            "processing_features": {
+                              "multi_currency": true,
+                              "back_office_charge": true,
+                              "checkout": true,
+                              "refund": true,
+                              "partial_refund": true,
+                              "client_save_card_on_checkout": true,
+                              "client_save_card_standalone": true,
+                              "save_card_by_business": true,
+                              "offset_fees": true
+                            }
+                          },
+                          "description": "Metadata for a payment gateway integration, including locales, supported regions, methods, and processing features."
                         }
                       }
                     }
@@ -868,12 +1295,396 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/payment_processing/payment_gateway.json"
+                          "type": "object",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "description": "The unique identifier (UID) of the payment gateway."
+                            },
+                            "gateway_name": {
+                              "type": "string",
+                              "description": "The unique name of the payment gateway initialized when the owning app was created, provided as the name parameter to the App Creation API."
+                            },
+                            "app_code_name": {
+                              "type": "string",
+                              "description": "The unique code name of the pre-created gateway's app, created via the API- Creates an app, https://api.vcita.biz/platform/v1/apps"
+                            },
+                            "gateway_logo_url": {
+                              "type": "string",
+                              "description": "The URL to the logo of the gateway."
+                            },
+                            "default_locale": {
+                              "type": "string",
+                              "enum": [
+                                "en",
+                                "fr",
+                                "de",
+                                "it",
+                                "pl",
+                                "pt",
+                                "es",
+                                "nl",
+                                "he",
+                                "en_gb",
+                                "lv"
+                              ],
+                              "description": "Specifies the fallback locale for the gateway's textual content. If a translation or string is missing, this locale will be used by default."
+                            },
+                            "gateway_type": {
+                              "type": "string",
+                              "enum": [
+                                "digital_wallet",
+                                "payments_provider"
+                              ],
+                              "description": "Integration type: a payment service provider (e.g., Stripe, Square) that enables merchants to process multiple payment methods, or a digital wallet (e.g., PayPal, Google Pay) that allows consumers to store and use payment credentials"
+                            },
+                            "status": {
+                              "type": "string",
+                              "enum": [
+                                "active",
+                                "disabled",
+                                "deprecated"
+                              ],
+                              "description": "Indicates the current status of the payment gateway: 'active' (available for use), 'disabled' (not available for use), or 'deprecated' (still available but not recommended for new integrations)"
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "description": "The date and time the payment gateway was created."
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "description": "The date and time the payment gateway was last updated."
+                            },
+                            "main_gateway_benefits": {
+                              "type": "array",
+                              "description": "A clear 3-4 bullet list highlighting the unique features and value of the gateway, aimed at encouraging merchants to connect with it. This information is stored per locale. May be an empty array if no benefits are configured.",
+                              "uniqueItems": true,
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "locale": {
+                                    "type": "string",
+                                    "enum": [
+                                      "en",
+                                      "fr",
+                                      "de",
+                                      "it",
+                                      "pl",
+                                      "pt",
+                                      "es",
+                                      "nl",
+                                      "he",
+                                      "en_gb",
+                                      "lv"
+                                    ]
+                                  },
+                                  "benefits": {
+                                    "type": "array",
+                                    "description": "A list of benefits in the specified locale.",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "required": [
+                                  "locale",
+                                  "benefits"
+                                ]
+                              }
+                            },
+                            "brief_benefit_highlights": {
+                              "type": "array",
+                              "description": "A brief, 2-4 word version of the gateway benefits, tailored for compact displays or mobile interfaces. This information is stored per locale. May be an empty array if no highlights are configured.",
+                              "uniqueItems": true,
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "locale": {
+                                    "type": "string",
+                                    "enum": [
+                                      "en",
+                                      "fr",
+                                      "de",
+                                      "it",
+                                      "pl",
+                                      "pt",
+                                      "es",
+                                      "nl",
+                                      "he",
+                                      "en_gb",
+                                      "lv"
+                                    ]
+                                  },
+                                  "highlights": {
+                                    "type": "array",
+                                    "description": "A list of short benefit highlights in the specified locale.",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "required": [
+                                  "locale",
+                                  "highlights"
+                                ]
+                              }
+                            },
+                            "supported_countries": {
+                              "type": "array",
+                              "description": "A list of countries supported by the payment gateway, represented using ISO 3166-1 alpha-2 country codes.",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "supported_currencies": {
+                              "type": "array",
+                              "description": "A list of currencies supported by the payment gateway, represented using ISO 4217 format.",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "minimum_charge_amount": {
+                              "type": [
+                                "string",
+                                "number",
+                                "null"
+                              ],
+                              "description": "The minimum value that can be charged using the payment gateway. May be returned as a string or number depending on the gateway configuration."
+                            },
+                            "payment_methods": {
+                              "type": "object",
+                              "description": "The payment methods supported by the gateway.",
+                              "properties": {
+                                "credit_card": {
+                                  "type": "boolean",
+                                  "description": "Indicates if the gateway supports credit card payments."
+                                },
+                                "ach": {
+                                  "type": "boolean",
+                                  "description": "Indicates if the gateway supports ACH payments."
+                                },
+                                "ideal": {
+                                  "type": "boolean",
+                                  "description": "Indicates if the gateway supports iDeal payments."
+                                },
+                                "bancontact": {
+                                  "type": "boolean",
+                                  "description": "Indicates if the gateway supports Bancontact payments."
+                                },
+                                "twint": {
+                                  "type": "boolean",
+                                  "description": "Indicates if the gateway supports Twint payments."
+                                },
+                                "express_wallets": {
+                                  "type": "boolean",
+                                  "description": "Indicates if the gateway supports Express Wallets, such as Google Pay and Apple Pay."
+                                }
+                              }
+                            },
+                            "processing_features": {
+                              "type": "object",
+                              "description": "The features the payment gateway supports and their current state (enabled/disabled).",
+                              "properties": {
+                                "multi_currency": {
+                                  "type": "boolean",
+                                  "description": "Indicates if the gateway supports multi-currency transactions."
+                                },
+                                "back_office_charge": {
+                                  "type": "boolean",
+                                  "description": "Indicates if the gateway allows the SMB to process charges directly from the back office."
+                                },
+                                "checkout": {
+                                  "type": "boolean",
+                                  "description": "Indicates whether the payment gateway supports a checkout option initiated from the client portal. This value must always be set to true, as client portal checkout is a core feature."
+                                },
+                                "refund": {
+                                  "type": "boolean",
+                                  "description": "Indicates if the gateway supports full online refunds."
+                                },
+                                "partial_refund": {
+                                  "type": "boolean",
+                                  "description": "Indicates if the gateway supports partial online refunds. Requires full refunds to be enabled."
+                                },
+                                "client_save_card_on_checkout": {
+                                  "type": "boolean",
+                                  "description": "Indicates if clients can save cards on file during a payment flow."
+                                },
+                                "client_save_card_standalone": {
+                                  "type": "boolean",
+                                  "description": "Indicates if clients can save cards on file through a standalone flow."
+                                },
+                                "save_card_by_business": {
+                                  "type": "boolean",
+                                  "description": "Indicates if the gateway supports saving cards on file from the business side."
+                                },
+                                "offset_fees": {
+                                  "type": "boolean",
+                                  "description": "Indicates whether the gateway supports offsetting processing fees, as surcharges, convenience fees, or both, while each SMB can enable only one fee type or none."
+                                }
+                              },
+                              "required": [
+                                "multi_currency",
+                                "back_office_charge",
+                                "checkout",
+                                "refund",
+                                "partial_refund",
+                                "client_save_card_on_checkout",
+                                "client_save_card_standalone",
+                                "save_card_by_business",
+                                "offset_fees"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "app_code_name",
+                            "gateway_logo_url",
+                            "default_locale",
+                            "gateway_type",
+                            "status",
+                            "main_gateway_benefits",
+                            "brief_benefit_highlights",
+                            "supported_countries",
+                            "supported_currencies",
+                            "payment_methods",
+                            "processing_features"
+                          ],
+                          "example": {
+                            "uid": "pgw_abc123def456",
+                            "gateway_name": "stripe_payments_v2",
+                            "app_code_name": "stripe_payments_v2",
+                            "gateway_logo_url": "https://cdn.stripe.com/logo.png",
+                            "default_locale": "en",
+                            "gateway_type": "payments_provider",
+                            "status": "active",
+                            "created_at": "2024-01-15T10:30:00.000Z",
+                            "updated_at": "2024-01-20T14:45:00.000Z",
+                            "main_gateway_benefits": [
+                              {
+                                "locale": "en",
+                                "benefits": [
+                                  "Accept payments from 195+ countries",
+                                  "Industry-leading fraud protection",
+                                  "Fast payouts in 2-7 business days",
+                                  "24/7 customer support"
+                                ]
+                              },
+                              {
+                                "locale": "es",
+                                "benefits": [
+                                  "Acepta pagos de más de 195 países",
+                                  "Protección líder contra fraudes",
+                                  "Pagos rápidos en 2-7 días hábiles",
+                                  "Soporte al cliente 24/7"
+                                ]
+                              }
+                            ],
+                            "brief_benefit_highlights": [
+                              {
+                                "locale": "en",
+                                "highlights": [
+                                  "Global reach",
+                                  "Fraud protection",
+                                  "Fast payouts"
+                                ]
+                              },
+                              {
+                                "locale": "es",
+                                "highlights": [
+                                  "Alcance global",
+                                  "Protección fraude",
+                                  "Pagos rápidos"
+                                ]
+                              }
+                            ],
+                            "supported_countries": [
+                              "US",
+                              "CA",
+                              "GB",
+                              "AU",
+                              "DE",
+                              "FR",
+                              "ES",
+                              "IT"
+                            ],
+                            "supported_currencies": [
+                              "USD",
+                              "EUR",
+                              "GBP",
+                              "CAD",
+                              "AUD"
+                            ],
+                            "minimum_charge_amount": 0.5,
+                            "payment_methods": {
+                              "credit_card": true,
+                              "ach": true,
+                              "ideal": true,
+                              "bancontact": false,
+                              "twint": false,
+                              "express_wallets": false
+                            },
+                            "processing_features": {
+                              "multi_currency": true,
+                              "back_office_charge": true,
+                              "checkout": true,
+                              "refund": true,
+                              "partial_refund": true,
+                              "client_save_card_on_checkout": true,
+                              "client_save_card_standalone": true,
+                              "save_card_by_business": true,
+                              "offset_fees": true
+                            }
+                          },
+                          "description": "Metadata for a payment gateway integration, including locales, supported regions, methods, and processing features."
                         }
                       }
                     }
@@ -1120,12 +1931,396 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/payment_processing/payment_gateway.json"
+                          "type": "object",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "description": "The unique identifier (UID) of the payment gateway."
+                            },
+                            "gateway_name": {
+                              "type": "string",
+                              "description": "The unique name of the payment gateway initialized when the owning app was created, provided as the name parameter to the App Creation API."
+                            },
+                            "app_code_name": {
+                              "type": "string",
+                              "description": "The unique code name of the pre-created gateway's app, created via the API- Creates an app, https://api.vcita.biz/platform/v1/apps"
+                            },
+                            "gateway_logo_url": {
+                              "type": "string",
+                              "description": "The URL to the logo of the gateway."
+                            },
+                            "default_locale": {
+                              "type": "string",
+                              "enum": [
+                                "en",
+                                "fr",
+                                "de",
+                                "it",
+                                "pl",
+                                "pt",
+                                "es",
+                                "nl",
+                                "he",
+                                "en_gb",
+                                "lv"
+                              ],
+                              "description": "Specifies the fallback locale for the gateway's textual content. If a translation or string is missing, this locale will be used by default."
+                            },
+                            "gateway_type": {
+                              "type": "string",
+                              "enum": [
+                                "digital_wallet",
+                                "payments_provider"
+                              ],
+                              "description": "Integration type: a payment service provider (e.g., Stripe, Square) that enables merchants to process multiple payment methods, or a digital wallet (e.g., PayPal, Google Pay) that allows consumers to store and use payment credentials"
+                            },
+                            "status": {
+                              "type": "string",
+                              "enum": [
+                                "active",
+                                "disabled",
+                                "deprecated"
+                              ],
+                              "description": "Indicates the current status of the payment gateway: 'active' (available for use), 'disabled' (not available for use), or 'deprecated' (still available but not recommended for new integrations)"
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "description": "The date and time the payment gateway was created."
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "description": "The date and time the payment gateway was last updated."
+                            },
+                            "main_gateway_benefits": {
+                              "type": "array",
+                              "description": "A clear 3-4 bullet list highlighting the unique features and value of the gateway, aimed at encouraging merchants to connect with it. This information is stored per locale. May be an empty array if no benefits are configured.",
+                              "uniqueItems": true,
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "locale": {
+                                    "type": "string",
+                                    "enum": [
+                                      "en",
+                                      "fr",
+                                      "de",
+                                      "it",
+                                      "pl",
+                                      "pt",
+                                      "es",
+                                      "nl",
+                                      "he",
+                                      "en_gb",
+                                      "lv"
+                                    ]
+                                  },
+                                  "benefits": {
+                                    "type": "array",
+                                    "description": "A list of benefits in the specified locale.",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "required": [
+                                  "locale",
+                                  "benefits"
+                                ]
+                              }
+                            },
+                            "brief_benefit_highlights": {
+                              "type": "array",
+                              "description": "A brief, 2-4 word version of the gateway benefits, tailored for compact displays or mobile interfaces. This information is stored per locale. May be an empty array if no highlights are configured.",
+                              "uniqueItems": true,
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "locale": {
+                                    "type": "string",
+                                    "enum": [
+                                      "en",
+                                      "fr",
+                                      "de",
+                                      "it",
+                                      "pl",
+                                      "pt",
+                                      "es",
+                                      "nl",
+                                      "he",
+                                      "en_gb",
+                                      "lv"
+                                    ]
+                                  },
+                                  "highlights": {
+                                    "type": "array",
+                                    "description": "A list of short benefit highlights in the specified locale.",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "required": [
+                                  "locale",
+                                  "highlights"
+                                ]
+                              }
+                            },
+                            "supported_countries": {
+                              "type": "array",
+                              "description": "A list of countries supported by the payment gateway, represented using ISO 3166-1 alpha-2 country codes.",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "supported_currencies": {
+                              "type": "array",
+                              "description": "A list of currencies supported by the payment gateway, represented using ISO 4217 format.",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "minimum_charge_amount": {
+                              "type": [
+                                "string",
+                                "number",
+                                "null"
+                              ],
+                              "description": "The minimum value that can be charged using the payment gateway. May be returned as a string or number depending on the gateway configuration."
+                            },
+                            "payment_methods": {
+                              "type": "object",
+                              "description": "The payment methods supported by the gateway.",
+                              "properties": {
+                                "credit_card": {
+                                  "type": "boolean",
+                                  "description": "Indicates if the gateway supports credit card payments."
+                                },
+                                "ach": {
+                                  "type": "boolean",
+                                  "description": "Indicates if the gateway supports ACH payments."
+                                },
+                                "ideal": {
+                                  "type": "boolean",
+                                  "description": "Indicates if the gateway supports iDeal payments."
+                                },
+                                "bancontact": {
+                                  "type": "boolean",
+                                  "description": "Indicates if the gateway supports Bancontact payments."
+                                },
+                                "twint": {
+                                  "type": "boolean",
+                                  "description": "Indicates if the gateway supports Twint payments."
+                                },
+                                "express_wallets": {
+                                  "type": "boolean",
+                                  "description": "Indicates if the gateway supports Express Wallets, such as Google Pay and Apple Pay."
+                                }
+                              }
+                            },
+                            "processing_features": {
+                              "type": "object",
+                              "description": "The features the payment gateway supports and their current state (enabled/disabled).",
+                              "properties": {
+                                "multi_currency": {
+                                  "type": "boolean",
+                                  "description": "Indicates if the gateway supports multi-currency transactions."
+                                },
+                                "back_office_charge": {
+                                  "type": "boolean",
+                                  "description": "Indicates if the gateway allows the SMB to process charges directly from the back office."
+                                },
+                                "checkout": {
+                                  "type": "boolean",
+                                  "description": "Indicates whether the payment gateway supports a checkout option initiated from the client portal. This value must always be set to true, as client portal checkout is a core feature."
+                                },
+                                "refund": {
+                                  "type": "boolean",
+                                  "description": "Indicates if the gateway supports full online refunds."
+                                },
+                                "partial_refund": {
+                                  "type": "boolean",
+                                  "description": "Indicates if the gateway supports partial online refunds. Requires full refunds to be enabled."
+                                },
+                                "client_save_card_on_checkout": {
+                                  "type": "boolean",
+                                  "description": "Indicates if clients can save cards on file during a payment flow."
+                                },
+                                "client_save_card_standalone": {
+                                  "type": "boolean",
+                                  "description": "Indicates if clients can save cards on file through a standalone flow."
+                                },
+                                "save_card_by_business": {
+                                  "type": "boolean",
+                                  "description": "Indicates if the gateway supports saving cards on file from the business side."
+                                },
+                                "offset_fees": {
+                                  "type": "boolean",
+                                  "description": "Indicates whether the gateway supports offsetting processing fees, as surcharges, convenience fees, or both, while each SMB can enable only one fee type or none."
+                                }
+                              },
+                              "required": [
+                                "multi_currency",
+                                "back_office_charge",
+                                "checkout",
+                                "refund",
+                                "partial_refund",
+                                "client_save_card_on_checkout",
+                                "client_save_card_standalone",
+                                "save_card_by_business",
+                                "offset_fees"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "app_code_name",
+                            "gateway_logo_url",
+                            "default_locale",
+                            "gateway_type",
+                            "status",
+                            "main_gateway_benefits",
+                            "brief_benefit_highlights",
+                            "supported_countries",
+                            "supported_currencies",
+                            "payment_methods",
+                            "processing_features"
+                          ],
+                          "example": {
+                            "uid": "pgw_abc123def456",
+                            "gateway_name": "stripe_payments_v2",
+                            "app_code_name": "stripe_payments_v2",
+                            "gateway_logo_url": "https://cdn.stripe.com/logo.png",
+                            "default_locale": "en",
+                            "gateway_type": "payments_provider",
+                            "status": "active",
+                            "created_at": "2024-01-15T10:30:00.000Z",
+                            "updated_at": "2024-01-20T14:45:00.000Z",
+                            "main_gateway_benefits": [
+                              {
+                                "locale": "en",
+                                "benefits": [
+                                  "Accept payments from 195+ countries",
+                                  "Industry-leading fraud protection",
+                                  "Fast payouts in 2-7 business days",
+                                  "24/7 customer support"
+                                ]
+                              },
+                              {
+                                "locale": "es",
+                                "benefits": [
+                                  "Acepta pagos de más de 195 países",
+                                  "Protección líder contra fraudes",
+                                  "Pagos rápidos en 2-7 días hábiles",
+                                  "Soporte al cliente 24/7"
+                                ]
+                              }
+                            ],
+                            "brief_benefit_highlights": [
+                              {
+                                "locale": "en",
+                                "highlights": [
+                                  "Global reach",
+                                  "Fraud protection",
+                                  "Fast payouts"
+                                ]
+                              },
+                              {
+                                "locale": "es",
+                                "highlights": [
+                                  "Alcance global",
+                                  "Protección fraude",
+                                  "Pagos rápidos"
+                                ]
+                              }
+                            ],
+                            "supported_countries": [
+                              "US",
+                              "CA",
+                              "GB",
+                              "AU",
+                              "DE",
+                              "FR",
+                              "ES",
+                              "IT"
+                            ],
+                            "supported_currencies": [
+                              "USD",
+                              "EUR",
+                              "GBP",
+                              "CAD",
+                              "AUD"
+                            ],
+                            "minimum_charge_amount": 0.5,
+                            "payment_methods": {
+                              "credit_card": true,
+                              "ach": true,
+                              "ideal": true,
+                              "bancontact": false,
+                              "twint": false,
+                              "express_wallets": false
+                            },
+                            "processing_features": {
+                              "multi_currency": true,
+                              "back_office_charge": true,
+                              "checkout": true,
+                              "refund": true,
+                              "partial_refund": true,
+                              "client_save_card_on_checkout": true,
+                              "client_save_card_standalone": true,
+                              "save_card_by_business": true,
+                              "offset_fees": true
+                            }
+                          },
+                          "description": "Metadata for a payment gateway integration, including locales, supported regions, methods, and processing features."
                         }
                       }
                     }
@@ -1141,7 +2336,50 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
@@ -1175,7 +2413,50 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
@@ -1268,12 +2549,91 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/payment_processing/paymentGatewayAssignment.json"
+                          "type": "object",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "description": "A unique identifier for the payment gateway assignment record."
+                            },
+                            "gateway_uid": {
+                              "type": "string",
+                              "description": "The unique identifier of the payment gateway being assigned."
+                            },
+                            "directory_uid": {
+                              "type": "string",
+                              "description": "The unique identifier of the directory to which the payment gateway is assigned."
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "description": "The date and time when the payment gateway assignment was created."
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "description": "The date and time when the payment gateway assignment was last updated."
+                            }
+                          },
+                          "required": [
+                            "gateway_uid",
+                            "directory_uid"
+                          ],
+                          "example": {
+                            "uid": "pga_abc123def456",
+                            "gateway_uid": "pgw_stripe_v2_789",
+                            "directory_uid": "dir_main_directory_123",
+                            "created_at": "2025-01-27T10:08:54.156Z",
+                            "updated_at": "2025-01-27T10:08:54.156Z"
+                          },
+                          "description": "A payment gateway assignment entity that defines the relationship between a payment gateway and a directory."
                         }
                       }
                     }
@@ -13353,7 +14713,50 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
@@ -13364,7 +14767,158 @@
                               "description": "List of stored payment cards for the client.",
                               "type": "array",
                               "items": {
-                                "$ref": "https://vcita.github.io/developers-hub/entities/payments/client_payment_card.json"
+                                "type": "object",
+                                "description": "Represents a stored payment card associated with a client. A client payment card holds tokenized card details used for processing payments on behalf of the client, including metadata about the card brand, funding type, expiration, and who initiated the card storage.",
+                                "properties": {
+                                  "uid": {
+                                    "type": "string",
+                                    "readOnly": true,
+                                    "description": "Unique identifier for the payment card record (e.g., \"card_123\")."
+                                  },
+                                  "client_uid": {
+                                    "type": "string",
+                                    "description": "Unique identifier of the client who owns this payment card (e.g., \"clt_aaabbbccc112233\")."
+                                  },
+                                  "business_uid": {
+                                    "type": "string",
+                                    "readOnly": true,
+                                    "description": "Unique identifier of the business this payment card is associated with (e.g., \"biz_1234567890\")."
+                                  },
+                                  "default": {
+                                    "type": "boolean",
+                                    "description": "Indicates whether this is the client's default payment card. Only one card per client can be marked as default."
+                                  },
+                                  "active": {
+                                    "type": "boolean",
+                                    "description": "Indicates whether the payment card is currently active and available for transactions."
+                                  },
+                                  "card_brand": {
+                                    "type": "string",
+                                    "enum": [
+                                      "visa",
+                                      "mastercard",
+                                      "amex",
+                                      "discover",
+                                      "diners",
+                                      "jcb",
+                                      "unionpay"
+                                    ],
+                                    "description": "The card network brand. Possible values: \"visa\" - Visa, \"mastercard\" - Mastercard, \"amex\" - American Express, \"discover\" - Discover, \"diners\" - Diners Club, \"jcb\" - JCB, \"unionpay\" - UnionPay."
+                                  },
+                                  "funding_type": {
+                                    "type": "string",
+                                    "enum": [
+                                      "credit",
+                                      "debit",
+                                      "prepaid",
+                                      "unknown"
+                                    ],
+                                    "description": "The funding source of the card. Possible values: \"credit\" - Credit card, \"debit\" - Debit card, \"prepaid\" - Prepaid card, \"unknown\" - Funding type could not be determined."
+                                  },
+                                  "last_four_digits": {
+                                    "type": "string",
+                                    "description": "The last four digits of the card number, used for display purposes only (e.g., \"4242\")."
+                                  },
+                                  "exp_month": {
+                                    "type": "integer",
+                                    "minimum": 1,
+                                    "maximum": 12,
+                                    "description": "The card's expiration month, as an integer from 1 (January) to 12 (December)."
+                                  },
+                                  "exp_year": {
+                                    "type": "integer",
+                                    "minimum": 2023,
+                                    "description": "The card's expiration year as a four-digit number (e.g., 2028)."
+                                  },
+                                  "cardholder_name": {
+                                    "type": "string",
+                                    "description": "The name of the cardholder as printed on the card (e.g., \"Jane Doe\")."
+                                  },
+                                  "staff_uid": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
+                                    "readOnly": true,
+                                    "description": "Unique identifier of the staff member who added this card on behalf of the client. Null if the card was added by the client directly."
+                                  },
+                                  "staff_name": {
+                                    "type": "string",
+                                    "readOnly": true,
+                                    "description": "Display name of the staff member who added the card (e.g., \"Jane Smith\"). Empty if the card was added by the client."
+                                  },
+                                  "payment_provider": {
+                                    "type": "string",
+                                    "enum": [
+                                      "stripe",
+                                      "square",
+                                      "squarepaymentgateway"
+                                    ],
+                                    "description": "The payment provider that tokenizes and processes this card. Possible values: \"stripe\" - Stripe, \"square\" - Square, \"squarepaymentgateway\" - Square Payment Gateway."
+                                  },
+                                  "initiator": {
+                                    "type": "string",
+                                    "enum": [
+                                      "client",
+                                      "staff"
+                                    ],
+                                    "description": "Indicates who initiated the card storage. Possible values: \"client\" - The client stored the card themselves, \"staff\" - A staff member stored the card on behalf of the client."
+                                  },
+                                  "can_be_used_by_staff": {
+                                    "type": "boolean",
+                                    "description": "Indicates whether this stored card is eligible to be used by staff-initiated payment flows, such as charging the client for services rendered."
+                                  },
+                                  "created_at": {
+                                    "type": "string",
+                                    "format": "date-time",
+                                    "readOnly": true,
+                                    "description": "The date and time when the payment card record was created, in ISO 8601 format."
+                                  },
+                                  "updated_at": {
+                                    "type": "string",
+                                    "format": "date-time",
+                                    "readOnly": true,
+                                    "description": "The date and time when the payment card record was last updated, in ISO 8601 format."
+                                  }
+                                },
+                                "required": [
+                                  "client_uid",
+                                  "card_brand",
+                                  "funding_type",
+                                  "last_four_digits",
+                                  "exp_month",
+                                  "exp_year",
+                                  "payment_provider",
+                                  "initiator"
+                                ],
+                                "readOnly": [
+                                  "uid",
+                                  "business_uid",
+                                  "staff_uid",
+                                  "staff_name",
+                                  "created_at",
+                                  "updated_at"
+                                ],
+                                "example": {
+                                  "uid": "card_123",
+                                  "client_uid": "clt_aaabbbccc112233",
+                                  "business_uid": "biz_1234567890",
+                                  "default": true,
+                                  "active": true,
+                                  "card_brand": "visa",
+                                  "funding_type": "credit",
+                                  "last_four_digits": "4242",
+                                  "exp_month": 12,
+                                  "exp_year": 2028,
+                                  "cardholder_name": "Jane Doe",
+                                  "staff_uid": null,
+                                  "staff_name": "Jane Smith",
+                                  "payment_provider": "stripe",
+                                  "initiator": "client",
+                                  "can_be_used_by_staff": false,
+                                  "created_at": "2026-01-15T10:30:00Z",
+                                  "updated_at": "2026-01-15T10:30:00Z"
+                                }
                               }
                             }
                           }
@@ -13419,7 +14973,50 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
@@ -13456,7 +15053,50 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
@@ -13538,7 +15178,50 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
@@ -13549,7 +15232,198 @@
                               "description": "List of Credit Notes",
                               "type": "array",
                               "items": {
-                                "$ref": "https://vcita.github.io/developers-hub/entities/payments/creditNote.json"
+                                "type": "object",
+                                "definitions": {
+                                  "creditNoteLineItem": {
+                                    "type": "object",
+                                    "description": "A line item refers to each credited item in the credit note. Credit note total amount will be a sum of all line items. Line items can be pre-populated from the original invoice or added as custom items.",
+                                    "properties": {
+                                      "name": {
+                                        "type": "string",
+                                        "description": "Line item name"
+                                      },
+                                      "quantity": {
+                                        "type": "number",
+                                        "description": "Line item quantity"
+                                      },
+                                      "unit_amount": {
+                                        "type": "number",
+                                        "description": "Unit price/amount"
+                                      },
+                                      "total_amount": {
+                                        "type": "number",
+                                        "description": "Line item total amount (quantity × unit_amount). Auto-calculated, read-only"
+                                      },
+                                      "taxes": {
+                                        "type": "array",
+                                        "description": "Tax information array",
+                                        "items": {
+                                          "$ref": "#/definitions/taxInfo"
+                                        }
+                                      }
+                                    },
+                                    "required": [
+                                      "name",
+                                      "quantity",
+                                      "unit_amount"
+                                    ]
+                                  },
+                                  "taxInfo": {
+                                    "type": "object",
+                                    "description": "Tax information object",
+                                    "properties": {
+                                      "name": {
+                                        "type": "string",
+                                        "description": "Tax name"
+                                      },
+                                      "rate": {
+                                        "type": "number",
+                                        "description": "Tax rate (e.g., 20 for 20%)"
+                                      },
+                                      "tax_total": {
+                                        "type": "number",
+                                        "description": "Tax total amount"
+                                      }
+                                    },
+                                    "required": [
+                                      "name",
+                                      "rate",
+                                      "tax_total"
+                                    ]
+                                  }
+                                },
+                                "properties": {
+                                  "uid": {
+                                    "type": "string",
+                                    "description": "The credit note's unique identifier. Auto-generated UID for the credit note"
+                                  },
+                                  "invoice_uid": {
+                                    "type": "string",
+                                    "description": "The unique identifier of the invoice this credit note is issued against. Required field. Links to Core invoice"
+                                  },
+                                  "status": {
+                                    "type": "string",
+                                    "enum": [
+                                      "ISSUED",
+                                      "SETTLED"
+                                    ],
+                                    "description": "Credit note status. Required field. Potential values: ISSUED, SETTLED. Issue refers to when the document is being officially issued and binding. Settled refers to the point where a monetary refund was executed per the credit value."
+                                  },
+                                  "unique_number": {
+                                    "type": "string",
+                                    "description": "Credit note unique, sequential number. Numeric value (like invoice number). Auto-generated if not provided. Format: numeric sequence (e.g., 1, 2, 3...) or yearly prefixed (e.g., 2025-0001, 2025-0002...)"
+                                  },
+                                  "total_amount": {
+                                    "type": "number",
+                                    "description": "The total amount of the credit note (sum of all items including taxes). Auto-calculated from items, read-only field"
+                                  },
+                                  "currency": {
+                                    "type": "string",
+                                    "description": "Three-letter ISO currency code (e.g., \"USD\", \"ILS\"). Required field. Must match invoice currency"
+                                  },
+                                  "issue_date": {
+                                    "type": "string",
+                                    "format": "date",
+                                    "description": "The date the credit note was issued. Read-only field"
+                                  },
+                                  "notes": {
+                                    "type": "string",
+                                    "description": "Credit note notes/reason. Maximum 200 characters. Optional. Used to provide context for the credit"
+                                  },
+                                  "line_items": {
+                                    "type": "array",
+                                    "description": "Array of credit note line items. Required, at least one item required",
+                                    "minItems": 1,
+                                    "items": {
+                                      "$ref": "#/definitions/creditNoteLineItem"
+                                    }
+                                  },
+                                  "created_at": {
+                                    "type": "string",
+                                    "format": "date-time",
+                                    "description": "Created date and time. Auto-generated timestamp"
+                                  },
+                                  "updated_at": {
+                                    "type": "string",
+                                    "format": "date-time",
+                                    "description": "Updated date and time. Auto-updated timestamp"
+                                  },
+                                  "net_total": {
+                                    "type": "number",
+                                    "description": "The credit note total amount excluding taxes. Auto-calculated, read-only"
+                                  },
+                                  "grand_total": {
+                                    "type": "number",
+                                    "description": "The credit note total amount including taxes. Auto-calculated, read-only (same as total_amount)"
+                                  },
+                                  "taxes": {
+                                    "type": "array",
+                                    "description": "Tax information array aggregated from all line items. Auto-calculated, read-only. Array of tax objects with structure: {name: string, rate: number, tax_total: number}. Aggregated by rate (sums tax_total for same rate + name)",
+                                    "items": {
+                                      "$ref": "#/definitions/taxInfo"
+                                    }
+                                  }
+                                },
+                                "required": [
+                                  "invoice_uid",
+                                  "currency",
+                                  "line_items"
+                                ],
+                                "readOnly": [
+                                  "uid",
+                                  "created_at",
+                                  "updated_at",
+                                  "status",
+                                  "issue_date",
+                                  "total_amount",
+                                  "net_total",
+                                  "grand_total",
+                                  "taxes"
+                                ],
+                                "example": {
+                                  "uid": "cn_abc123def456",
+                                  "invoice_uid": "inv_abc123",
+                                  "status": "ISSUED",
+                                  "unique_number": "2025-0001",
+                                  "total_amount": 75,
+                                  "currency": "USD",
+                                  "issue_date": "2025-11-19",
+                                  "notes": "Goodwill credit.",
+                                  "net_total": 62.5,
+                                  "grand_total": 75,
+                                  "taxes": [
+                                    {
+                                      "name": "VAT",
+                                      "rate": 20,
+                                      "tax_total": 12.5
+                                    }
+                                  ],
+                                  "line_items": [
+                                    {
+                                      "name": "Consulting Services Credit",
+                                      "quantity": 1,
+                                      "unit_amount": 50,
+                                      "total_amount": 50,
+                                      "taxes": [
+                                        {
+                                          "name": "VAT",
+                                          "rate": 20,
+                                          "tax_total": 10
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "name": "Custom Goodwill Credit",
+                                      "quantity": 1,
+                                      "unit_amount": 25,
+                                      "total_amount": 25,
+                                      "taxes": []
+                                    }
+                                  ],
+                                  "created_at": "2025-11-19T10:30:00Z",
+                                  "updated_at": "2025-11-19T10:30:00Z"
+                                },
+                                "description": "Credit note entity allows businesses to modify their issued invoices in a compliant invoicing flow. The credit note is a binding legal document that represents the credit factor of the invoice balance, of which the outstanding balance is being calculated from."
                               }
                             }
                           }
@@ -13583,16 +15457,24 @@
                 "type": "object",
                 "properties": {
                   "invoice_uid": {
-                    "$ref": "https://vcita.github.io/developers-hub/entities/payments/creditNote.json#/properties/invoice_uid"
+                    "type": "string",
+                    "description": "The unique identifier of the invoice this credit note is issued against. Required field. Links to Core invoice"
                   },
                   "notes": {
-                    "$ref": "https://vcita.github.io/developers-hub/entities/payments/creditNote.json#/properties/notes"
+                    "type": "string",
+                    "description": "Credit note notes/reason. Maximum 200 characters. Optional. Used to provide context for the credit"
                   },
                   "line_items": {
-                    "$ref": "https://vcita.github.io/developers-hub/entities/payments/creditNote.json#/properties/line_items"
+                    "type": "array",
+                    "description": "Array of credit note line items. Required, at least one item required",
+                    "minItems": 1,
+                    "items": {
+                      "$ref": "#/definitions/creditNoteLineItem"
+                    }
                   },
                   "unique_number": {
-                    "$ref": "https://vcita.github.io/developers-hub/entities/payments/creditNote.json#/properties/unique_number"
+                    "type": "string",
+                    "description": "Credit note unique, sequential number. Numeric value (like invoice number). Auto-generated if not provided. Format: numeric sequence (e.g., 1, 2, 3...) or yearly prefixed (e.g., 2025-0001, 2025-0002...)"
                   },
                   "source_payment_uid": {
                     "type": "string",
@@ -13645,12 +15527,246 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/payments/creditNote.json"
+                          "type": "object",
+                          "definitions": {
+                            "creditNoteLineItem": {
+                              "type": "object",
+                              "description": "A line item refers to each credited item in the credit note. Credit note total amount will be a sum of all line items. Line items can be pre-populated from the original invoice or added as custom items.",
+                              "properties": {
+                                "name": {
+                                  "type": "string",
+                                  "description": "Line item name"
+                                },
+                                "quantity": {
+                                  "type": "number",
+                                  "description": "Line item quantity"
+                                },
+                                "unit_amount": {
+                                  "type": "number",
+                                  "description": "Unit price/amount"
+                                },
+                                "total_amount": {
+                                  "type": "number",
+                                  "description": "Line item total amount (quantity × unit_amount). Auto-calculated, read-only"
+                                },
+                                "taxes": {
+                                  "type": "array",
+                                  "description": "Tax information array",
+                                  "items": {
+                                    "$ref": "#/definitions/taxInfo"
+                                  }
+                                }
+                              },
+                              "required": [
+                                "name",
+                                "quantity",
+                                "unit_amount"
+                              ]
+                            },
+                            "taxInfo": {
+                              "type": "object",
+                              "description": "Tax information object",
+                              "properties": {
+                                "name": {
+                                  "type": "string",
+                                  "description": "Tax name"
+                                },
+                                "rate": {
+                                  "type": "number",
+                                  "description": "Tax rate (e.g., 20 for 20%)"
+                                },
+                                "tax_total": {
+                                  "type": "number",
+                                  "description": "Tax total amount"
+                                }
+                              },
+                              "required": [
+                                "name",
+                                "rate",
+                                "tax_total"
+                              ]
+                            }
+                          },
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "description": "The credit note's unique identifier. Auto-generated UID for the credit note"
+                            },
+                            "invoice_uid": {
+                              "type": "string",
+                              "description": "The unique identifier of the invoice this credit note is issued against. Required field. Links to Core invoice"
+                            },
+                            "status": {
+                              "type": "string",
+                              "enum": [
+                                "ISSUED",
+                                "SETTLED"
+                              ],
+                              "description": "Credit note status. Required field. Potential values: ISSUED, SETTLED. Issue refers to when the document is being officially issued and binding. Settled refers to the point where a monetary refund was executed per the credit value."
+                            },
+                            "unique_number": {
+                              "type": "string",
+                              "description": "Credit note unique, sequential number. Numeric value (like invoice number). Auto-generated if not provided. Format: numeric sequence (e.g., 1, 2, 3...) or yearly prefixed (e.g., 2025-0001, 2025-0002...)"
+                            },
+                            "total_amount": {
+                              "type": "number",
+                              "description": "The total amount of the credit note (sum of all items including taxes). Auto-calculated from items, read-only field"
+                            },
+                            "currency": {
+                              "type": "string",
+                              "description": "Three-letter ISO currency code (e.g., \"USD\", \"ILS\"). Required field. Must match invoice currency"
+                            },
+                            "issue_date": {
+                              "type": "string",
+                              "format": "date",
+                              "description": "The date the credit note was issued. Read-only field"
+                            },
+                            "notes": {
+                              "type": "string",
+                              "description": "Credit note notes/reason. Maximum 200 characters. Optional. Used to provide context for the credit"
+                            },
+                            "line_items": {
+                              "type": "array",
+                              "description": "Array of credit note line items. Required, at least one item required",
+                              "minItems": 1,
+                              "items": {
+                                "$ref": "#/definitions/creditNoteLineItem"
+                              }
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "description": "Created date and time. Auto-generated timestamp"
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "description": "Updated date and time. Auto-updated timestamp"
+                            },
+                            "net_total": {
+                              "type": "number",
+                              "description": "The credit note total amount excluding taxes. Auto-calculated, read-only"
+                            },
+                            "grand_total": {
+                              "type": "number",
+                              "description": "The credit note total amount including taxes. Auto-calculated, read-only (same as total_amount)"
+                            },
+                            "taxes": {
+                              "type": "array",
+                              "description": "Tax information array aggregated from all line items. Auto-calculated, read-only. Array of tax objects with structure: {name: string, rate: number, tax_total: number}. Aggregated by rate (sums tax_total for same rate + name)",
+                              "items": {
+                                "$ref": "#/definitions/taxInfo"
+                              }
+                            }
+                          },
+                          "required": [
+                            "invoice_uid",
+                            "currency",
+                            "line_items"
+                          ],
+                          "readOnly": [
+                            "uid",
+                            "created_at",
+                            "updated_at",
+                            "status",
+                            "issue_date",
+                            "total_amount",
+                            "net_total",
+                            "grand_total",
+                            "taxes"
+                          ],
+                          "example": {
+                            "uid": "cn_abc123def456",
+                            "invoice_uid": "inv_abc123",
+                            "status": "ISSUED",
+                            "unique_number": "2025-0001",
+                            "total_amount": 75,
+                            "currency": "USD",
+                            "issue_date": "2025-11-19",
+                            "notes": "Goodwill credit.",
+                            "net_total": 62.5,
+                            "grand_total": 75,
+                            "taxes": [
+                              {
+                                "name": "VAT",
+                                "rate": 20,
+                                "tax_total": 12.5
+                              }
+                            ],
+                            "line_items": [
+                              {
+                                "name": "Consulting Services Credit",
+                                "quantity": 1,
+                                "unit_amount": 50,
+                                "total_amount": 50,
+                                "taxes": [
+                                  {
+                                    "name": "VAT",
+                                    "rate": 20,
+                                    "tax_total": 10
+                                  }
+                                ]
+                              },
+                              {
+                                "name": "Custom Goodwill Credit",
+                                "quantity": 1,
+                                "unit_amount": 25,
+                                "total_amount": 25,
+                                "taxes": []
+                              }
+                            ],
+                            "created_at": "2025-11-19T10:30:00Z",
+                            "updated_at": "2025-11-19T10:30:00Z"
+                          },
+                          "description": "Credit note entity allows businesses to modify their issued invoices in a compliant invoicing flow. The credit note is a binding legal document that represents the credit factor of the invoice balance, of which the outstanding balance is being calculated from."
                         }
                       }
                     }
@@ -13694,12 +15810,246 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/payments/creditNote.json"
+                          "type": "object",
+                          "definitions": {
+                            "creditNoteLineItem": {
+                              "type": "object",
+                              "description": "A line item refers to each credited item in the credit note. Credit note total amount will be a sum of all line items. Line items can be pre-populated from the original invoice or added as custom items.",
+                              "properties": {
+                                "name": {
+                                  "type": "string",
+                                  "description": "Line item name"
+                                },
+                                "quantity": {
+                                  "type": "number",
+                                  "description": "Line item quantity"
+                                },
+                                "unit_amount": {
+                                  "type": "number",
+                                  "description": "Unit price/amount"
+                                },
+                                "total_amount": {
+                                  "type": "number",
+                                  "description": "Line item total amount (quantity × unit_amount). Auto-calculated, read-only"
+                                },
+                                "taxes": {
+                                  "type": "array",
+                                  "description": "Tax information array",
+                                  "items": {
+                                    "$ref": "#/definitions/taxInfo"
+                                  }
+                                }
+                              },
+                              "required": [
+                                "name",
+                                "quantity",
+                                "unit_amount"
+                              ]
+                            },
+                            "taxInfo": {
+                              "type": "object",
+                              "description": "Tax information object",
+                              "properties": {
+                                "name": {
+                                  "type": "string",
+                                  "description": "Tax name"
+                                },
+                                "rate": {
+                                  "type": "number",
+                                  "description": "Tax rate (e.g., 20 for 20%)"
+                                },
+                                "tax_total": {
+                                  "type": "number",
+                                  "description": "Tax total amount"
+                                }
+                              },
+                              "required": [
+                                "name",
+                                "rate",
+                                "tax_total"
+                              ]
+                            }
+                          },
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "description": "The credit note's unique identifier. Auto-generated UID for the credit note"
+                            },
+                            "invoice_uid": {
+                              "type": "string",
+                              "description": "The unique identifier of the invoice this credit note is issued against. Required field. Links to Core invoice"
+                            },
+                            "status": {
+                              "type": "string",
+                              "enum": [
+                                "ISSUED",
+                                "SETTLED"
+                              ],
+                              "description": "Credit note status. Required field. Potential values: ISSUED, SETTLED. Issue refers to when the document is being officially issued and binding. Settled refers to the point where a monetary refund was executed per the credit value."
+                            },
+                            "unique_number": {
+                              "type": "string",
+                              "description": "Credit note unique, sequential number. Numeric value (like invoice number). Auto-generated if not provided. Format: numeric sequence (e.g., 1, 2, 3...) or yearly prefixed (e.g., 2025-0001, 2025-0002...)"
+                            },
+                            "total_amount": {
+                              "type": "number",
+                              "description": "The total amount of the credit note (sum of all items including taxes). Auto-calculated from items, read-only field"
+                            },
+                            "currency": {
+                              "type": "string",
+                              "description": "Three-letter ISO currency code (e.g., \"USD\", \"ILS\"). Required field. Must match invoice currency"
+                            },
+                            "issue_date": {
+                              "type": "string",
+                              "format": "date",
+                              "description": "The date the credit note was issued. Read-only field"
+                            },
+                            "notes": {
+                              "type": "string",
+                              "description": "Credit note notes/reason. Maximum 200 characters. Optional. Used to provide context for the credit"
+                            },
+                            "line_items": {
+                              "type": "array",
+                              "description": "Array of credit note line items. Required, at least one item required",
+                              "minItems": 1,
+                              "items": {
+                                "$ref": "#/definitions/creditNoteLineItem"
+                              }
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "description": "Created date and time. Auto-generated timestamp"
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "description": "Updated date and time. Auto-updated timestamp"
+                            },
+                            "net_total": {
+                              "type": "number",
+                              "description": "The credit note total amount excluding taxes. Auto-calculated, read-only"
+                            },
+                            "grand_total": {
+                              "type": "number",
+                              "description": "The credit note total amount including taxes. Auto-calculated, read-only (same as total_amount)"
+                            },
+                            "taxes": {
+                              "type": "array",
+                              "description": "Tax information array aggregated from all line items. Auto-calculated, read-only. Array of tax objects with structure: {name: string, rate: number, tax_total: number}. Aggregated by rate (sums tax_total for same rate + name)",
+                              "items": {
+                                "$ref": "#/definitions/taxInfo"
+                              }
+                            }
+                          },
+                          "required": [
+                            "invoice_uid",
+                            "currency",
+                            "line_items"
+                          ],
+                          "readOnly": [
+                            "uid",
+                            "created_at",
+                            "updated_at",
+                            "status",
+                            "issue_date",
+                            "total_amount",
+                            "net_total",
+                            "grand_total",
+                            "taxes"
+                          ],
+                          "example": {
+                            "uid": "cn_abc123def456",
+                            "invoice_uid": "inv_abc123",
+                            "status": "ISSUED",
+                            "unique_number": "2025-0001",
+                            "total_amount": 75,
+                            "currency": "USD",
+                            "issue_date": "2025-11-19",
+                            "notes": "Goodwill credit.",
+                            "net_total": 62.5,
+                            "grand_total": 75,
+                            "taxes": [
+                              {
+                                "name": "VAT",
+                                "rate": 20,
+                                "tax_total": 12.5
+                              }
+                            ],
+                            "line_items": [
+                              {
+                                "name": "Consulting Services Credit",
+                                "quantity": 1,
+                                "unit_amount": 50,
+                                "total_amount": 50,
+                                "taxes": [
+                                  {
+                                    "name": "VAT",
+                                    "rate": 20,
+                                    "tax_total": 10
+                                  }
+                                ]
+                              },
+                              {
+                                "name": "Custom Goodwill Credit",
+                                "quantity": 1,
+                                "unit_amount": 25,
+                                "total_amount": 25,
+                                "taxes": []
+                              }
+                            ],
+                            "created_at": "2025-11-19T10:30:00Z",
+                            "updated_at": "2025-11-19T10:30:00Z"
+                          },
+                          "description": "Credit note entity allows businesses to modify their issued invoices in a compliant invoicing flow. The credit note is a binding legal document that represents the credit factor of the invoice balance, of which the outstanding balance is being calculated from."
                         }
                       }
                     }
@@ -14984,64 +17334,126 @@
                 "type": "object",
                 "properties": {
                   "matter_uid": {
-                    "$ref": "https://vcita.github.io/developers-hub/entities/payments/invoice.json#/properties/matter_uid"
+                    "type": "string",
+                    "description": "Matter UID. The identify number of the client that the invoice for issued for"
                   },
                   "issue_date": {
-                    "$ref": "https://vcita.github.io/developers-hub/entities/payments/invoice.json#/properties/issue_date"
+                    "type": "string",
+                    "format": "date",
+                    "description": "The date the invoice was issued. Issue_date >=Today()"
                   },
                   "due_date": {
-                    "$ref": "https://vcita.github.io/developers-hub/entities/payments/invoice.json#/properties/due_date"
+                    "type": "string",
+                    "format": "date",
+                    "description": "Invoice due date. Expected date for payment. Must be >= issue_date"
                   },
                   "currency": {
-                    "$ref": "https://vcita.github.io/developers-hub/entities/payments/invoice.json#/properties/currency"
+                    "type": "string",
+                    "description": "Three-letter ISO currency code (e.g., \"USD\", \"ILS\")"
                   },
                   "status": {
-                    "$ref": "https://vcita.github.io/developers-hub/entities/payments/invoice.json#/properties/status"
+                    "type": "string",
+                    "enum": [
+                      "DRAFT",
+                      "ISSUED",
+                      "CANCELLED"
+                    ],
+                    "description": "Invoice statuses (Draft, Issued, Cancelled). Draft: refers to the initial editable stage of the invoice. Issued: Invoice was issued. (in Strict mode: Invoice is immune and cannot be edited. Cancelled: Cancelled invoices: In strict mode: Can be performed only from \"Draft\" state. In Flex mode: Issued to Cancelled is allowed. Required field: \"DRAFT\" or \"ISSUED\" or \"CANCELLED\" (default: \"ISSUED\")"
                   },
                   "unique_number": {
-                    "$ref": "https://vcita.github.io/developers-hub/entities/payments/invoice.json#/properties/unique_number"
+                    "type": "string",
+                    "description": "Invoice unique, sequential number.\nTwo types of numbering:\n1. Unique sequence of numbers (1,2,3….)\n2. A yearly repeated numbering including a year's prefix (2025-0001, 2025-0002…). Within each year start - rounding the count (2026-0001, 2026-0002,…).\nOptional, auto-generated if not provided"
                   },
                   "invoice_title": {
-                    "$ref": "https://vcita.github.io/developers-hub/entities/payments/invoice.json#/properties/invoice_title"
+                    "type": "string",
+                    "description": "Invoice title. A document title to appear on top of the PDF. Optional. Default: \"INVOICE\""
                   },
                   "billing_address": {
-                    "$ref": "https://vcita.github.io/developers-hub/entities/payments/invoice.json#/properties/billing_address"
+                    "type": "string",
+                    "description": "Full business billing address, including street, city, state, country, and zipcode"
                   },
                   "purchase_order": {
-                    "$ref": "https://vcita.github.io/developers-hub/entities/payments/invoice.json#/properties/purchase_order"
+                    "type": "string",
+                    "description": "Purchase order number"
                   },
                   "allow_online_payment": {
-                    "$ref": "https://vcita.github.io/developers-hub/entities/payments/invoice.json#/properties/allow_online_payment"
+                    "type": "boolean",
+                    "description": "Enable online payment for this specific invoice (allow the client to pay directly from the client portal)"
                   },
                   "allow_partial_payment": {
-                    "$ref": "https://vcita.github.io/developers-hub/entities/payments/invoice.json#/properties/allow_partial_payment"
+                    "type": "boolean",
+                    "description": "Enable partial payment for this specific invoice (allow the client to pay a portion of the invoice amount rather than its full due price)"
                   },
                   "enable_late_fee": {
-                    "$ref": "https://vcita.github.io/developers-hub/entities/payments/invoice.json#/properties/enable_late_fee"
+                    "type": "boolean",
+                    "description": "Enable late fee on invoice for this specific invoice. (late fee will be added to the invoice automatically when the invoice will become overdue. Not applicable in strict mode where an invoice is a legal binding document and cannot be edited)"
                   },
                   "note": {
-                    "$ref": "https://vcita.github.io/developers-hub/entities/payments/invoice.json#/properties/note"
+                    "type": "string",
+                    "description": "Invoice notes/comments appears in the invoice document"
                   },
                   "terms_and_conditions": {
-                    "$ref": "https://vcita.github.io/developers-hub/entities/payments/invoice.json#/properties/terms_and_conditions"
+                    "type": "string",
+                    "description": "Payment terms and conditions. appears in the invoice document"
                   },
                   "additional_recipients": {
-                    "$ref": "https://vcita.github.io/developers-hub/entities/payments/invoice.json#/properties/additional_recipients"
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "format": "email"
+                    },
+                    "description": "CC email recipients (array of email strings). comma separated"
                   },
                   "line_item_groups": {
-                    "$ref": "https://vcita.github.io/developers-hub/entities/payments/invoice.json#/properties/line_item_groups"
+                    "type": "array",
+                    "description": "Array of invoice line item groups. Line item groups allows to group invoice line items per need, while each line item group will have at least a single line item set in it. Optional, used when `add_item_header` feature flag is enabled",
+                    "minItems": 1,
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "description": "Section name"
+                        },
+                        "line_item_group_index": {
+                          "type": "number",
+                          "description": "Section order/index"
+                        },
+                        "line_items": {
+                          "type": "array",
+                          "description": "Array of line items within this section",
+                          "minItems": 1,
+                          "items": {
+                            "$ref": "#/definitions/lineItem"
+                          }
+                        }
+                      },
+                      "required": [
+                        "name",
+                        "line_item_group_index",
+                        "line_items"
+                      ]
+                    }
                   },
                   "display_line_item_groups_total": {
-                    "$ref": "https://vcita.github.io/developers-hub/entities/payments/invoice.json#/properties/display_line_item_groups_total"
+                    "type": "boolean",
+                    "description": "Display the total price of the items that are nested under a line items group"
                   },
                   "display_line_item_total": {
-                    "$ref": "https://vcita.github.io/developers-hub/entities/payments/invoice.json#/properties/display_line_item_total"
+                    "type": "boolean",
+                    "description": "Display nested under a group line item price"
                   },
                   "estimate_uid": {
-                    "$ref": "https://vcita.github.io/developers-hub/entities/payments/invoice.json#/properties/estimate_uid"
+                    "type": "string",
+                    "description": "The unique identifier of the estimate from which invoice was created"
                   },
                   "line_items": {
-                    "$ref": "https://vcita.github.io/developers-hub/entities/payments/invoice.json#/properties/line_items"
+                    "type": "array",
+                    "description": "Array of invoice line items. Line items that are not part of the line item groups. Required if line_item_groups not provided, at least one line item required",
+                    "minItems": 1,
+                    "items": {
+                      "$ref": "#/definitions/lineItem"
+                    }
                   },
                   "notify_recipient": {
                     "type": "boolean",
@@ -15159,12 +17571,386 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/payments/invoice.json"
+                          "type": "object",
+                          "definitions": {
+                            "lineItem": {
+                              "type": "object",
+                              "description": "A line item refers to each billable item in the invoice. Invoice total amount will be a sum of all line items. A line item can be added nested under a line items group, or independently in the invoice (not nested)",
+                              "properties": {
+                                "name": {
+                                  "type": "string",
+                                  "description": "Line item name/title"
+                                },
+                                "quantity": {
+                                  "type": "number",
+                                  "description": "Line item quantity"
+                                },
+                                "unit_amount": {
+                                  "type": "number",
+                                  "description": "Unit price/amount"
+                                },
+                                "description": {
+                                  "type": "string",
+                                  "description": "Line item description"
+                                },
+                                "entity_uid": {
+                                  "type": "string",
+                                  "description": "UID of related entity (service/product/package)"
+                                },
+                                "entity_type": {
+                                  "type": "string",
+                                  "enum": [
+                                    "Meeting",
+                                    "EventAttendance",
+                                    "ProductOrder",
+                                    "ClientBookingPackage",
+                                    "Service",
+                                    "Product",
+                                    "BookingPackage"
+                                  ],
+                                  "description": "Type of related entity. If custom item → NULL"
+                                },
+                                "uid": {
+                                  "type": "string",
+                                  "description": "Line item UID (for updates)"
+                                },
+                                "tax_uids": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "description": "Array of tax UIDs to apply. Pulled from the taxes set in the business Taxes settings. 0-3 taxes per line item are allowed"
+                                },
+                                "discount": {
+                                  "type": "object",
+                                  "description": "Line item discount. Can be a percentage or a fixed amount to be reduced from the line item amount",
+                                  "properties": {
+                                    "discount_type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "percent",
+                                        "amount"
+                                      ],
+                                      "description": "Type of discount: percentage or fixed amount"
+                                    },
+                                    "amount": {
+                                      "type": "number",
+                                      "description": "Discount value. If discount_type is 'percent', this is the percentage (e.g., 10 for 10%). If discount_type is 'amount', this is the fixed discount amount"
+                                    }
+                                  },
+                                  "required": [
+                                    "discount_type",
+                                    "amount"
+                                  ]
+                                },
+                                "line_item_index": {
+                                  "type": "number",
+                                  "description": "Line item position/index"
+                                }
+                              },
+                              "required": [
+                                "name",
+                                "quantity",
+                                "unit_amount"
+                              ]
+                            }
+                          },
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "description": "The invoice's unique identifier"
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "description": "Created date and time"
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "description": "Updated date and time"
+                            },
+                            "matter_uid": {
+                              "type": "string",
+                              "description": "Matter UID. The identify number of the client that the invoice for issued for"
+                            },
+                            "issue_date": {
+                              "type": "string",
+                              "format": "date",
+                              "description": "The date the invoice was issued. Issue_date >=Today()"
+                            },
+                            "due_date": {
+                              "type": "string",
+                              "format": "date",
+                              "description": "Invoice due date. Expected date for payment. Must be >= issue_date"
+                            },
+                            "currency": {
+                              "type": "string",
+                              "description": "Three-letter ISO currency code (e.g., \"USD\", \"ILS\")"
+                            },
+                            "status": {
+                              "type": "string",
+                              "enum": [
+                                "DRAFT",
+                                "ISSUED",
+                                "CANCELLED"
+                              ],
+                              "description": "Invoice statuses (Draft, Issued, Cancelled). Draft: refers to the initial editable stage of the invoice. Issued: Invoice was issued. (in Strict mode: Invoice is immune and cannot be edited. Cancelled: Cancelled invoices: In strict mode: Can be performed only from \"Draft\" state. In Flex mode: Issued to Cancelled is allowed. Required field: \"DRAFT\" or \"ISSUED\" or \"CANCELLED\" (default: \"ISSUED\")"
+                            },
+                            "unique_number": {
+                              "type": "string",
+                              "description": "Invoice unique, sequential number.\nTwo types of numbering:\n1. Unique sequence of numbers (1,2,3….)\n2. A yearly repeated numbering including a year's prefix (2025-0001, 2025-0002…). Within each year start - rounding the count (2026-0001, 2026-0002,…).\nOptional, auto-generated if not provided"
+                            },
+                            "invoice_title": {
+                              "type": "string",
+                              "description": "Invoice title. A document title to appear on top of the PDF. Optional. Default: \"INVOICE\""
+                            },
+                            "billing_address": {
+                              "type": "string",
+                              "description": "Full business billing address, including street, city, state, country, and zipcode"
+                            },
+                            "purchase_order": {
+                              "type": "string",
+                              "description": "Purchase order number"
+                            },
+                            "allow_online_payment": {
+                              "type": "boolean",
+                              "description": "Enable online payment for this specific invoice (allow the client to pay directly from the client portal)"
+                            },
+                            "allow_partial_payment": {
+                              "type": "boolean",
+                              "description": "Enable partial payment for this specific invoice (allow the client to pay a portion of the invoice amount rather than its full due price)"
+                            },
+                            "enable_late_fee": {
+                              "type": "boolean",
+                              "description": "Enable late fee on invoice for this specific invoice. (late fee will be added to the invoice automatically when the invoice will become overdue. Not applicable in strict mode where an invoice is a legal binding document and cannot be edited)"
+                            },
+                            "note": {
+                              "type": "string",
+                              "description": "Invoice notes/comments appears in the invoice document"
+                            },
+                            "terms_and_conditions": {
+                              "type": "string",
+                              "description": "Payment terms and conditions. appears in the invoice document"
+                            },
+                            "additional_recipients": {
+                              "type": "array",
+                              "items": {
+                                "type": "string",
+                                "format": "email"
+                              },
+                              "description": "CC email recipients (array of email strings). comma separated"
+                            },
+                            "line_item_groups": {
+                              "type": "array",
+                              "description": "Array of invoice line item groups. Line item groups allows to group invoice line items per need, while each line item group will have at least a single line item set in it. Optional, used when `add_item_header` feature flag is enabled",
+                              "minItems": 1,
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "name": {
+                                    "type": "string",
+                                    "description": "Section name"
+                                  },
+                                  "line_item_group_index": {
+                                    "type": "number",
+                                    "description": "Section order/index"
+                                  },
+                                  "line_items": {
+                                    "type": "array",
+                                    "description": "Array of line items within this section",
+                                    "minItems": 1,
+                                    "items": {
+                                      "$ref": "#/definitions/lineItem"
+                                    }
+                                  }
+                                },
+                                "required": [
+                                  "name",
+                                  "line_item_group_index",
+                                  "line_items"
+                                ]
+                              }
+                            },
+                            "display_line_item_groups_total": {
+                              "type": "boolean",
+                              "description": "Display the total price of the items that are nested under a line items group"
+                            },
+                            "display_line_item_total": {
+                              "type": "boolean",
+                              "description": "Display nested under a group line item price"
+                            },
+                            "estimate_uid": {
+                              "type": "string",
+                              "description": "The unique identifier of the estimate from which invoice was created"
+                            },
+                            "line_items": {
+                              "type": "array",
+                              "description": "Array of invoice line items. Line items that are not part of the line item groups. Required if line_item_groups not provided, at least one line item required",
+                              "minItems": 1,
+                              "items": {
+                                "$ref": "#/definitions/lineItem"
+                              }
+                            },
+                            "payment_status_uid": {
+                              "type": "string",
+                              "description": "The identified number of the payment request that is associated with the invoice"
+                            },
+                            "net_total": {
+                              "type": "number",
+                              "description": "The invoice total amount exclude taxes"
+                            },
+                            "grand_total": {
+                              "type": "number",
+                              "description": "The invoice total amount including taxes"
+                            },
+                            "taxes": {
+                              "type": "number",
+                              "description": "The total taxes amount as calculated per the invoice line items amount"
+                            }
+                          },
+                          "anyOf": [
+                            {
+                              "required": [
+                                "matter_uid",
+                                "issue_date",
+                                "due_date",
+                                "currency",
+                                "line_items"
+                              ]
+                            },
+                            {
+                              "required": [
+                                "matter_uid",
+                                "issue_date",
+                                "due_date",
+                                "currency",
+                                "line_item_groups"
+                              ]
+                            }
+                          ],
+                          "readOnly": [
+                            "uid",
+                            "created_at",
+                            "updated_at",
+                            "payment_status_uid",
+                            "net_total",
+                            "grand_total",
+                            "taxes"
+                          ],
+                          "example": {
+                            "uid": "inv-aaabbbccc112233",
+                            "created_at": "2024-01-15T10:00:00.000Z",
+                            "updated_at": "2024-01-15T10:00:00.000Z",
+                            "matter_uid": "matter_123",
+                            "issue_date": "2024-01-15",
+                            "due_date": "2024-02-15",
+                            "currency": "USD",
+                            "status": "ISSUED",
+                            "unique_number": "2024-0001",
+                            "invoice_title": "INVOICE",
+                            "billing_address": "123 Main St, City, State 12345",
+                            "purchase_order": "PO-12345",
+                            "allow_online_payment": true,
+                            "allow_partial_payment": false,
+                            "enable_late_fee": false,
+                            "note": "Thank you for your business",
+                            "terms_and_conditions": "Payment due within 30 days",
+                            "additional_recipients": [
+                              "accounting@example.com"
+                            ],
+                            "display_line_item_groups_total": true,
+                            "display_line_item_total": true,
+                            "estimate_uid": null,
+                            "line_item_groups": [
+                              {
+                                "name": "Services",
+                                "line_item_group_index": 0,
+                                "line_items": [
+                                  {
+                                    "name": "Consulting Services",
+                                    "quantity": 2,
+                                    "unit_amount": 150,
+                                    "description": "Hourly consulting",
+                                    "entity_uid": "service_123",
+                                    "entity_type": "Service",
+                                    "tax_uids": [
+                                      "tax_uid_1"
+                                    ],
+                                    "discount": {
+                                      "discount_type": "percent",
+                                      "amount": 10
+                                    },
+                                    "line_item_index": 0
+                                  }
+                                ]
+                              }
+                            ],
+                            "line_items": [
+                              {
+                                "name": "Design materials",
+                                "quantity": 1,
+                                "unit_amount": 114,
+                                "description": "Design materials",
+                                "entity_uid": "product_123",
+                                "entity_type": "Product",
+                                "tax_uids": [
+                                  "tax_uid_1"
+                                ],
+                                "discount": null,
+                                "line_item_index": 1
+                              }
+                            ]
+                          },
+                          "description": "Invoice entity representing a bill or invoice document with line items, payment terms, and client information."
                         }
                       }
                     }
@@ -15208,64 +17994,126 @@
                 "type": "object",
                 "properties": {
                   "matter_uid": {
-                    "$ref": "https://vcita.github.io/developers-hub/entities/payments/invoice.json#/properties/matter_uid"
+                    "type": "string",
+                    "description": "Matter UID. The identify number of the client that the invoice for issued for"
                   },
                   "issue_date": {
-                    "$ref": "https://vcita.github.io/developers-hub/entities/payments/invoice.json#/properties/issue_date"
+                    "type": "string",
+                    "format": "date",
+                    "description": "The date the invoice was issued. Issue_date >=Today()"
                   },
                   "due_date": {
-                    "$ref": "https://vcita.github.io/developers-hub/entities/payments/invoice.json#/properties/due_date"
+                    "type": "string",
+                    "format": "date",
+                    "description": "Invoice due date. Expected date for payment. Must be >= issue_date"
                   },
                   "currency": {
-                    "$ref": "https://vcita.github.io/developers-hub/entities/payments/invoice.json#/properties/currency"
+                    "type": "string",
+                    "description": "Three-letter ISO currency code (e.g., \"USD\", \"ILS\")"
                   },
                   "status": {
-                    "$ref": "https://vcita.github.io/developers-hub/entities/payments/invoice.json#/properties/status"
+                    "type": "string",
+                    "enum": [
+                      "DRAFT",
+                      "ISSUED",
+                      "CANCELLED"
+                    ],
+                    "description": "Invoice statuses (Draft, Issued, Cancelled). Draft: refers to the initial editable stage of the invoice. Issued: Invoice was issued. (in Strict mode: Invoice is immune and cannot be edited. Cancelled: Cancelled invoices: In strict mode: Can be performed only from \"Draft\" state. In Flex mode: Issued to Cancelled is allowed. Required field: \"DRAFT\" or \"ISSUED\" or \"CANCELLED\" (default: \"ISSUED\")"
                   },
                   "unique_number": {
-                    "$ref": "https://vcita.github.io/developers-hub/entities/payments/invoice.json#/properties/unique_number"
+                    "type": "string",
+                    "description": "Invoice unique, sequential number.\nTwo types of numbering:\n1. Unique sequence of numbers (1,2,3….)\n2. A yearly repeated numbering including a year's prefix (2025-0001, 2025-0002…). Within each year start - rounding the count (2026-0001, 2026-0002,…).\nOptional, auto-generated if not provided"
                   },
                   "invoice_title": {
-                    "$ref": "https://vcita.github.io/developers-hub/entities/payments/invoice.json#/properties/invoice_title"
+                    "type": "string",
+                    "description": "Invoice title. A document title to appear on top of the PDF. Optional. Default: \"INVOICE\""
                   },
                   "billing_address": {
-                    "$ref": "https://vcita.github.io/developers-hub/entities/payments/invoice.json#/properties/billing_address"
+                    "type": "string",
+                    "description": "Full business billing address, including street, city, state, country, and zipcode"
                   },
                   "purchase_order": {
-                    "$ref": "https://vcita.github.io/developers-hub/entities/payments/invoice.json#/properties/purchase_order"
+                    "type": "string",
+                    "description": "Purchase order number"
                   },
                   "allow_online_payment": {
-                    "$ref": "https://vcita.github.io/developers-hub/entities/payments/invoice.json#/properties/allow_online_payment"
+                    "type": "boolean",
+                    "description": "Enable online payment for this specific invoice (allow the client to pay directly from the client portal)"
                   },
                   "allow_partial_payment": {
-                    "$ref": "https://vcita.github.io/developers-hub/entities/payments/invoice.json#/properties/allow_partial_payment"
+                    "type": "boolean",
+                    "description": "Enable partial payment for this specific invoice (allow the client to pay a portion of the invoice amount rather than its full due price)"
                   },
                   "enable_late_fee": {
-                    "$ref": "https://vcita.github.io/developers-hub/entities/payments/invoice.json#/properties/enable_late_fee"
+                    "type": "boolean",
+                    "description": "Enable late fee on invoice for this specific invoice. (late fee will be added to the invoice automatically when the invoice will become overdue. Not applicable in strict mode where an invoice is a legal binding document and cannot be edited)"
                   },
                   "note": {
-                    "$ref": "https://vcita.github.io/developers-hub/entities/payments/invoice.json#/properties/note"
+                    "type": "string",
+                    "description": "Invoice notes/comments appears in the invoice document"
                   },
                   "terms_and_conditions": {
-                    "$ref": "https://vcita.github.io/developers-hub/entities/payments/invoice.json#/properties/terms_and_conditions"
+                    "type": "string",
+                    "description": "Payment terms and conditions. appears in the invoice document"
                   },
                   "additional_recipients": {
-                    "$ref": "https://vcita.github.io/developers-hub/entities/payments/invoice.json#/properties/additional_recipients"
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "format": "email"
+                    },
+                    "description": "CC email recipients (array of email strings). comma separated"
                   },
                   "line_item_groups": {
-                    "$ref": "https://vcita.github.io/developers-hub/entities/payments/invoice.json#/properties/line_item_groups"
+                    "type": "array",
+                    "description": "Array of invoice line item groups. Line item groups allows to group invoice line items per need, while each line item group will have at least a single line item set in it. Optional, used when `add_item_header` feature flag is enabled",
+                    "minItems": 1,
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "description": "Section name"
+                        },
+                        "line_item_group_index": {
+                          "type": "number",
+                          "description": "Section order/index"
+                        },
+                        "line_items": {
+                          "type": "array",
+                          "description": "Array of line items within this section",
+                          "minItems": 1,
+                          "items": {
+                            "$ref": "#/definitions/lineItem"
+                          }
+                        }
+                      },
+                      "required": [
+                        "name",
+                        "line_item_group_index",
+                        "line_items"
+                      ]
+                    }
                   },
                   "display_line_item_groups_total": {
-                    "$ref": "https://vcita.github.io/developers-hub/entities/payments/invoice.json#/properties/display_line_item_groups_total"
+                    "type": "boolean",
+                    "description": "Display the total price of the items that are nested under a line items group"
                   },
                   "display_line_item_total": {
-                    "$ref": "https://vcita.github.io/developers-hub/entities/payments/invoice.json#/properties/display_line_item_total"
+                    "type": "boolean",
+                    "description": "Display nested under a group line item price"
                   },
                   "estimate_uid": {
-                    "$ref": "https://vcita.github.io/developers-hub/entities/payments/invoice.json#/properties/estimate_uid"
+                    "type": "string",
+                    "description": "The unique identifier of the estimate from which invoice was created"
                   },
                   "line_items": {
-                    "$ref": "https://vcita.github.io/developers-hub/entities/payments/invoice.json#/properties/line_items"
+                    "type": "array",
+                    "description": "Array of invoice line items. Line items that are not part of the line item groups. Required if line_item_groups not provided, at least one line item required",
+                    "minItems": 1,
+                    "items": {
+                      "$ref": "#/definitions/lineItem"
+                    }
                   },
                   "notify_recipient": {
                     "type": "boolean",
@@ -15366,12 +18214,386 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/payments/invoice.json"
+                          "type": "object",
+                          "definitions": {
+                            "lineItem": {
+                              "type": "object",
+                              "description": "A line item refers to each billable item in the invoice. Invoice total amount will be a sum of all line items. A line item can be added nested under a line items group, or independently in the invoice (not nested)",
+                              "properties": {
+                                "name": {
+                                  "type": "string",
+                                  "description": "Line item name/title"
+                                },
+                                "quantity": {
+                                  "type": "number",
+                                  "description": "Line item quantity"
+                                },
+                                "unit_amount": {
+                                  "type": "number",
+                                  "description": "Unit price/amount"
+                                },
+                                "description": {
+                                  "type": "string",
+                                  "description": "Line item description"
+                                },
+                                "entity_uid": {
+                                  "type": "string",
+                                  "description": "UID of related entity (service/product/package)"
+                                },
+                                "entity_type": {
+                                  "type": "string",
+                                  "enum": [
+                                    "Meeting",
+                                    "EventAttendance",
+                                    "ProductOrder",
+                                    "ClientBookingPackage",
+                                    "Service",
+                                    "Product",
+                                    "BookingPackage"
+                                  ],
+                                  "description": "Type of related entity. If custom item → NULL"
+                                },
+                                "uid": {
+                                  "type": "string",
+                                  "description": "Line item UID (for updates)"
+                                },
+                                "tax_uids": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "description": "Array of tax UIDs to apply. Pulled from the taxes set in the business Taxes settings. 0-3 taxes per line item are allowed"
+                                },
+                                "discount": {
+                                  "type": "object",
+                                  "description": "Line item discount. Can be a percentage or a fixed amount to be reduced from the line item amount",
+                                  "properties": {
+                                    "discount_type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "percent",
+                                        "amount"
+                                      ],
+                                      "description": "Type of discount: percentage or fixed amount"
+                                    },
+                                    "amount": {
+                                      "type": "number",
+                                      "description": "Discount value. If discount_type is 'percent', this is the percentage (e.g., 10 for 10%). If discount_type is 'amount', this is the fixed discount amount"
+                                    }
+                                  },
+                                  "required": [
+                                    "discount_type",
+                                    "amount"
+                                  ]
+                                },
+                                "line_item_index": {
+                                  "type": "number",
+                                  "description": "Line item position/index"
+                                }
+                              },
+                              "required": [
+                                "name",
+                                "quantity",
+                                "unit_amount"
+                              ]
+                            }
+                          },
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "description": "The invoice's unique identifier"
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "description": "Created date and time"
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "description": "Updated date and time"
+                            },
+                            "matter_uid": {
+                              "type": "string",
+                              "description": "Matter UID. The identify number of the client that the invoice for issued for"
+                            },
+                            "issue_date": {
+                              "type": "string",
+                              "format": "date",
+                              "description": "The date the invoice was issued. Issue_date >=Today()"
+                            },
+                            "due_date": {
+                              "type": "string",
+                              "format": "date",
+                              "description": "Invoice due date. Expected date for payment. Must be >= issue_date"
+                            },
+                            "currency": {
+                              "type": "string",
+                              "description": "Three-letter ISO currency code (e.g., \"USD\", \"ILS\")"
+                            },
+                            "status": {
+                              "type": "string",
+                              "enum": [
+                                "DRAFT",
+                                "ISSUED",
+                                "CANCELLED"
+                              ],
+                              "description": "Invoice statuses (Draft, Issued, Cancelled). Draft: refers to the initial editable stage of the invoice. Issued: Invoice was issued. (in Strict mode: Invoice is immune and cannot be edited. Cancelled: Cancelled invoices: In strict mode: Can be performed only from \"Draft\" state. In Flex mode: Issued to Cancelled is allowed. Required field: \"DRAFT\" or \"ISSUED\" or \"CANCELLED\" (default: \"ISSUED\")"
+                            },
+                            "unique_number": {
+                              "type": "string",
+                              "description": "Invoice unique, sequential number.\nTwo types of numbering:\n1. Unique sequence of numbers (1,2,3….)\n2. A yearly repeated numbering including a year's prefix (2025-0001, 2025-0002…). Within each year start - rounding the count (2026-0001, 2026-0002,…).\nOptional, auto-generated if not provided"
+                            },
+                            "invoice_title": {
+                              "type": "string",
+                              "description": "Invoice title. A document title to appear on top of the PDF. Optional. Default: \"INVOICE\""
+                            },
+                            "billing_address": {
+                              "type": "string",
+                              "description": "Full business billing address, including street, city, state, country, and zipcode"
+                            },
+                            "purchase_order": {
+                              "type": "string",
+                              "description": "Purchase order number"
+                            },
+                            "allow_online_payment": {
+                              "type": "boolean",
+                              "description": "Enable online payment for this specific invoice (allow the client to pay directly from the client portal)"
+                            },
+                            "allow_partial_payment": {
+                              "type": "boolean",
+                              "description": "Enable partial payment for this specific invoice (allow the client to pay a portion of the invoice amount rather than its full due price)"
+                            },
+                            "enable_late_fee": {
+                              "type": "boolean",
+                              "description": "Enable late fee on invoice for this specific invoice. (late fee will be added to the invoice automatically when the invoice will become overdue. Not applicable in strict mode where an invoice is a legal binding document and cannot be edited)"
+                            },
+                            "note": {
+                              "type": "string",
+                              "description": "Invoice notes/comments appears in the invoice document"
+                            },
+                            "terms_and_conditions": {
+                              "type": "string",
+                              "description": "Payment terms and conditions. appears in the invoice document"
+                            },
+                            "additional_recipients": {
+                              "type": "array",
+                              "items": {
+                                "type": "string",
+                                "format": "email"
+                              },
+                              "description": "CC email recipients (array of email strings). comma separated"
+                            },
+                            "line_item_groups": {
+                              "type": "array",
+                              "description": "Array of invoice line item groups. Line item groups allows to group invoice line items per need, while each line item group will have at least a single line item set in it. Optional, used when `add_item_header` feature flag is enabled",
+                              "minItems": 1,
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "name": {
+                                    "type": "string",
+                                    "description": "Section name"
+                                  },
+                                  "line_item_group_index": {
+                                    "type": "number",
+                                    "description": "Section order/index"
+                                  },
+                                  "line_items": {
+                                    "type": "array",
+                                    "description": "Array of line items within this section",
+                                    "minItems": 1,
+                                    "items": {
+                                      "$ref": "#/definitions/lineItem"
+                                    }
+                                  }
+                                },
+                                "required": [
+                                  "name",
+                                  "line_item_group_index",
+                                  "line_items"
+                                ]
+                              }
+                            },
+                            "display_line_item_groups_total": {
+                              "type": "boolean",
+                              "description": "Display the total price of the items that are nested under a line items group"
+                            },
+                            "display_line_item_total": {
+                              "type": "boolean",
+                              "description": "Display nested under a group line item price"
+                            },
+                            "estimate_uid": {
+                              "type": "string",
+                              "description": "The unique identifier of the estimate from which invoice was created"
+                            },
+                            "line_items": {
+                              "type": "array",
+                              "description": "Array of invoice line items. Line items that are not part of the line item groups. Required if line_item_groups not provided, at least one line item required",
+                              "minItems": 1,
+                              "items": {
+                                "$ref": "#/definitions/lineItem"
+                              }
+                            },
+                            "payment_status_uid": {
+                              "type": "string",
+                              "description": "The identified number of the payment request that is associated with the invoice"
+                            },
+                            "net_total": {
+                              "type": "number",
+                              "description": "The invoice total amount exclude taxes"
+                            },
+                            "grand_total": {
+                              "type": "number",
+                              "description": "The invoice total amount including taxes"
+                            },
+                            "taxes": {
+                              "type": "number",
+                              "description": "The total taxes amount as calculated per the invoice line items amount"
+                            }
+                          },
+                          "anyOf": [
+                            {
+                              "required": [
+                                "matter_uid",
+                                "issue_date",
+                                "due_date",
+                                "currency",
+                                "line_items"
+                              ]
+                            },
+                            {
+                              "required": [
+                                "matter_uid",
+                                "issue_date",
+                                "due_date",
+                                "currency",
+                                "line_item_groups"
+                              ]
+                            }
+                          ],
+                          "readOnly": [
+                            "uid",
+                            "created_at",
+                            "updated_at",
+                            "payment_status_uid",
+                            "net_total",
+                            "grand_total",
+                            "taxes"
+                          ],
+                          "example": {
+                            "uid": "inv-aaabbbccc112233",
+                            "created_at": "2024-01-15T10:00:00.000Z",
+                            "updated_at": "2024-01-15T10:00:00.000Z",
+                            "matter_uid": "matter_123",
+                            "issue_date": "2024-01-15",
+                            "due_date": "2024-02-15",
+                            "currency": "USD",
+                            "status": "ISSUED",
+                            "unique_number": "2024-0001",
+                            "invoice_title": "INVOICE",
+                            "billing_address": "123 Main St, City, State 12345",
+                            "purchase_order": "PO-12345",
+                            "allow_online_payment": true,
+                            "allow_partial_payment": false,
+                            "enable_late_fee": false,
+                            "note": "Thank you for your business",
+                            "terms_and_conditions": "Payment due within 30 days",
+                            "additional_recipients": [
+                              "accounting@example.com"
+                            ],
+                            "display_line_item_groups_total": true,
+                            "display_line_item_total": true,
+                            "estimate_uid": null,
+                            "line_item_groups": [
+                              {
+                                "name": "Services",
+                                "line_item_group_index": 0,
+                                "line_items": [
+                                  {
+                                    "name": "Consulting Services",
+                                    "quantity": 2,
+                                    "unit_amount": 150,
+                                    "description": "Hourly consulting",
+                                    "entity_uid": "service_123",
+                                    "entity_type": "Service",
+                                    "tax_uids": [
+                                      "tax_uid_1"
+                                    ],
+                                    "discount": {
+                                      "discount_type": "percent",
+                                      "amount": 10
+                                    },
+                                    "line_item_index": 0
+                                  }
+                                ]
+                              }
+                            ],
+                            "line_items": [
+                              {
+                                "name": "Design materials",
+                                "quantity": 1,
+                                "unit_amount": 114,
+                                "description": "Design materials",
+                                "entity_uid": "product_123",
+                                "entity_type": "Product",
+                                "tax_uids": [
+                                  "tax_uid_1"
+                                ],
+                                "discount": null,
+                                "line_item_index": 1
+                              }
+                            ]
+                          },
+                          "description": "Invoice entity representing a bill or invoice document with line items, payment terms, and client information."
                         }
                       }
                     }
@@ -15459,7 +18681,50 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
@@ -15494,7 +18759,348 @@
             "description": "List of Payment Gateways",
             "type": "array",
             "items": {
-              "$ref": "https://vcita.github.io/developers-hub/entities/payment_processing/payment_gateway.json"
+              "type": "object",
+              "properties": {
+                "uid": {
+                  "type": "string",
+                  "description": "The unique identifier (UID) of the payment gateway."
+                },
+                "gateway_name": {
+                  "type": "string",
+                  "description": "The unique name of the payment gateway initialized when the owning app was created, provided as the name parameter to the App Creation API."
+                },
+                "app_code_name": {
+                  "type": "string",
+                  "description": "The unique code name of the pre-created gateway's app, created via the API- Creates an app, https://api.vcita.biz/platform/v1/apps"
+                },
+                "gateway_logo_url": {
+                  "type": "string",
+                  "description": "The URL to the logo of the gateway."
+                },
+                "default_locale": {
+                  "type": "string",
+                  "enum": [
+                    "en",
+                    "fr",
+                    "de",
+                    "it",
+                    "pl",
+                    "pt",
+                    "es",
+                    "nl",
+                    "he",
+                    "en_gb",
+                    "lv"
+                  ],
+                  "description": "Specifies the fallback locale for the gateway's textual content. If a translation or string is missing, this locale will be used by default."
+                },
+                "gateway_type": {
+                  "type": "string",
+                  "enum": [
+                    "digital_wallet",
+                    "payments_provider"
+                  ],
+                  "description": "Integration type: a payment service provider (e.g., Stripe, Square) that enables merchants to process multiple payment methods, or a digital wallet (e.g., PayPal, Google Pay) that allows consumers to store and use payment credentials"
+                },
+                "status": {
+                  "type": "string",
+                  "enum": [
+                    "active",
+                    "disabled",
+                    "deprecated"
+                  ],
+                  "description": "Indicates the current status of the payment gateway: 'active' (available for use), 'disabled' (not available for use), or 'deprecated' (still available but not recommended for new integrations)"
+                },
+                "created_at": {
+                  "type": "string",
+                  "format": "date-time",
+                  "description": "The date and time the payment gateway was created."
+                },
+                "updated_at": {
+                  "type": "string",
+                  "format": "date-time",
+                  "description": "The date and time the payment gateway was last updated."
+                },
+                "main_gateway_benefits": {
+                  "type": "array",
+                  "description": "A clear 3-4 bullet list highlighting the unique features and value of the gateway, aimed at encouraging merchants to connect with it. This information is stored per locale. May be an empty array if no benefits are configured.",
+                  "uniqueItems": true,
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "locale": {
+                        "type": "string",
+                        "enum": [
+                          "en",
+                          "fr",
+                          "de",
+                          "it",
+                          "pl",
+                          "pt",
+                          "es",
+                          "nl",
+                          "he",
+                          "en_gb",
+                          "lv"
+                        ]
+                      },
+                      "benefits": {
+                        "type": "array",
+                        "description": "A list of benefits in the specified locale.",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "required": [
+                      "locale",
+                      "benefits"
+                    ]
+                  }
+                },
+                "brief_benefit_highlights": {
+                  "type": "array",
+                  "description": "A brief, 2-4 word version of the gateway benefits, tailored for compact displays or mobile interfaces. This information is stored per locale. May be an empty array if no highlights are configured.",
+                  "uniqueItems": true,
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "locale": {
+                        "type": "string",
+                        "enum": [
+                          "en",
+                          "fr",
+                          "de",
+                          "it",
+                          "pl",
+                          "pt",
+                          "es",
+                          "nl",
+                          "he",
+                          "en_gb",
+                          "lv"
+                        ]
+                      },
+                      "highlights": {
+                        "type": "array",
+                        "description": "A list of short benefit highlights in the specified locale.",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "required": [
+                      "locale",
+                      "highlights"
+                    ]
+                  }
+                },
+                "supported_countries": {
+                  "type": "array",
+                  "description": "A list of countries supported by the payment gateway, represented using ISO 3166-1 alpha-2 country codes.",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "supported_currencies": {
+                  "type": "array",
+                  "description": "A list of currencies supported by the payment gateway, represented using ISO 4217 format.",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "minimum_charge_amount": {
+                  "type": [
+                    "string",
+                    "number",
+                    "null"
+                  ],
+                  "description": "The minimum value that can be charged using the payment gateway. May be returned as a string or number depending on the gateway configuration."
+                },
+                "payment_methods": {
+                  "type": "object",
+                  "description": "The payment methods supported by the gateway.",
+                  "properties": {
+                    "credit_card": {
+                      "type": "boolean",
+                      "description": "Indicates if the gateway supports credit card payments."
+                    },
+                    "ach": {
+                      "type": "boolean",
+                      "description": "Indicates if the gateway supports ACH payments."
+                    },
+                    "ideal": {
+                      "type": "boolean",
+                      "description": "Indicates if the gateway supports iDeal payments."
+                    },
+                    "bancontact": {
+                      "type": "boolean",
+                      "description": "Indicates if the gateway supports Bancontact payments."
+                    },
+                    "twint": {
+                      "type": "boolean",
+                      "description": "Indicates if the gateway supports Twint payments."
+                    },
+                    "express_wallets": {
+                      "type": "boolean",
+                      "description": "Indicates if the gateway supports Express Wallets, such as Google Pay and Apple Pay."
+                    }
+                  }
+                },
+                "processing_features": {
+                  "type": "object",
+                  "description": "The features the payment gateway supports and their current state (enabled/disabled).",
+                  "properties": {
+                    "multi_currency": {
+                      "type": "boolean",
+                      "description": "Indicates if the gateway supports multi-currency transactions."
+                    },
+                    "back_office_charge": {
+                      "type": "boolean",
+                      "description": "Indicates if the gateway allows the SMB to process charges directly from the back office."
+                    },
+                    "checkout": {
+                      "type": "boolean",
+                      "description": "Indicates whether the payment gateway supports a checkout option initiated from the client portal. This value must always be set to true, as client portal checkout is a core feature."
+                    },
+                    "refund": {
+                      "type": "boolean",
+                      "description": "Indicates if the gateway supports full online refunds."
+                    },
+                    "partial_refund": {
+                      "type": "boolean",
+                      "description": "Indicates if the gateway supports partial online refunds. Requires full refunds to be enabled."
+                    },
+                    "client_save_card_on_checkout": {
+                      "type": "boolean",
+                      "description": "Indicates if clients can save cards on file during a payment flow."
+                    },
+                    "client_save_card_standalone": {
+                      "type": "boolean",
+                      "description": "Indicates if clients can save cards on file through a standalone flow."
+                    },
+                    "save_card_by_business": {
+                      "type": "boolean",
+                      "description": "Indicates if the gateway supports saving cards on file from the business side."
+                    },
+                    "offset_fees": {
+                      "type": "boolean",
+                      "description": "Indicates whether the gateway supports offsetting processing fees, as surcharges, convenience fees, or both, while each SMB can enable only one fee type or none."
+                    }
+                  },
+                  "required": [
+                    "multi_currency",
+                    "back_office_charge",
+                    "checkout",
+                    "refund",
+                    "partial_refund",
+                    "client_save_card_on_checkout",
+                    "client_save_card_standalone",
+                    "save_card_by_business",
+                    "offset_fees"
+                  ]
+                }
+              },
+              "required": [
+                "app_code_name",
+                "gateway_logo_url",
+                "default_locale",
+                "gateway_type",
+                "status",
+                "main_gateway_benefits",
+                "brief_benefit_highlights",
+                "supported_countries",
+                "supported_currencies",
+                "payment_methods",
+                "processing_features"
+              ],
+              "example": {
+                "uid": "pgw_abc123def456",
+                "gateway_name": "stripe_payments_v2",
+                "app_code_name": "stripe_payments_v2",
+                "gateway_logo_url": "https://cdn.stripe.com/logo.png",
+                "default_locale": "en",
+                "gateway_type": "payments_provider",
+                "status": "active",
+                "created_at": "2024-01-15T10:30:00.000Z",
+                "updated_at": "2024-01-20T14:45:00.000Z",
+                "main_gateway_benefits": [
+                  {
+                    "locale": "en",
+                    "benefits": [
+                      "Accept payments from 195+ countries",
+                      "Industry-leading fraud protection",
+                      "Fast payouts in 2-7 business days",
+                      "24/7 customer support"
+                    ]
+                  },
+                  {
+                    "locale": "es",
+                    "benefits": [
+                      "Acepta pagos de más de 195 países",
+                      "Protección líder contra fraudes",
+                      "Pagos rápidos en 2-7 días hábiles",
+                      "Soporte al cliente 24/7"
+                    ]
+                  }
+                ],
+                "brief_benefit_highlights": [
+                  {
+                    "locale": "en",
+                    "highlights": [
+                      "Global reach",
+                      "Fraud protection",
+                      "Fast payouts"
+                    ]
+                  },
+                  {
+                    "locale": "es",
+                    "highlights": [
+                      "Alcance global",
+                      "Protección fraude",
+                      "Pagos rápidos"
+                    ]
+                  }
+                ],
+                "supported_countries": [
+                  "US",
+                  "CA",
+                  "GB",
+                  "AU",
+                  "DE",
+                  "FR",
+                  "ES",
+                  "IT"
+                ],
+                "supported_currencies": [
+                  "USD",
+                  "EUR",
+                  "GBP",
+                  "CAD",
+                  "AUD"
+                ],
+                "minimum_charge_amount": 0.5,
+                "payment_methods": {
+                  "credit_card": true,
+                  "ach": true,
+                  "ideal": true,
+                  "bancontact": false,
+                  "twint": false,
+                  "express_wallets": false
+                },
+                "processing_features": {
+                  "multi_currency": true,
+                  "back_office_charge": true,
+                  "checkout": true,
+                  "refund": true,
+                  "partial_refund": true,
+                  "client_save_card_on_checkout": true,
+                  "client_save_card_standalone": true,
+                  "save_card_by_business": true,
+                  "offset_fees": true
+                }
+              },
+              "description": "Metadata for a payment gateway integration, including locales, supported regions, methods, and processing features."
             }
           }
         }
@@ -15835,7 +19441,123 @@
             "description": "List of Coupons",
             "type": "array",
             "items": {
-              "$ref": "https://vcita.github.io/developers-hub/entities/sales/Coupon.json"
+              "type": "object",
+              "properties": {
+                "uid": {
+                  "type": "string"
+                },
+                "business_uid": {
+                  "type": "string",
+                  "description": "The business the coupon belongs to"
+                },
+                "coupon_name": {
+                  "type": "string",
+                  "description": "A human-readable name for the coupon"
+                },
+                "discount_type": {
+                  "type": "string",
+                  "enum": [
+                    "fixed",
+                    "percent"
+                  ],
+                  "description": "Type of discount offered, fixed: for fixed amount, percent: for percentage disscount"
+                },
+                "discount_value": {
+                  "type": "number",
+                  "description": "The discount amount (decimal) given by applying the coupon. If the coupon type is \"fixed\" then the amount is the discount given, keeping the same currency as the item ($5.5). If the type is \"percent\" then the amount is the discount percent from the original price (5.3%)"
+                },
+                "coupon_code": {
+                  "type": "string",
+                  "description": "A unique identifier or code for the coupon"
+                },
+                "status": {
+                  "type": "string",
+                  "enum": [
+                    "active",
+                    "scheduled",
+                    "expired"
+                  ],
+                  "description": "The status of the coupon"
+                },
+                "valid_for_services": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "A list of services (UIDs) where the coupon can be applied"
+                },
+                "valid_for_staff": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "A list of staff (UIDs) where the coupon can be applied"
+                },
+                "start_date": {
+                  "type": "string",
+                  "description": "The start date when the coupon becomes active, in ISO 8601 format",
+                  "format": "date-time"
+                },
+                "expiration_date": {
+                  "type": "string",
+                  "description": "The expiry date when the coupon is no longer valid, in ISO 8601 format",
+                  "format": "date-time"
+                },
+                "max_redemptions": {
+                  "type": "number",
+                  "description": "The maximum number of times the coupon can be used"
+                },
+                "max_redemptions_per_client": {
+                  "type": "number",
+                  "description": "The maximum number of times an individual client can use the coupon"
+                },
+                "total_redemptions": {
+                  "type": "number",
+                  "description": "The total number of times the coupon has been redeemed"
+                },
+                "created_at": {
+                  "type": "string",
+                  "description": "The creation date and time of the coupon, in ISO 8601 format",
+                  "format": "date-time"
+                },
+                "updated_at": {
+                  "type": "string",
+                  "description": "Updated date and time of the coupon, in ISO 8601 format",
+                  "format": "date-time"
+                }
+              },
+              "required": [
+                "uid",
+                "coupon_name",
+                "discount_type",
+                "discount_value",
+                "coupon_code",
+                "start_date",
+                "expiration_date"
+              ],
+              "example": {
+                "uid": "56a78b56c",
+                "business_uid": "hfjds47r534",
+                "coupon_name": "Summer 2024",
+                "discount_type": "fixed",
+                "discount_value": "20",
+                "coupon_code": "SAVE20",
+                "status": "active",
+                "valid_for_services": [
+                  "5ya4gbwm2c3qoic8"
+                ],
+                "valid_for_staff": [
+                  "0c4ac9717ab26f56"
+                ],
+                "start_date": "2024-03-20T12:34:56Z",
+                "expiration_date": "2024-01-01T09:00:00Z",
+                "max_redemptions": 100,
+                "max_redemptions_per_client": 1,
+                "total_redemptions": 23,
+                "created_at": "2021-07-20T14:00:00.000Z",
+                "updated_at": "2021-07-20T14:00:00.000Z"
+              },
+              "description": "Represents a discount coupon with validity window, scope, and redemption limits."
             }
           }
         }

--- a/mcp_swagger/scheduling.json
+++ b/mcp_swagger/scheduling.json
@@ -3839,7 +3839,50 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
@@ -3931,7 +3974,50 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
@@ -4003,12 +4089,108 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/scheduling/resourceType.json"
+                          "type": "object",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "description": "The entity's unique identifier",
+                              "readOnly": true
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "description": "Creation date and time",
+                              "readOnly": true
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "description": "Last update date and time",
+                              "readOnly": true
+                            },
+                            "name": {
+                              "type": "string",
+                              "description": "The name of the resource type",
+                              "example": "Treatment Room"
+                            },
+                            "services": {
+                              "type": "array",
+                              "description": "Array of service UIDs that require this resource type",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "deleted_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "description": "Soft delete timestamp. Null for active resource types",
+                              "nullable": true,
+                              "readOnly": true
+                            }
+                          },
+                          "required": [
+                            "name"
+                          ],
+                          "example": {
+                            "uid": "94ca2054-3bb0-4788-8e9e-ee2442975cdd",
+                            "created_at": "2023-06-15T10:30:00Z",
+                            "updated_at": "2023-06-15T14:45:10Z",
+                            "name": "Treatment Room",
+                            "services": [
+                              "treatment-service-uid",
+                              "consultation-service-uid"
+                            ],
+                            "deleted_at": null
+                          },
+                          "description": "Defines a type/category of resource required by services (e.g., room type)."
                         }
                       }
                     }
@@ -4070,12 +4252,108 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/scheduling/resourceType.json"
+                          "type": "object",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "description": "The entity's unique identifier",
+                              "readOnly": true
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "description": "Creation date and time",
+                              "readOnly": true
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "description": "Last update date and time",
+                              "readOnly": true
+                            },
+                            "name": {
+                              "type": "string",
+                              "description": "The name of the resource type",
+                              "example": "Treatment Room"
+                            },
+                            "services": {
+                              "type": "array",
+                              "description": "Array of service UIDs that require this resource type",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "deleted_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "description": "Soft delete timestamp. Null for active resource types",
+                              "nullable": true,
+                              "readOnly": true
+                            }
+                          },
+                          "required": [
+                            "name"
+                          ],
+                          "example": {
+                            "uid": "94ca2054-3bb0-4788-8e9e-ee2442975cdd",
+                            "created_at": "2023-06-15T10:30:00Z",
+                            "updated_at": "2023-06-15T14:45:10Z",
+                            "name": "Treatment Room",
+                            "services": [
+                              "treatment-service-uid",
+                              "consultation-service-uid"
+                            ],
+                            "deleted_at": null
+                          },
+                          "description": "Defines a type/category of resource required by services (e.g., room type)."
                         }
                       }
                     }
@@ -4155,12 +4433,108 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/scheduling/resourceType.json"
+                          "type": "object",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "description": "The entity's unique identifier",
+                              "readOnly": true
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "description": "Creation date and time",
+                              "readOnly": true
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "description": "Last update date and time",
+                              "readOnly": true
+                            },
+                            "name": {
+                              "type": "string",
+                              "description": "The name of the resource type",
+                              "example": "Treatment Room"
+                            },
+                            "services": {
+                              "type": "array",
+                              "description": "Array of service UIDs that require this resource type",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "deleted_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "description": "Soft delete timestamp. Null for active resource types",
+                              "nullable": true,
+                              "readOnly": true
+                            }
+                          },
+                          "required": [
+                            "name"
+                          ],
+                          "example": {
+                            "uid": "94ca2054-3bb0-4788-8e9e-ee2442975cdd",
+                            "created_at": "2023-06-15T10:30:00Z",
+                            "updated_at": "2023-06-15T14:45:10Z",
+                            "name": "Treatment Room",
+                            "services": [
+                              "treatment-service-uid",
+                              "consultation-service-uid"
+                            ],
+                            "deleted_at": null
+                          },
+                          "description": "Defines a type/category of resource required by services (e.g., room type)."
                         }
                       }
                     }
@@ -4223,7 +4597,50 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     }
                   ]
                 }
@@ -4351,7 +4768,50 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
@@ -4420,12 +4880,103 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/scheduling/resource.json"
+                          "type": "object",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "description": "The entity's unique identifier",
+                              "readOnly": true
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "description": "Creation date and time",
+                              "readOnly": true
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "description": "Last update date and time",
+                              "readOnly": true
+                            },
+                            "resource_type_uid": {
+                              "type": "string",
+                              "description": "The resource type this instance belongs to. Links to the ResourceType entity"
+                            },
+                            "name": {
+                              "type": "string",
+                              "description": "The name of the resource",
+                              "example": "Treatment Room 1"
+                            },
+                            "deleted_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "description": "Soft delete timestamp. Null for active resources",
+                              "nullable": true,
+                              "readOnly": true
+                            }
+                          },
+                          "required": [
+                            "name",
+                            "resource_type_uid"
+                          ],
+                          "example": {
+                            "uid": "a4ca2054-3bb0-4788-8e9e-ee2442975e22",
+                            "created_at": "2023-06-15T11:30:00Z",
+                            "updated_at": "2023-06-15T15:45:10Z",
+                            "resource_type_uid": "94ca2054-3bb0-4788-8e9e-ee2442975cdd",
+                            "name": "Treatment Room 1",
+                            "deleted_at": null
+                          },
+                          "description": "A schedulable resource instance (e.g., room, equipment) belonging to a resource type."
                         }
                       }
                     }
@@ -4496,12 +5047,103 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/scheduling/resource.json"
+                          "type": "object",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "description": "The entity's unique identifier",
+                              "readOnly": true
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "description": "Creation date and time",
+                              "readOnly": true
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "description": "Last update date and time",
+                              "readOnly": true
+                            },
+                            "resource_type_uid": {
+                              "type": "string",
+                              "description": "The resource type this instance belongs to. Links to the ResourceType entity"
+                            },
+                            "name": {
+                              "type": "string",
+                              "description": "The name of the resource",
+                              "example": "Treatment Room 1"
+                            },
+                            "deleted_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "description": "Soft delete timestamp. Null for active resources",
+                              "nullable": true,
+                              "readOnly": true
+                            }
+                          },
+                          "required": [
+                            "name",
+                            "resource_type_uid"
+                          ],
+                          "example": {
+                            "uid": "a4ca2054-3bb0-4788-8e9e-ee2442975e22",
+                            "created_at": "2023-06-15T11:30:00Z",
+                            "updated_at": "2023-06-15T15:45:10Z",
+                            "resource_type_uid": "94ca2054-3bb0-4788-8e9e-ee2442975cdd",
+                            "name": "Treatment Room 1",
+                            "deleted_at": null
+                          },
+                          "description": "A schedulable resource instance (e.g., room, equipment) belonging to a resource type."
                         }
                       }
                     }
@@ -4578,12 +5220,103 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
                         "data": {
-                          "$ref": "https://vcita.github.io/developers-hub/entities/scheduling/resource.json"
+                          "type": "object",
+                          "properties": {
+                            "uid": {
+                              "type": "string",
+                              "description": "The entity's unique identifier",
+                              "readOnly": true
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "description": "Creation date and time",
+                              "readOnly": true
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "description": "Last update date and time",
+                              "readOnly": true
+                            },
+                            "resource_type_uid": {
+                              "type": "string",
+                              "description": "The resource type this instance belongs to. Links to the ResourceType entity"
+                            },
+                            "name": {
+                              "type": "string",
+                              "description": "The name of the resource",
+                              "example": "Treatment Room 1"
+                            },
+                            "deleted_at": {
+                              "type": "string",
+                              "format": "date-time",
+                              "description": "Soft delete timestamp. Null for active resources",
+                              "nullable": true,
+                              "readOnly": true
+                            }
+                          },
+                          "required": [
+                            "name",
+                            "resource_type_uid"
+                          ],
+                          "example": {
+                            "uid": "a4ca2054-3bb0-4788-8e9e-ee2442975e22",
+                            "created_at": "2023-06-15T11:30:00Z",
+                            "updated_at": "2023-06-15T15:45:10Z",
+                            "resource_type_uid": "94ca2054-3bb0-4788-8e9e-ee2442975cdd",
+                            "name": "Treatment Room 1",
+                            "deleted_at": null
+                          },
+                          "description": "A schedulable resource instance (e.g., room, equipment) belonging to a resource type."
                         }
                       }
                     }
@@ -4646,7 +5379,50 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     }
                   ]
                 }
@@ -4754,7 +5530,50 @@
                 "schema": {
                   "allOf": [
                     {
-                      "$ref": "https://vcita.github.io/developers-hub/entities/response.json"
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Indicates whether the API request was successful (true) or failed (false)."
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "The response payload. Present on successful responses (success: true)."
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message for simple error responses. Used in some legacy endpoints."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Array of error objects for detailed error responses. Present on error responses (success: false).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Machine-readable error code (e.g., 'already_exists', 'invalid', 'not_found')."
+                              },
+                              "message": {
+                                "type": "string",
+                                "description": "Human-readable error message."
+                              },
+                              "field": {
+                                "type": "string",
+                                "description": "The field that caused the error (for validation errors)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "message"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ],
+                      "description": "Generic wrapper object for API responses. Success responses contain 'data', while error responses contain 'errors' array or 'error' string."
                     },
                     {
                       "properties": {
@@ -4812,7 +5631,91 @@
             "description": "List of AvailabilitySlots",
             "type": "array",
             "items": {
-              "$ref": "https://vcita.github.io/developers-hub/entities/scheduling/availabilitySlot.json"
+              "type": "object",
+              "properties": {
+                "start": {
+                  "type": "string",
+                  "format": "date-time",
+                  "description": "Start date and time of the availability slot",
+                  "example": "2025-05-19T10:00:00.000Z"
+                },
+                "end": {
+                  "type": "string",
+                  "format": "date-time",
+                  "description": "End date and time of the availability slot",
+                  "example": "2025-05-19T11:00:00.000Z"
+                },
+                "available_entities": {
+                  "type": "array",
+                  "description": "List of available entities for this time slot",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "entity_uid": {
+                        "type": "string",
+                        "description": "Unique identifier of the entity",
+                        "example": "staff-789"
+                      },
+                      "entity_type": {
+                        "type": "string",
+                        "enum": [
+                          "staff",
+                          "resource"
+                        ],
+                        "description": "Type of the entity"
+                      },
+                      "group_entity_type": {
+                        "type": "string",
+                        "enum": [
+                          "staff",
+                          "resource_type"
+                        ],
+                        "description": "Type of the group this entity belongs to",
+                        "nullable": true
+                      },
+                      "group_entity_uid": {
+                        "type": "string",
+                        "description": "Unique identifier of the group this entity belongs to (optional)",
+                        "nullable": true,
+                        "example": "rt-456"
+                      }
+                    },
+                    "required": [
+                      "entity_uid",
+                      "entity_type"
+                    ]
+                  }
+                }
+              },
+              "required": [
+                "start",
+                "end",
+                "available_entities"
+              ],
+              "example": {
+                "start": "2025-05-19T10:00:00.000Z",
+                "end": "2025-05-19T11:00:00.000Z",
+                "available_entities": [
+                  {
+                    "entity_uid": "staff-789",
+                    "entity_type": "staff",
+                    "group_entity_type": "staff"
+                  },
+                  {
+                    "entity_uid": "res-123",
+                    "entity_type": "resource",
+                    "group_entity_type": "resource_type",
+                    "group_entity_uid": "rt-456"
+                  },
+                  {
+                    "entity_uid": "res-124",
+                    "entity_type": "resource",
+                    "group_entity_type": "resource_type",
+                    "group_entity_uid": "rt-456"
+                  }
+                ]
+              },
+              "description": "Represents a time window and the entities available for booking within it."
             }
           }
         }
@@ -4824,7 +5727,55 @@
             "description": "List of Resources",
             "type": "array",
             "items": {
-              "$ref": "https://vcita.github.io/developers-hub/entities/scheduling/resource.json"
+              "type": "object",
+              "properties": {
+                "uid": {
+                  "type": "string",
+                  "description": "The entity's unique identifier",
+                  "readOnly": true
+                },
+                "created_at": {
+                  "type": "string",
+                  "format": "date-time",
+                  "description": "Creation date and time",
+                  "readOnly": true
+                },
+                "updated_at": {
+                  "type": "string",
+                  "format": "date-time",
+                  "description": "Last update date and time",
+                  "readOnly": true
+                },
+                "resource_type_uid": {
+                  "type": "string",
+                  "description": "The resource type this instance belongs to. Links to the ResourceType entity"
+                },
+                "name": {
+                  "type": "string",
+                  "description": "The name of the resource",
+                  "example": "Treatment Room 1"
+                },
+                "deleted_at": {
+                  "type": "string",
+                  "format": "date-time",
+                  "description": "Soft delete timestamp. Null for active resources",
+                  "nullable": true,
+                  "readOnly": true
+                }
+              },
+              "required": [
+                "name",
+                "resource_type_uid"
+              ],
+              "example": {
+                "uid": "a4ca2054-3bb0-4788-8e9e-ee2442975e22",
+                "created_at": "2023-06-15T11:30:00Z",
+                "updated_at": "2023-06-15T15:45:10Z",
+                "resource_type_uid": "94ca2054-3bb0-4788-8e9e-ee2442975cdd",
+                "name": "Treatment Room 1",
+                "deleted_at": null
+              },
+              "description": "A schedulable resource instance (e.g., room, equipment) belonging to a resource type."
             }
           }
         }
@@ -4836,7 +5787,60 @@
             "description": "List of ResourceTypes",
             "type": "array",
             "items": {
-              "$ref": "https://vcita.github.io/developers-hub/entities/scheduling/resourceType.json"
+              "type": "object",
+              "properties": {
+                "uid": {
+                  "type": "string",
+                  "description": "The entity's unique identifier",
+                  "readOnly": true
+                },
+                "created_at": {
+                  "type": "string",
+                  "format": "date-time",
+                  "description": "Creation date and time",
+                  "readOnly": true
+                },
+                "updated_at": {
+                  "type": "string",
+                  "format": "date-time",
+                  "description": "Last update date and time",
+                  "readOnly": true
+                },
+                "name": {
+                  "type": "string",
+                  "description": "The name of the resource type",
+                  "example": "Treatment Room"
+                },
+                "services": {
+                  "type": "array",
+                  "description": "Array of service UIDs that require this resource type",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "deleted_at": {
+                  "type": "string",
+                  "format": "date-time",
+                  "description": "Soft delete timestamp. Null for active resource types",
+                  "nullable": true,
+                  "readOnly": true
+                }
+              },
+              "required": [
+                "name"
+              ],
+              "example": {
+                "uid": "94ca2054-3bb0-4788-8e9e-ee2442975cdd",
+                "created_at": "2023-06-15T10:30:00Z",
+                "updated_at": "2023-06-15T14:45:10Z",
+                "name": "Treatment Room",
+                "services": [
+                  "treatment-service-uid",
+                  "consultation-service-uid"
+                ],
+                "deleted_at": null
+              },
+              "description": "Defines a type/category of resource required by services (e.g., room type)."
             }
           }
         }
@@ -4848,7 +5852,34 @@
             "description": "List of BusinessAvailabilities",
             "type": "array",
             "items": {
-              "$ref": "https://vcita.github.io/developers-hub/entities/scheduling/businessAvailability.json"
+              "type": "object",
+              "required": [
+                "booking_slots",
+                "business_uid"
+              ],
+              "properties": {
+                "booking_slots": {
+                  "type": "array",
+                  "description": "Array of available booking time slots in ISO format",
+                  "items": {
+                    "type": "string",
+                    "format": "date-time"
+                  }
+                },
+                "business_uid": {
+                  "type": "string",
+                  "description": "Unique identifier for a business account"
+                }
+              },
+              "example": {
+                "booking_slots": [
+                  "2023-03-15T09:00:00Z",
+                  "2023-03-15T09:30:00Z",
+                  "2023-03-15T10:00:00Z"
+                ],
+                "business_uid": "c4kektjxu9o2nqw6"
+              },
+              "description": "A BusinessBookingSlots entity represents the available booking time slots for a business. It includes an array of available time slots in ISO 8601 format and a unique identifier for the business account."
             }
           }
         }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "unify": "node scripts/unify-openapi.js",
     "unify:verbose": "node scripts/unify-openapi.js --verbose",
     "unify:dry-run": "node scripts/unify-openapi.js --dry-run --verbose",
+    "unify:flatten": "node scripts/unify-openapi.js --flatten-refs",
     "gen:entities": "node scripts/generate-entity-md.js",
     "gen:entity": "node scripts/generate-entity-md.js --entity",
     "update-readme": "node scripts/update-readme-swaggers.js",

--- a/scripts/README-unify-openapi.md
+++ b/scripts/README-unify-openapi.md
@@ -150,6 +150,11 @@ Options:
   --output-dir <dir>    Output directory (default: ./mcp_swagger)
   --verbose             Enable detailed logging
   --dry-run            Preview processing without writing files
+  --flatten-refs        Inline external $ref URLs that live in this repo
+                        (alias: --inline-refs)
+  --refs-base-url <url> External ref URL prefix to flatten
+                        (default: https://vcita.github.io/developers-hub/)
+  --refs-base-dir <dir> Local dir the ref URL prefix maps to (default: .)
   --help               Show help message
 ```
 
@@ -164,7 +169,30 @@ node scripts/unify-openapi.js --dry-run --verbose
 
 # Custom output directory with verbose logging
 node scripts/unify-openapi.js --output-dir ./dist/apis --verbose
+
+# Flatten external entity references into inline JSON
+node scripts/unify-openapi.js --flatten-refs
 ```
+
+### 🔗 Flattening External References
+
+By default the unified specs keep external `$ref` URLs such as
+`https://vcita.github.io/developers-hub/entities/response.json`. Those entities
+actually live in this repo (the URL prefix maps to the repo root, so the ref
+above resolves to `entities/response.json` on disk), but ReadMe and some other
+tooling cannot dereference the external URLs.
+
+Passing `--flatten-refs` (alias `--inline-refs`) walks each unified spec and
+replaces every external `$ref` with the inline JSON it points to, producing a
+self-contained specification:
+
+- Only refs beginning with `--refs-base-url` are touched; internal refs
+  (`#/components/schemas/...`, `#/definitions/...`) are left untouched.
+- Both whole-file refs and refs with a JSON Pointer fragment
+  (`.../invoice.json#/properties/status`) are supported.
+- Nested external refs inside inlined entities are resolved recursively, with a
+  cycle guard that leaves circular refs in place and logs a warning.
+- Ref targets missing on disk are left in place and reported in the summary.
 
 ## 📈 Script Output
 
@@ -282,6 +310,9 @@ npm run unify:verbose
 
 # Dry run with verbose output
 npm run unify:dry-run
+
+# Flatten external entity references into inline JSON
+npm run unify:flatten
 ```
 
 ## 🔄 Re-running the Script

--- a/scripts/unify-openapi.js
+++ b/scripts/unify-openapi.js
@@ -46,7 +46,13 @@ const config = {
   inputDir: './swagger',
   outputDir: './mcp_swagger',
   verbose: false,
-  dryRun: false
+  dryRun: false,
+  // Reference flattening: replace external $ref URLs (that actually live in this
+  // repo, e.g. under entities/) with the inline JSON they point to. ReadMe struggles
+  // to resolve these external URLs, so inlining produces self-contained specs.
+  flattenRefs: false,
+  refsBaseUrl: 'https://vcita.github.io/developers-hub/',
+  refsBaseDir: '.'
 };
 
 // Parse command line arguments
@@ -65,6 +71,16 @@ for (let i = 0; i < args.length; i++) {
     case '--dry-run':
       config.dryRun = true;
       break;
+    case '--flatten-refs':
+    case '--inline-refs':
+      config.flattenRefs = true;
+      break;
+    case '--refs-base-url':
+      config.refsBaseUrl = args[++i];
+      break;
+    case '--refs-base-dir':
+      config.refsBaseDir = args[++i];
+      break;
     case '--help':
       console.log(`
 Usage: node scripts/unify-openapi.js [options]
@@ -74,6 +90,11 @@ Options:
   --output-dir <dir>    Output directory (default: ./mcp_swagger)
   --verbose             Enable verbose logging
   --dry-run            Show what would be processed without writing files
+  --flatten-refs        Inline external \$ref URLs that live in this repo
+                        (alias: --inline-refs). Internal #/... refs are left as-is.
+  --refs-base-url <url> External ref URL prefix to flatten
+                        (default: https://vcita.github.io/developers-hub/)
+  --refs-base-dir <dir> Local dir the ref URL prefix maps to (default: .)
   --help               Show this help message
 
 Conflict Resolution:
@@ -473,8 +494,125 @@ function convertDefinitionsToComponents(fileContent, fileName) {
   return components;
 }
 
+// Flatten external $ref URLs into inline JSON
+// ============================================
+// ReadMe (and some other tooling) cannot resolve external $ref URLs such as
+// "https://vcita.github.io/developers-hub/entities/response.json". Those files
+// actually live in this repo (the URL prefix maps to the repo root, so the ref
+// above is entities/response.json on disk). This function walks a spec and
+// replaces every such external $ref with the inline JSON it points to, producing
+// a self-contained specification.
+//
+// SCOPE:
+// - Only refs whose value starts with `baseUrl` are touched.
+// - Internal refs (#/components/schemas/..., #/definitions/...) are left untouched.
+//
+// SUPPORTED REF FORMS:
+// 1. Whole-file:   ".../entities/response.json"
+// 2. With pointer: ".../entities/payments/invoice.json#/properties/status"
+//                  → the JSON Pointer fragment is resolved within the file.
+//
+// NESTED REFS:
+// Inlined content may itself contain external refs; those are resolved
+// recursively. A resolution stack guards against circular references — if a
+// cycle is detected the offending $ref is left in place and a warning is logged.
+//
+// Returns { spec, count, missing } where `count` is how many external refs were
+// inlined and `missing` lists ref targets that could not be found on disk.
+function flattenExternalRefs(spec, baseUrl, baseDir) {
+  const fileCache = new Map();
+  const stats = { count: 0, missing: new Set() };
+
+  function loadFile(relPath) {
+    if (fileCache.has(relPath)) return fileCache.get(relPath);
+    const filePath = path.join(baseDir, relPath);
+    let content = null;
+    try {
+      content = fs.readJsonSync(filePath);
+    } catch (error) {
+      content = null; // Cached as null so we only warn once per missing file
+    }
+    fileCache.set(relPath, content);
+    return content;
+  }
+
+  // Resolve a JSON Pointer fragment (RFC 6901) within a document.
+  function resolvePointer(doc, pointer) {
+    if (!pointer || pointer === '#' || pointer === '#/') return doc;
+    const parts = pointer.replace(/^#\//, '').split('/');
+    let current = doc;
+    for (const rawPart of parts) {
+      const key = rawPart.replace(/~1/g, '/').replace(/~0/g, '~');
+      if (current && typeof current === 'object' && key in current) {
+        current = current[key];
+      } else {
+        return undefined;
+      }
+    }
+    return current;
+  }
+
+  // `stack` holds the external ref URLs currently being resolved (cycle guard).
+  function walk(node, stack) {
+    if (Array.isArray(node)) {
+      return node.map(item => walk(item, stack));
+    }
+    if (node && typeof node === 'object') {
+      const refValue = node.$ref;
+      if (typeof refValue === 'string' && refValue.startsWith(baseUrl)) {
+        if (stack.includes(refValue)) {
+          log.warn(`Circular external ref, leaving in place: ${refValue}`);
+          return node;
+        }
+
+        const withoutPrefix = refValue.slice(baseUrl.length);
+        const hashIndex = withoutPrefix.indexOf('#');
+        const relPath = hashIndex === -1 ? withoutPrefix : withoutPrefix.slice(0, hashIndex);
+        const pointer = hashIndex === -1 ? '' : withoutPrefix.slice(hashIndex);
+
+        const fileContent = loadFile(relPath);
+        if (fileContent === null) {
+          stats.missing.add(relPath);
+          log.warn(`External ref target not found on disk, leaving in place: ${refValue}`);
+          return node;
+        }
+
+        const target = resolvePointer(fileContent, pointer);
+        if (target === undefined) {
+          stats.missing.add(refValue.slice(baseUrl.length));
+          log.warn(`External ref pointer did not resolve, leaving in place: ${refValue}`);
+          return node;
+        }
+
+        // Recursively inline any external refs inside the resolved content.
+        const resolved = walk(JSON.parse(JSON.stringify(target)), [...stack, refValue]);
+        stats.count++;
+        log.verbose(`Flattened external ref: ${refValue}`);
+
+        // Preserve sibling annotations that sat next to $ref (e.g. description);
+        // siblings win over the inlined content, matching OpenAPI 3.1 semantics.
+        const { $ref, ...siblings } = node;
+        if (Object.keys(siblings).length > 0 && resolved && typeof resolved === 'object' && !Array.isArray(resolved)) {
+          return { ...resolved, ...walk(siblings, stack) };
+        }
+        return resolved;
+      }
+
+      const result = {};
+      for (const [key, value] of Object.entries(node)) {
+        result[key] = walk(value, stack);
+      }
+      return result;
+    }
+    return node;
+  }
+
+  const flattened = walk(spec, []);
+  return { spec: flattened, count: stats.count, missing: Array.from(stats.missing) };
+}
+
 // Merge components from multiple files
-// 
+//
 // CONFLICT RESOLUTION STRATEGY:
 // =============================
 // When merging OpenAPI components (schemas, security schemes, etc.) from multiple files,
@@ -1020,7 +1158,8 @@ async function main() {
       successfulDomains: 0,
       totalFiles: 0,
       totalPaths: 0,
-      totalConflicts: 0
+      totalConflicts: 0,
+      totalRefsFlattened: 0
     };
     
     // Process each domain
@@ -1037,7 +1176,19 @@ async function main() {
           summary.totalFiles += result.stats.filesProcessed;
           summary.totalPaths += result.stats.pathsGenerated;
           summary.totalConflicts += result.stats.pathConflicts + result.stats.componentConflicts;
-          
+
+          // Flatten external $ref URLs into inline JSON (if requested)
+          if (config.flattenRefs) {
+            const { spec: flatSpec, count, missing } = flattenExternalRefs(
+              result.spec, config.refsBaseUrl, config.refsBaseDir);
+            result.spec = flatSpec;
+            summary.totalRefsFlattened += count;
+            log.info(`Domain ${domain}: Flattened ${count} external reference(s) into inline JSON`);
+            if (missing.length > 0) {
+              log.warn(`Domain ${domain}: ${missing.length} external ref target(s) not found: ${missing.join(', ')}`);
+            }
+          }
+
           // Write unified file
           if (!config.dryRun) {
             const outputFile = path.join(config.outputDir, `${domain}.json`);
@@ -1059,6 +1210,9 @@ async function main() {
     console.log(`Total files processed: ${summary.totalFiles}`);
     console.log(`Total paths generated: ${summary.totalPaths}`);
     console.log(`Total conflicts resolved: ${summary.totalConflicts}`);
+    if (config.flattenRefs) {
+      console.log(`Total external refs flattened: ${summary.totalRefsFlattened}`);
+    }
     
     if (summary.totalConflicts > 0) {
       console.log('\n🔧 CONFLICT RESOLUTION APPLIED:');
@@ -1107,5 +1261,6 @@ module.exports = {
   normalizeEndpoints, 
   extractBasePath, 
   convertSwaggerToOpenAPI,
-  convertDefinitionsToComponents 
+  convertDefinitionsToComponents,
+  flattenExternalRefs
 };


### PR DESCRIPTION
## Summary

Adds a `--flatten-refs` flag to the unify script and recompiles the `mcp_swagger` specs with all external entity references inlined.

ReadMe (and some other tooling) cannot dereference external `$ref` URLs such as `https://vcita.github.io/developers-hub/entities/response.json`. Those entities actually live in this repo (the URL prefix maps to the repo root → `entities/response.json` on disk), so this change inlines them to produce self-contained specs.

## Changes

- **`scripts/unify-openapi.js`**: new `flattenExternalRefs()` pass + `--flatten-refs` (alias `--inline-refs`), with `--refs-base-url` / `--refs-base-dir` overrides.
  - Only external refs matching the base URL are inlined; internal `#/...` refs are left untouched.
  - Supports whole-file refs and refs with a JSON-Pointer fragment (`.../invoice.json#/properties/status`).
  - Nested external refs are resolved recursively, with a cycle guard.
  - Sibling annotations next to `$ref` are preserved; missing targets are left in place and reported.
- **`mcp_swagger/*.json`**: recompiled with external refs flattened (434 refs inlined across all domains, 0 missing).
- **`package.json`**: `npm run unify:flatten`.
- **`scripts/README-unify-openapi.md`**: documented the flag.

## Test plan

- `node scripts/unify-openapi.js --flatten-refs --dry-run` → 434 external refs flattened, 0 missing targets, 0 remaining external `$ref`s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)