### PR TITLE
docs: add legacy v2 business settings endpoint (/v2/settings/businesses/{business_uid})

### DIFF
--- a/swagger/platform_administration/legacy/legacy_v2_settings_businesses.json
+++ b/swagger/platform_administration/legacy/legacy_v2_settings_businesses.json
@@ -1,0 +1,215 @@
+{
+  "basePath": "/",
+  "host": "api.vcita.biz",
+  "info": {
+    "title": "Business Settings API",
+    "version": "v2.0",
+    "description": "Endpoints for reading and updating a business's own profile settings (name, address, phone, website, and client-facing visibility flags). The business address is stored as a free-text string and geocoded server-side into a read-only `structured_address`. Available for **Staff & Directory tokens** — a Staff token of a staff member belonging to the business (with settings access), or a Directory token of the owning directory. Directory tokens MUST send the business in the `X-On-Behalf-Of` header; a Directory token without it is rejected with 403."
+  },
+  "paths": {
+    "/v2/settings/businesses/{business_uid}": {
+      "get": {
+        "consumes": ["application/json"],
+        "description": "## Overview\nReturns the full settings object for the business, including profile fields, client-facing visibility flags, branding, and the server-geocoded `structured_address`.\n\nAvailable for **Staff & Directory tokens** — a Staff token of a staff member belonging to the business, or a Directory token of the owning directory. Directory tokens MUST send the business in the `X-On-Behalf-Of` header (a Directory token without it is rejected with 403).",
+        "parameters": [
+          {
+            "description": "The business UID — the public identifier of the business (e.g., \"fyclhomrzdspdyk6\").",
+            "in": "path",
+            "name": "business_uid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "The business UID to act on behalf of. Required when authenticating with a Directory token; not needed for a Staff token (e.g., \"fyclhomrzdspdyk6\").",
+            "in": "header",
+            "name": "X-On-Behalf-Of",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "produces": ["application/json"],
+        "responses": {
+          "200": {
+            "description": "The business settings object.",
+            "examples": {
+              "application/json": {
+                "uid": "fyclhomrzdspdyk6",
+                "name": "Summit Peak Climate Solutions",
+                "address": "233 S Wacker Dr, Chicago, IL 60606, USA",
+                "structured_address": {
+                  "street_number": "233",
+                  "street_name": "South Wacker Drive",
+                  "city": "Chicago",
+                  "state": "Illinois",
+                  "state_code": "IL",
+                  "country": "United States",
+                  "country_code": "US",
+                  "postal_code": "60606",
+                  "county": "Cook County",
+                  "latitude": 41.8788,
+                  "longitude": -87.6359,
+                  "formatted_address": "233 S Wacker Dr, Chicago, IL 60606, USA",
+                  "place_id": "ChIJ0X31pIK3voARwd2Vg2M3D3Q",
+                  "location_type": "ROOFTOP"
+                },
+                "info_website": "https://summitpeakclimate.com",
+                "show_address": true,
+                "show_phone": true,
+                "show_email": true,
+                "show_website": true
+              }
+            }
+          }
+        },
+        "summary": "Show Business Settings",
+        "tags": ["Business Settings"]
+      },
+      "put": {
+        "consumes": ["application/json"],
+        "description": "## Overview\nUpdates the business's own profile settings. Only the fields provided in the body are changed.\n\nThe **`address`** is a plain free-text string; it is geocoded server-side into `structured_address`, so a real, resolvable address must be sent (a made-up string may fail to geocode). `structured_address` is **read-only** and cannot be supplied as input — it is returned on the response once geocoding completes.\n\nAvailable for **Staff & Directory tokens** — a Staff token of a staff member belonging to the business (with settings access), or a Directory token of the owning directory. Directory tokens MUST send the business in the `X-On-Behalf-Of` header (without it, a Directory token is rejected with 403). A client token or an unrelated staff is rejected with 401/403.",
+        "parameters": [
+          {
+            "description": "The business UID — the public identifier of the business (e.g., \"fyclhomrzdspdyk6\").",
+            "in": "path",
+            "name": "business_uid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "The business UID to act on behalf of. Required when authenticating with a Directory token; not needed for a Staff token (e.g., \"fyclhomrzdspdyk6\").",
+            "in": "header",
+            "name": "X-On-Behalf-Of",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "description": "The settings fields to update. All fields are optional; send only the ones you want to change.",
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "description": "Display name of the business (e.g., \"Summit Peak Climate Solutions\")."
+                },
+                "address": {
+                  "type": "string",
+                  "description": "The business's physical street address as free text. Geocoded server-side into the read-only `structured_address`; send a real, resolvable address (e.g., \"233 S Wacker Dr, Chicago, IL 60606, USA\")."
+                },
+                "billing_address": {
+                  "type": "string",
+                  "description": "The billing address as free text, used on invoices and estimates (e.g., \"233 S Wacker Dr, Chicago, IL 60606, USA\")."
+                },
+                "business_description": {
+                  "type": "string",
+                  "description": "Short description of the business shown to clients (e.g., \"Residential and commercial HVAC service.\")."
+                },
+                "phone_info": {
+                  "type": "string",
+                  "description": "The business phone number (e.g., \"+13125550142\")."
+                },
+                "country_name": {
+                  "type": "string",
+                  "description": "Country name for the business (e.g., \"United States\")."
+                },
+                "info_website": {
+                  "type": "string",
+                  "description": "The business website URL (e.g., \"https://summitpeakclimate.com\")."
+                },
+                "display_country_code": {
+                  "type": "boolean",
+                  "description": "Whether to show the country dialing code alongside the phone number (e.g., true, false)."
+                },
+                "locale": {
+                  "type": "string",
+                  "description": "The business locale / language (e.g., \"en\", \"es\")."
+                },
+                "sender_name": {
+                  "type": "string",
+                  "description": "The name used as the sender on outgoing client communications (e.g., \"Summit Peak Team\")."
+                },
+                "use_sender_name": {
+                  "type": "boolean",
+                  "description": "Whether to use `sender_name` on outgoing communications (e.g., true, false)."
+                },
+                "show_address": {
+                  "type": "boolean",
+                  "description": "Whether the business address is shown on the client-facing site (e.g., true, false)."
+                },
+                "show_phone": {
+                  "type": "boolean",
+                  "description": "Whether the business phone is shown on the client-facing site (e.g., true, false)."
+                },
+                "show_email": {
+                  "type": "boolean",
+                  "description": "Whether the business email is shown on the client-facing site (e.g., true, false)."
+                },
+                "show_website": {
+                  "type": "boolean",
+                  "description": "Whether the business website is shown on the client-facing site (e.g., true, false)."
+                }
+              }
+            }
+          }
+        ],
+        "produces": ["application/json"],
+        "responses": {
+          "200": {
+            "description": "The updated business settings object. When `address` changed, `structured_address` reflects the newly geocoded value.",
+            "examples": {
+              "application/json": {
+                "uid": "fyclhomrzdspdyk6",
+                "name": "Summit Peak Climate Solutions",
+                "address": "233 S Wacker Dr, Chicago, IL 60606, USA",
+                "structured_address": {
+                  "street_number": "233",
+                  "street_name": "South Wacker Drive",
+                  "city": "Chicago",
+                  "state": "Illinois",
+                  "state_code": "IL",
+                  "country": "United States",
+                  "country_code": "US",
+                  "postal_code": "60606",
+                  "latitude": 41.8788,
+                  "longitude": -87.6359,
+                  "formatted_address": "233 S Wacker Dr, Chicago, IL 60606, USA",
+                  "place_id": "ChIJ0X31pIK3voARwd2Vg2M3D3Q"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "The staff lacks settings access for this business.",
+            "examples": {
+              "application/json": {
+                "status": "failure",
+                "message": "401 Unauthorized"
+              }
+            }
+          },
+          "403": {
+            "description": "The token is not authorized to act on this business — e.g. a Directory token sent without the `X-On-Behalf-Of` header, or a token that does not belong to the business or its owning directory.",
+            "examples": {
+              "application/json": {
+                "error": "Unauthorized"
+              }
+            }
+          },
+          "422": {
+            "description": "Validation failed for one or more fields.",
+            "examples": {
+              "application/json": {
+                "errors": ["Address is invalid"]
+              }
+            }
+          }
+        },
+        "summary": "Update Business Settings",
+        "tags": ["Business Settings"]
+      }
+    }
+  },
+  "swagger": "2.0"
+}


### PR DESCRIPTION
## What

Adds a legacy-swagger definition for the **business settings** endpoint:

- `GET /v2/settings/businesses/{business_uid}` — read the full business settings object
- `PUT /v2/settings/businesses/{business_uid}` — update business profile settings

New file: `swagger/platform_administration/legacy/legacy_v2_settings_businesses.json` (Swagger 2.0, mirroring the existing `legacy/` conventions).

## Why

This endpoint (Core `Api::V2::Settings::BusinessesController#update`) is how a business's own profile is updated — notably the **address** — but it was undocumented. The `address` is a free-text string that Core geocodes server-side into a read-only `structured_address`; that behavior and the exact field set are documented here.

## Verified behavior

Tested live against the integration environment:

| Auth | Result |
|---|---|
| Staff token (belonging staff, `X-On-Behalf-Of`) | ✅ 200 — updates + geocodes |
| Directory token **with** `X-On-Behalf-Of` | ✅ 200 |
| Directory token **without** `X-On-Behalf-Of` | ❌ 403 |

The spec documents this: **Staff & Directory tokens**, with Directory tokens requiring `X-On-Behalf-Of` (403 otherwise), plus the `X-On-Behalf-Of` header parameter and a `403` response.

## Notes

- `mcp_swagger/` is auto-generated (`npm run unify`) and is **intentionally left untouched** in this PR.
- Validated: valid JSON; `npm run unify:dry-run` unifies the `platform_administration` domain cleanly with no conflicts introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)