### PR TITLE
docs(platform-administration): enrich v2 business-settings examples + document PUT field validations

### DIFF
--- a/swagger/platform_administration/legacy/legacy_v2_settings_businesses.json
+++ b/swagger/platform_administration/legacy/legacy_v2_settings_businesses.json
@@ -193,7 +193,8 @@
                 },
                 "business_description": {
                   "type": "string",
-                  "description": "Short description of the business shown to clients (e.g., \"Residential and commercial HVAC service.\")."
+                  "description": "Short description of the business shown to clients (e.g., \"Residential and commercial HVAC service.\") Maximum 255 characters; longer values are rejected with 422.",
+                  "maxLength": 255
                 },
                 "phone_info": {
                   "type": "string",

--- a/swagger/platform_administration/legacy/legacy_v2_settings_businesses.json
+++ b/swagger/platform_administration/legacy/legacy_v2_settings_businesses.json
@@ -9,7 +9,9 @@
   "paths": {
     "/v2/settings/businesses/{business_uid}": {
       "get": {
-        "consumes": ["application/json"],
+        "consumes": [
+          "application/json"
+        ],
         "description": "## Overview\nReturns the full settings object for the business, including profile fields, client-facing visibility flags, branding, and the server-geocoded `structured_address`.\n\nAvailable for **Staff & Directory tokens** — a Staff token of a staff member belonging to the business, or a Directory token of the owning directory. Directory tokens MUST send the business in the `X-On-Behalf-Of` header (a Directory token without it is rejected with 403).",
         "parameters": [
           {
@@ -27,7 +29,9 @@
             "type": "string"
           }
         ],
-        "produces": ["application/json"],
+        "produces": [
+          "application/json"
+        ],
         "responses": {
           "200": {
             "description": "The business settings object.",
@@ -35,6 +39,15 @@
               "application/json": {
                 "uid": "fyclhomrzdspdyk6",
                 "name": "Summit Peak Climate Solutions",
+                "business_description": "Residential and commercial HVAC service.",
+                "profession": {
+                  "value": 937,
+                  "text": "HVAC contractor",
+                  "merchant_category_code": "1711"
+                },
+                "country_name": "United States",
+                "phone_info": "+13125550142",
+                "display_country_code": false,
                 "address": "233 S Wacker Dr, Chicago, IL 60606, USA",
                 "structured_address": {
                   "street_number": "233",
@@ -50,22 +63,98 @@
                   "longitude": -87.6359,
                   "formatted_address": "233 S Wacker Dr, Chicago, IL 60606, USA",
                   "place_id": "ChIJ0X31pIK3voARwd2Vg2M3D3Q",
-                  "location_type": "ROOFTOP"
+                  "location_type": "ROOFTOP",
+                  "viewport": {
+                    "northeast": {
+                      "lat": 41.8801,
+                      "lng": -87.6345
+                    },
+                    "southwest": {
+                      "lat": 41.8774,
+                      "lng": -87.6372
+                    }
+                  }
                 },
+                "currency": "USD",
                 "info_website": "https://summitpeakclimate.com",
-                "show_address": true,
+                "avatar_id": 1944,
+                "photo_path": null,
+                "logo_path": null,
+                "hide_powered_by": false,
+                "display_phone_number": "+13125550142",
+                "invoice_terms": "Payment of invoices is due by the due date specified, or may be subject to late payment fees or interest charges.",
+                "invoice_show_taxes": true,
+                "multiple_currencies": null,
+                "estimate_terms": "The estimate covers listed services/items only, and is based on the information provided at the time. Changes or additions may increase costs. The estimate is valid only until the expiration date specified, unless updated otherwise.",
+                "locale": "en",
+                "first_day": 0,
+                "owner": {
+                  "first_name": "Jordan",
+                  "last_name": "Rivera",
+                  "email": "owner@example.com",
+                  "display_name": "Jordan Rivera",
+                  "title": null,
+                  "mobile_number": "+13125550142",
+                  "country_name": "United States"
+                },
                 "show_phone": true,
+                "show_address": true,
                 "show_email": true,
-                "show_website": true
+                "show_website": true,
+                "branding": {
+                  "bg_top_color": "#4675d9",
+                  "theme_top_color": "#4DA51E",
+                  "backoffice_branding": false,
+                  "primary_color": "#4675d9",
+                  "secondary_color": "#16a085",
+                  "text_color": "#FFFFFF",
+                  "avatar_id": null,
+                  "bg_url": ""
+                },
+                "rwg_category": null,
+                "info_business_size": null,
+                "restriction_settings": {
+                  "enable_booking_restriction": false,
+                  "restricted_services": null,
+                  "services_count": 0,
+                  "booking_restriction_uid": null
+                },
+                "event_waitlist_enabled": false,
+                "auto_fill_event_waitlist_spots": false,
+                "service_waitlist_enabled": false,
+                "pdf_customization_template": null,
+                "pdf_customization_cover": null,
+                "pdf_customization_logo_size": null,
+                "pdf_customization_color_type": null,
+                "pdf_customization_color": null,
+                "tax_mode": "exclude",
+                "arrival_window_value": 0,
+                "enable_tips_for_cp": null,
+                "enable_tips_for_bo": null,
+                "tips": [],
+                "client_store_card_for_business_use": null,
+                "google_redirect": {
+                  "name": null,
+                  "address": null,
+                  "phone": null
+                },
+                "vcita_payments_business_location": null,
+                "vcita_payments_business_owner_location": null,
+                "vcita_payments_business_profession_code": null,
+                "vcita_payments_preliminary_state": "not_yet_determined"
               }
             }
           }
         },
         "summary": "Show Business Settings",
-        "tags": ["Business Settings"]
+        "tags": [
+          "Business Settings"
+        ]
       },
       "put": {
-        "consumes": ["application/json"],
+        "consumes": [
+          "application/json"
+        ],
         "description": "## Overview\nUpdates the business's own profile settings. Only the fields provided in the body are changed.\n\nThe **`address`** is a plain free-text string; it is geocoded server-side into `structured_address`, so a real, resolvable address must be sent (a made-up string may fail to geocode). `structured_address` is **read-only** and cannot be supplied as input — it is returned on the response once geocoding completes.\n\nAvailable for **Staff & Directory tokens** — a Staff token of a staff member belonging to the business (with settings access), or a Directory token of the owning directory. Directory tokens MUST send the business in the `X-On-Behalf-Of` header (without it, a Directory token is rejected with 403). A client token or an unrelated staff is rejected with 401/403.",
         "parameters": [
           {
@@ -154,7 +243,9 @@
             }
           }
         ],
-        "produces": ["application/json"],
+        "produces": [
+          "application/json"
+        ],
         "responses": {
           "200": {
             "description": "The updated business settings object. When `address` changed, `structured_address` reflects the newly geocoded value.",
@@ -162,6 +253,15 @@
               "application/json": {
                 "uid": "fyclhomrzdspdyk6",
                 "name": "Summit Peak Climate Solutions",
+                "business_description": "Residential and commercial HVAC service.",
+                "profession": {
+                  "value": 937,
+                  "text": "HVAC contractor",
+                  "merchant_category_code": "1711"
+                },
+                "country_name": "United States",
+                "phone_info": "+13125550142",
+                "display_country_code": false,
                 "address": "233 S Wacker Dr, Chicago, IL 60606, USA",
                 "structured_address": {
                   "street_number": "233",
@@ -172,11 +272,90 @@
                   "country": "United States",
                   "country_code": "US",
                   "postal_code": "60606",
+                  "county": "Cook County",
                   "latitude": 41.8788,
                   "longitude": -87.6359,
                   "formatted_address": "233 S Wacker Dr, Chicago, IL 60606, USA",
-                  "place_id": "ChIJ0X31pIK3voARwd2Vg2M3D3Q"
-                }
+                  "place_id": "ChIJ0X31pIK3voARwd2Vg2M3D3Q",
+                  "location_type": "ROOFTOP",
+                  "viewport": {
+                    "northeast": {
+                      "lat": 41.8801,
+                      "lng": -87.6345
+                    },
+                    "southwest": {
+                      "lat": 41.8774,
+                      "lng": -87.6372
+                    }
+                  }
+                },
+                "currency": "USD",
+                "info_website": "https://summitpeakclimate.com",
+                "avatar_id": 1944,
+                "photo_path": null,
+                "logo_path": null,
+                "hide_powered_by": false,
+                "display_phone_number": "+13125550142",
+                "invoice_terms": "Payment of invoices is due by the due date specified, or may be subject to late payment fees or interest charges.",
+                "invoice_show_taxes": true,
+                "multiple_currencies": null,
+                "estimate_terms": "The estimate covers listed services/items only, and is based on the information provided at the time. Changes or additions may increase costs. The estimate is valid only until the expiration date specified, unless updated otherwise.",
+                "locale": "en",
+                "first_day": 0,
+                "owner": {
+                  "first_name": "Jordan",
+                  "last_name": "Rivera",
+                  "email": "owner@example.com",
+                  "display_name": "Jordan Rivera",
+                  "title": null,
+                  "mobile_number": "+13125550142",
+                  "country_name": "United States"
+                },
+                "show_phone": true,
+                "show_address": true,
+                "show_email": true,
+                "show_website": true,
+                "branding": {
+                  "bg_top_color": "#4675d9",
+                  "theme_top_color": "#4DA51E",
+                  "backoffice_branding": false,
+                  "primary_color": "#4675d9",
+                  "secondary_color": "#16a085",
+                  "text_color": "#FFFFFF",
+                  "avatar_id": null,
+                  "bg_url": ""
+                },
+                "rwg_category": null,
+                "info_business_size": null,
+                "restriction_settings": {
+                  "enable_booking_restriction": false,
+                  "restricted_services": null,
+                  "services_count": 0,
+                  "booking_restriction_uid": null
+                },
+                "event_waitlist_enabled": false,
+                "auto_fill_event_waitlist_spots": false,
+                "service_waitlist_enabled": false,
+                "pdf_customization_template": null,
+                "pdf_customization_cover": null,
+                "pdf_customization_logo_size": null,
+                "pdf_customization_color_type": null,
+                "pdf_customization_color": null,
+                "tax_mode": "exclude",
+                "arrival_window_value": 0,
+                "enable_tips_for_cp": null,
+                "enable_tips_for_bo": null,
+                "tips": [],
+                "client_store_card_for_business_use": null,
+                "google_redirect": {
+                  "name": null,
+                  "address": null,
+                  "phone": null
+                },
+                "vcita_payments_business_location": null,
+                "vcita_payments_business_owner_location": null,
+                "vcita_payments_business_profession_code": null,
+                "vcita_payments_preliminary_state": "not_yet_determined"
               }
             }
           },
@@ -201,13 +380,17 @@
             "description": "Validation failed for one or more fields.",
             "examples": {
               "application/json": {
-                "errors": ["Address is invalid"]
+                "errors": [
+                  "Address is invalid"
+                ]
               }
             }
           }
         },
         "summary": "Update Business Settings",
-        "tags": ["Business Settings"]
+        "tags": [
+          "Business Settings"
+        ]
       }
     }
   },

--- a/swagger/platform_administration/legacy/legacy_v2_settings_businesses.json
+++ b/swagger/platform_administration/legacy/legacy_v2_settings_businesses.json
@@ -181,15 +181,16 @@
               "properties": {
                 "name": {
                   "type": "string",
-                  "description": "Display name of the business (e.g., \"Summit Peak Climate Solutions\")."
+                  "description": "Display name of the business (e.g., \"Summit Peak Climate Solutions\"). Max 100 characters; no HTML tags or newlines; must be non-empty and not a restricted/reserved word — otherwise rejected with 422.",
+                  "maxLength": 100
                 },
                 "address": {
                   "type": "string",
-                  "description": "The business's physical street address as free text. Geocoded server-side into the read-only `structured_address`; send a real, resolvable address (e.g., \"233 S Wacker Dr, Chicago, IL 60606, USA\")."
+                  "description": "The business's physical street address as free text. Geocoded server-side into the read-only `structured_address`; send a real, resolvable address (e.g., \"233 S Wacker Dr, Chicago, IL 60606, USA\"). HTML is stripped; no length limit is enforced on this endpoint."
                 },
                 "billing_address": {
                   "type": "string",
-                  "description": "The billing address as free text, used on invoices and estimates (e.g., \"233 S Wacker Dr, Chicago, IL 60606, USA\")."
+                  "description": "The billing address as free text, used on invoices and estimates (e.g., \"233 S Wacker Dr, Chicago, IL 60606, USA\"). HTML is stripped."
                 },
                 "business_description": {
                   "type": "string",
@@ -214,7 +215,23 @@
                 },
                 "locale": {
                   "type": "string",
-                  "description": "The business locale / language (e.g., \"en\", \"es\")."
+                  "description": "The business locale / language (e.g., \"en\", \"es\"). Must be one of the supported locales; invalid values are rejected with 422.",
+                  "enum": [
+                    "en",
+                    "he",
+                    "es",
+                    "pl",
+                    "fr",
+                    "it",
+                    "pt",
+                    "de",
+                    "nl",
+                    "en-GB",
+                    "zh-SG",
+                    "lv",
+                    "keys",
+                    "pseudo"
+                  ]
                 },
                 "sender_name": {
                   "type": "string",


### PR DESCRIPTION
Follow-up to #308 (which added the `/v2/settings/businesses/{business_uid}` legacy swagger). This enriches the docs to match the live API and Core-enforced validation.

## What changed
- **Enriched GET/PUT `200` examples** from a 9-field subset to the full response shape returned by the live API (profession, currency, locale, owner, branding, invoice/estimate terms, tax + waitlist + pdf-customization settings, google_redirect, `vcita_payments_*`, …). Values sanitized; `api_token` intentionally omitted.
- **Documented PUT request-body validation**, sourced by tracing Core (`Api::V2::Settings::BusinessesController#update` → `BusinessesAPI.update_business_attributes` → `Business` model + `BusinessBaseValidator`):
  - `name` — `maxLength: 100` (no HTML/newlines, non-empty, no reserved words)
  - `business_description` — `maxLength: 255`
  - `locale` — `enum` of supported locales (`en, he, es, pl, fr, it, pt, de, nl, en-GB, zh-SG, lv, keys, pseudo`)
  - `address` / `billing_address` — HTML-stripped, geocoded server-side; no length limit enforced on this endpoint

## Why
An AI-agent integration hit a **422** updating `business_description` with a ~700-char draft — Core caps it at 255. Only `name`, `business_description`, and `locale` are hard-validated on this update path; the constraints are now explicit in the contract so integrators (and the published hub) reflect reality.

## Note
`mcp_swagger` regeneration (`npm run unify && npm run update-readme`) is **not** included here — it should run as the normal generate step so the published hub picks up these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)