### PR TITLE
docs(ai): add staff_scope filter and bizai action to AI recommendations spec [VCITA2-14980]

### DIFF
--- a/entities/ai/AIRecommendedAction.json
+++ b/entities/ai/AIRecommendedAction.json
@@ -8,8 +8,8 @@
       },
       "action": {
         "type": "string",
-        "enum": ["reply", "estimate", "schedule", "acknowledge", "bizai_chat"],
-        "description": "The type of action recommended. Possible values:\n- 'reply': Suggests responding to a user message.\n- 'estimate': Suggests providing a price estimate.\n- 'schedule': Suggests scheduling an appointment or meeting.\n- 'acknowledge': No action or artifact is prepared; the user reviews the item and then completes or dismisses it.\n- 'bizai_chat': Hands the item off to BizAI Chat (the business AI chat assistant) to handle on the user's behalf."
+        "enum": ["reply", "estimate", "schedule", "acknowledge", "chat_with_bizai"],
+        "description": "The type of action recommended. Possible values:\n- 'reply': Suggests responding to a user message.\n- 'estimate': Suggests providing a price estimate.\n- 'schedule': Suggests scheduling an appointment or meeting.\n- 'acknowledge': No action or artifact is prepared; the user reviews the item and then completes or dismisses it.\n- 'chat_with_bizai': Hands the item off to BizAI (the business AI chat assistant) to handle on the user's behalf."
       },
       "display": {
         "type": "object",

--- a/entities/ai/AIRecommendedAction.json
+++ b/entities/ai/AIRecommendedAction.json
@@ -8,8 +8,8 @@
       },
       "action": {
         "type": "string",
-        "enum": ["reply", "estimate", "schedule", "acknowledge", "bizai"],
-        "description": "The type of action recommended. Possible values:\n- 'reply': Suggests responding to a user message.\n- 'estimate': Suggests providing a price estimate.\n- 'schedule': Suggests scheduling an appointment or meeting.\n- 'acknowledge': No action or artifact is prepared; the user reviews the item and then completes or dismisses it.\n- 'bizai': Hands the item off to BizAI (the business AI assistant) to handle on the user's behalf."
+        "enum": ["reply", "estimate", "schedule", "acknowledge", "bizai_chat"],
+        "description": "The type of action recommended. Possible values:\n- 'reply': Suggests responding to a user message.\n- 'estimate': Suggests providing a price estimate.\n- 'schedule': Suggests scheduling an appointment or meeting.\n- 'acknowledge': No action or artifact is prepared; the user reviews the item and then completes or dismisses it.\n- 'bizai_chat': Hands the item off to BizAI Chat (the business AI chat assistant) to handle on the user's behalf."
       },
       "display": {
         "type": "object",

--- a/entities/ai/AIRecommendedAction.json
+++ b/entities/ai/AIRecommendedAction.json
@@ -8,8 +8,8 @@
       },
       "action": {
         "type": "string",
-        "enum": ["reply", "estimate", "schedule", "acknowledge"],
-        "description": "The type of action recommended. Possible values:\n- 'reply': Suggests responding to a user message.\n- 'estimate': Suggests providing a price estimate.\n- 'schedule': Suggests scheduling an appointment or meeting.\n- 'acknowledge': No action or artifact is prepared; the user reviews the item and then completes or dismisses it."
+        "enum": ["reply", "estimate", "schedule", "acknowledge", "bizai"],
+        "description": "The type of action recommended. Possible values:\n- 'reply': Suggests responding to a user message.\n- 'estimate': Suggests providing a price estimate.\n- 'schedule': Suggests scheduling an appointment or meeting.\n- 'acknowledge': No action or artifact is prepared; the user reviews the item and then completes or dismisses it.\n- 'bizai': Hands the item off to BizAI (the business AI assistant) to handle on the user's behalf."
       },
       "display": {
         "type": "object",

--- a/swagger/ai/recommendations.json
+++ b/swagger/ai/recommendations.json
@@ -110,17 +110,17 @@
             "description": "Filter by the record's 'producer' (creation source). When omitted, only legacy records with an empty 'producer' are returned (default). Pass 'any' to return only records that have a non-empty 'producer', or pass a specific producer value (for example: 'client_agent') to return only records from that producer."
           },
           {
-            "name": "staff_scope",
+            "name": "view",
             "in": "query",
             "schema": {
               "type": "string",
               "enum": [
-                "mine",
-                "all"
+                "my_view",
+                "team"
               ],
-              "default": "mine"
+              "default": "my_view"
             },
-            "description": "Which staff members' recommendations to return. 'mine' (default) returns only the caller's own recommendations; 'all' returns recommendations across every staff member in the business, subject to the caller having permission to view other staff members' entities (e.g., \"mine\", \"all\")."
+            "description": "Which staff members' recommendations to return. 'my_view' (default) returns only the caller's own recommendations; 'team' returns recommendations across every staff member in the business, subject to the caller having permission to view other staff members' entities (e.g., \"my_view\", \"team\")."
           },
           {
             "name": "include",
@@ -524,9 +524,9 @@
               "estimate",
               "schedule",
               "acknowledge",
-              "bizai"
+              "bizai_chat"
             ],
-            "description": "The type of action recommended. Possible values:\n- 'reply': Suggests responding to a user message.\n- 'estimate': Suggests providing a price estimate.\n- 'schedule': Suggests scheduling an appointment or meeting.\n- 'acknowledge': No action or artifact is prepared; the user reviews the item and then completes or dismisses it.\n- 'bizai': Hands the item off to BizAI (the business AI assistant) to handle on the user's behalf."
+            "description": "The type of action recommended. Possible values:\n- 'reply': Suggests responding to a user message.\n- 'estimate': Suggests providing a price estimate.\n- 'schedule': Suggests scheduling an appointment or meeting.\n- 'acknowledge': No action or artifact is prepared; the user reviews the item and then completes or dismisses it.\n- 'bizai_chat': Hands the item off to BizAI Chat (the business AI chat assistant) to handle on the user's behalf."
           },
           "display": {
             "type": "object",

--- a/swagger/ai/recommendations.json
+++ b/swagger/ai/recommendations.json
@@ -110,6 +110,19 @@
             "description": "Filter by the record's 'producer' (creation source). When omitted, only legacy records with an empty 'producer' are returned (default). Pass 'any' to return only records that have a non-empty 'producer', or pass a specific producer value (for example: 'client_agent') to return only records from that producer."
           },
           {
+            "name": "staff_scope",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "mine",
+                "all"
+              ],
+              "default": "mine"
+            },
+            "description": "Which staff members' recommendations to return. 'mine' (default) returns only the caller's own recommendations; 'all' returns recommendations across every staff member in the business, subject to the caller having permission to view other staff members' entities (e.g., \"mine\", \"all\")."
+          },
+          {
             "name": "include",
             "in": "query",
             "description": "Optional data sets to include in the response, beyond the recommendations list. Supported values: 'counts' (adds per-category totals under 'meta.counts'). Repeat the parameter to request multiple. When omitted, no extra data is returned and 'meta' is absent.",
@@ -510,9 +523,10 @@
               "reply",
               "estimate",
               "schedule",
-              "acknowledge"
+              "acknowledge",
+              "bizai"
             ],
-            "description": "The type of action recommended. Possible values:\n- 'reply': Suggests responding to a user message.\n- 'estimate': Suggests providing a price estimate.\n- 'schedule': Suggests scheduling an appointment or meeting.\n- 'acknowledge': No action or artifact is prepared; the user reviews the item and then completes or dismisses it."
+            "description": "The type of action recommended. Possible values:\n- 'reply': Suggests responding to a user message.\n- 'estimate': Suggests providing a price estimate.\n- 'schedule': Suggests scheduling an appointment or meeting.\n- 'acknowledge': No action or artifact is prepared; the user reviews the item and then completes or dismisses it.\n- 'bizai': Hands the item off to BizAI (the business AI assistant) to handle on the user's behalf."
           },
           "display": {
             "type": "object",

--- a/swagger/ai/recommendations.json
+++ b/swagger/ai/recommendations.json
@@ -524,9 +524,9 @@
               "estimate",
               "schedule",
               "acknowledge",
-              "bizai_chat"
+              "chat_with_bizai"
             ],
-            "description": "The type of action recommended. Possible values:\n- 'reply': Suggests responding to a user message.\n- 'estimate': Suggests providing a price estimate.\n- 'schedule': Suggests scheduling an appointment or meeting.\n- 'acknowledge': No action or artifact is prepared; the user reviews the item and then completes or dismisses it.\n- 'bizai_chat': Hands the item off to BizAI Chat (the business AI chat assistant) to handle on the user's behalf."
+            "description": "The type of action recommended. Possible values:\n- 'reply': Suggests responding to a user message.\n- 'estimate': Suggests providing a price estimate.\n- 'schedule': Suggests scheduling an appointment or meeting.\n- 'acknowledge': No action or artifact is prepared; the user reviews the item and then completes or dismisses it.\n- 'chat_with_bizai': Hands the item off to BizAI (the business AI chat assistant) to handle on the user's behalf."
           },
           "display": {
             "type": "object",


### PR DESCRIPTION
## What & why
Implements [VCITA2-14980](https://myvcita.atlassian.net/browse/VCITA2-14980) — spec/interface only for the AI Recommendation feature.

### Changes
1. **`staff_scope` query param** on `GET /v3/ai/ai_recommendations` — enum `mine` | `all`, default `mine`. The v3 replacement for the legacy `team_view_filter`: `mine` returns only the caller's own recommendations; `all` returns recommendations across every staff member in the business, subject to the caller's permission to view other staff members' entities.
   - Named `staff_scope` to sit in the same family as the existing `staff_uid` param, snake_case and enum-backed per v3 API standards (the legacy `team_view_filter`/`teams_view_filter` is inconsistent and overloaded across legacy endpoints).
2. **`bizai` added to the `action` enum** in both `swagger/ai/recommendations.json` and `entities/ai/AIRecommendedAction.json`.

### ⚠️ Reviewer note — please confirm the `bizai` description
The requirement to add `bizai` came from the client-agent (CA) side. At the time of writing, `bizai` does **not yet exist** as a recommendation action type anywhere in `aiagents` / `aiplatform` / `core` (searched all remote branches) — the action union is still `reply|estimate|schedule|acknowledge`. So the human-readable description here is a **best-effort inference**:

> `'bizai': Hands the item off to BizAI (the business AI assistant) to handle on the user's behalf.`

Please confirm the exact wording with whoever requested the new type (the CA/recommendation-combiner owner) and adjust if needed.

### Scope
- Spec/interface only. `staff_scope` logic (permissions, validation, data fetching) and the aiplatform DTO are **out of scope** per the ticket, to be done separately.
- `mcp_swagger/` intentionally untouched — it is regenerated automatically on deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[VCITA2-14980]: https://myvcita.atlassian.net/browse/VCITA2-14980?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ