### PR TITLE
VCITA2-15059 + VCITA2-15082: align ai_recommendations docs & add FYI category

### DIFF
--- a/entities/ai/AIRecommendation.json
+++ b/entities/ai/AIRecommendation.json
@@ -25,9 +25,9 @@
       },
       "category": {
         "type": "string",
-        "enum": ["needs_attention", "opportunity"],
+        "enum": ["needs_attention", "opportunity", "fyi"],
         "default": "needs_attention",
-        "description": "Recommendation category set by the producer for interface use: 'needs_attention' (time-sensitive and requires the user's attention) or 'opportunity' (growth-focused value opportunity that does not require immediate action)."
+        "description": "Recommendation category set by the producer for interface use: 'needs_attention' (time-sensitive and requires the user's attention), 'opportunity' (growth-focused value opportunity that does not require immediate action), or 'fyi' (informational only, no action required)."
       },
       "priority": {
         "type": "string",

--- a/entities/ai/AIRecommendedAction.json
+++ b/entities/ai/AIRecommendedAction.json
@@ -36,21 +36,6 @@
           "type": "string"
         }
       },
-      "context": {
-        "type": "object",
-        "description": "The context in which the recommendation was generated.",
-        "properties": {
-          "context_uid": {
-            "type": "string",
-            "description": "A unique identifier for the context associated with this recommendation."
-          },
-          "context_type": {
-            "type": "string",
-            "description": "The type of context (e.g., 'matter','client', 'business').",
-            "enum": ["matter","client", "business"]
-          }
-        }
-      },
       "confidence": {
         "type": "number",
         "description": "A confidence score (0-1) indicating how confident the AI is in this recommendation."
@@ -68,10 +53,7 @@
       "payload": {
         "message": "Hi please send some more details"
       },
-      "context": {
-        "context_uid": "ctx-456",
-        "context_type": "client"
-      }
+      "confidence": 0.85
     }
   }
   

--- a/swagger/ai/recommendations.json
+++ b/swagger/ai/recommendations.json
@@ -451,10 +451,9 @@
           }
         },
         "required": [
-          "user_description",
-          "staff_uid",
-          "sources",
-          "actions"
+          "actions",
+          "context",
+          "target"
         ]
       },
       "AIRecommendationUpdateRequest": {
@@ -552,8 +551,17 @@
             "items": {
               "type": "string"
             }
+          },
+          "confidence": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 1,
+            "description": "A confidence score (0-1) indicating how confident the AI is in this recommendation (e.g., 0.85)."
           }
-        }
+        },
+        "required": [
+          "action"
+        ]
       }
     },
     "securitySchemes": {

--- a/swagger/ai/recommendations.json
+++ b/swagger/ai/recommendations.json
@@ -99,7 +99,7 @@
                 "upcoming"
               ]
             },
-            "description": "Filter by category bucket. Each record belongs to one bucket only, checked in this order:\nupcoming – due_at is in the future (based on time, even if the stored category is different).\nfyi – due_at is not in the future and execution_policy is auto_execute (again, based on fields, not stored category).\nneeds_attention / opportunity – stored category is one of these, due_at is not in the future, and execution_policy is requires_human_approval."
+            "description": "Filter by category bucket. Only active recommendations are bucketed. Each record belongs to one bucket only, checked in this order:\nupcoming – due_at is in the future (regardless of stored category).\nneeds_attention / opportunity / fyi – due_at is not in the future (past or unset) and the stored category matches the requested bucket."
           },
           {
             "name": "producer",
@@ -159,23 +159,23 @@
                           "properties": {
                             "counts": {
                               "type": "object",
-                              "description": "Returned only when 'include=counts' is requested. Number of recommendations per bucket across the full set matching every query filter except 'category' (that is: 'target', 'context', 'status', and 'producer' are all applied; 'category' is intentionally ignored). This lets the caller show how many items exist in each bucket regardless of the category currently being requested. The counts are computed scope-wide - they are also independent of pagination, so they reflect totals even for buckets not present in the returned page. Every matching recommendation is counted in exactly one bucket (no overlap), evaluated in this order: future 'due_at' -> 'upcoming'; else 'execution_policy' = 'auto_execute' -> 'fyi'; else by stored category -> 'needs_attention' or 'opportunity'.",
+                              "description": "Returned only when 'include=counts' is requested. Number of recommendations per bucket across the full set matching every query filter except 'category' and 'status' (that is: 'target', 'context', and 'producer' are all applied; 'category' is intentionally ignored and counts always reflect active recommendations regardless of the 'status' filter). This lets the caller show how many items exist in each bucket regardless of the category currently being requested. The counts are computed scope-wide - they are also independent of pagination, so they reflect totals even for buckets not present in the returned page. Only active recommendations are counted. Every matching recommendation is counted in exactly one bucket (no overlap), evaluated in this order: future 'due_at' -> 'upcoming'; else by stored category -> 'needs_attention', 'opportunity', or 'fyi'.",
                               "properties": {
                                 "needs_attention": {
                                   "type": "integer",
-                                  "description": "Recommendations with stored category 'needs_attention', a non-future 'due_at', and 'execution_policy' = 'requires_human_approval'."
+                                  "description": "Active recommendations with stored category 'needs_attention' and a non-future 'due_at' (past or unset)."
                                 },
                                 "upcoming": {
                                   "type": "integer",
-                                  "description": "Recommendations whose 'due_at' is in the future, regardless of stored category. Derived bucket - these are excluded from every other bucket."
+                                  "description": "Active recommendations whose 'due_at' is in the future, regardless of stored category. Derived bucket - these are excluded from every other bucket."
                                 },
                                 "opportunity": {
                                   "type": "integer",
-                                  "description": "Recommendations with stored category 'opportunity', a non-future 'due_at', and 'execution_policy' = 'requires_human_approval'."
+                                  "description": "Active recommendations with stored category 'opportunity' and a non-future 'due_at' (past or unset)."
                                 },
                                 "fyi": {
                                   "type": "integer",
-                                  "description": "Non-future recommendations whose 'execution_policy' is 'auto_execute', regardless of stored category. Derived bucket."
+                                  "description": "Active recommendations with stored category 'fyi' and a non-future 'due_at' (past or unset)."
                                 }
                               }
                             }
@@ -326,10 +326,11 @@
             "type": "string",
             "enum": [
               "needs_attention",
-              "opportunity"
+              "opportunity",
+              "fyi"
             ],
             "default": "needs_attention",
-            "description": "Recommendation category set by the producer for interface use: 'needs_attention' (time-sensitive and requires the user's attention) or 'opportunity' (growth-focused value opportunity that does not require immediate action)."
+            "description": "Recommendation category set by the producer for interface use: 'needs_attention' (time-sensitive and requires the user's attention), 'opportunity' (growth-focused value opportunity that does not require immediate action), or 'fyi' (informational only, no action required)."
           },
           "priority": {
             "type": "string",


### PR DESCRIPTION
## Overview

Documentation for two `ai_recommendations` changes, matching the aiplatform PR (vcita/aiplatform#450):

- **VCITA2-15059** — align the `POST /v3/ai/ai_recommendations` contract with the implementation.
- **VCITA2-15082** — document `fyi` as a first-class stored category.

Source-of-truth files only (`swagger/` + `entities/`); the `mcp_swagger/` bundles are regenerated by the deploy pipeline and intentionally not touched here.

---

## VCITA2-15059 — Contract alignment

**`swagger/ai/recommendations.json`**
- Fix the broken `AIRecommendationRequest.required` array (was `user_description`/`staff_uid`/`sources` — fields that don't exist) → `["actions", "context", "target"]`.
- Add `confidence` (number, 0–1) and `required: ["action"]` to `AIRecommendationActionRequest`.

**`entities/ai/AIRecommendedAction.json`**
- Remove the phantom per-action `context` object (no column / DTO / mapping exists for it).
- Keep `confidence` (now backed by an entity column).

## VCITA2-15082 — FYI category

**`swagger/ai/recommendations.json`** + **`entities/ai/AIRecommendation.json`**
- Add `fyi` to the `category` enum (create request + entity), described as "informational only, no action required".
- Rewrite the `category` filter and `meta.counts` descriptions to match the new bucketing: only **active** recommendations are bucketed; `upcoming` = future `due_at`; otherwise by stored category (`needs_attention` / `opportunity` / `fyi`). `execution_policy` no longer participates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)