### PR TITLE
docs(search): document the two client-activity date filters and the matters response

### DIFF
--- a/swagger/clients/search.json
+++ b/swagger/clients/search.json
@@ -531,6 +531,118 @@
             "description": "Human-readable error message."
           }
         }
+      },
+      "MatterSearchHit": {
+        "type": "object",
+        "description": "A matter-based client row, returned in `matters` when `new_decoration=true`. A matter is a contact plus a relationship facet, and is the record the client card represents.",
+        "properties": {
+          "matter_uid": {
+            "type": "string",
+            "description": "Unique identifier of the matter (e.g., \"n0mumippp00vlwtu\")."
+          },
+          "matter_name": {
+            "type": "string",
+            "description": "Name of the matter (e.g., \"Maya Collins\")."
+          },
+          "contact_uid": {
+            "type": "string",
+            "description": "Unique identifier of the contact behind the matter (e.g., \"xgng9vk6yxltv0gh\")."
+          },
+          "contact_full_name": {
+            "type": "string",
+            "description": "Contact's full name. Respects staff permissions for last-name visibility (e.g., \"Maya Collins\")."
+          },
+          "contact_email": {
+            "type": "string",
+            "nullable": true,
+            "description": "Contact's email address. Null when the requesting staff cannot view emails (e.g., \"maya@example.com\")."
+          },
+          "phone_to_display": {
+            "type": "string",
+            "nullable": true,
+            "description": "Contact's display phone number. Null when the requesting staff cannot view phones (e.g., \"+15551234567\")."
+          },
+          "contact_status": {
+            "type": "string",
+            "description": "Current status of the contact (e.g., \"lead\", \"customer\", \"loyal\", \"inactive\")."
+          },
+          "tags": {
+            "type": "string",
+            "description": "Space-separated tags applied to the matter (e.g., \"vip New\")."
+          },
+          "contact_address": {
+            "type": "string",
+            "nullable": true,
+            "description": "Contact's address (e.g., \"New York, NY\")."
+          },
+          "review_score": {
+            "type": "number",
+            "nullable": true,
+            "description": "Latest review score left by the client (e.g., 5)."
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "When the matter was created, in ISO 8601 format (e.g., \"2026-06-19T17:17:35.000Z\")."
+          },
+          "last_activity_time": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "description": "Timestamp of the **client's own** most recent activity — any activity except messages the business sent. This is the value the client card shows as \"Last active on\", and the field `search_filter[last_client_activity_filter]` ranges over. Null when the client has never been active (e.g., \"2026-08-12T00:00:00.000Z\")."
+          },
+          "last_activity_action": {
+            "type": "string",
+            "nullable": true,
+            "description": "Human-readable label for the most recent activity, when the business has the last-activity capability enabled (e.g., \"Booked an appointment\")."
+          },
+          "last_interaction": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "description": "Timestamp of the most recent message in **either** direction, including messages sent by the business — so a staff reply advances it while `last_activity_time` stays put. The field `search_filter[last_interaction_filter]` ranges over this one (e.g., \"2026-08-12T13:08:52.000Z\")."
+          },
+          "custom_fields": {
+            "type": "object",
+            "additionalProperties": true,
+            "description": "Custom field values keyed by field UID."
+          },
+          "calculated_fields": {
+            "type": "object",
+            "additionalProperties": true,
+            "description": "Aggregated counters for the matter, such as open payments, pending estimates, and scheduled bookings."
+          }
+        },
+        "example": {
+          "matter_uid": "n0mumippp00vlwtu",
+          "matter_name": "Maya Collins",
+          "contact_uid": "xgng9vk6yxltv0gh",
+          "contact_full_name": "Maya Collins",
+          "contact_email": "maya@example.com",
+          "phone_to_display": "+15551234567",
+          "contact_status": "customer",
+          "tags": "vip",
+          "created_at": "2026-06-19T17:17:35.000Z",
+          "last_activity_time": "2026-08-12T00:00:00.000Z",
+          "last_interaction": "2026-08-12T13:08:52.000Z"
+        }
+      },
+      "MatterSearchResult": {
+        "type": "object",
+        "description": "Client search response when `new_decoration=true`.",
+        "properties": {
+          "counts": {
+            "type": "integer",
+            "description": "Total number of matching clients across all pages — use this for totals rather than the length of `matters` (e.g., 16)."
+          },
+          "matters": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MatterSearchHit"
+            },
+            "description": "The current page of matching matter rows (length <= `per_page`)."
+          }
+        }
       }
     },
     "securitySchemes": {
@@ -713,7 +825,7 @@
           {
             "name": "sort_by",
             "in": "query",
-            "description": "Field to sort results by for **general search only** (when `entity` is not set). The value is mapped through a column identifier mapping for client card fields, or used directly if no mapping exists. **Not applicable to appointment or event searches** — use `search_filter[sort_type]` and `search_filter[sort_order]` instead.",
+            "description": "Field to sort results by for **general search only** (when `entity` is not set). The value is mapped through a column identifier mapping for client card fields, or used directly if no mapping exists. For client searches the activity sort keys mirror the two activity filters: `last_client_activity` orders by the client's own activity (most recently active first with `sort_order=desc`), while `last_interaction` — the default — orders by the last message in either direction. Use the key that matches the filter you applied so the ordering and the dates shown agree. Other common values: `created_at`. **Not applicable to appointment or event searches** — use `search_filter[sort_type]` and `search_filter[sort_order]` instead.",
             "required": false,
             "schema": {
               "type": "string"
@@ -766,7 +878,7 @@
           {
             "name": "new_decoration",
             "in": "query",
-            "description": "When set to `true`, uses the newer matter-based client decoration format. The response will contain `counts` and `matters` instead of the default `top_hits` format for client results.",
+            "description": "When set to `true`, uses the newer matter-based client decoration format. The response will contain `counts` and `matters` (an array of `MatterSearchHit`) instead of the default `top_hits` format for client results.",
             "required": false,
             "schema": {
               "type": "string",
@@ -839,17 +951,60 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "search_filter[last_client_activity_filter][range][gte]",
+            "in": "query",
+            "required": false,
+            "description": "Earliest client-activity date to include, as `YYYY-MM-DD` (e.g., \"2026-07-30\"). Matches the client's own activity — any activity except messages the business sent — which is the value returned as `last_activity_time`. Use this for \"active in the last N days\", \"no activity since\", and \"when were they last active\" questions. **Two different activity dates exist — pick by intent.** `last_client_activity_filter` matches activity by the *client* (any activity except messages the business sent) and is the field reported as `last_activity_time`, the same value the client card shows as \"Last active on\". `last_interaction_filter` matches the last message in *either* direction, so a reply sent by staff advances it. Filtering on `last_interaction_filter` while displaying `last_activity_time` yields records whose shown date falls outside the requested range.",
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          },
+          {
+            "name": "search_filter[last_client_activity_filter][range][lte]",
+            "in": "query",
+            "required": false,
+            "description": "Latest client-activity date to include, as `YYYY-MM-DD` (e.g., \"2026-08-13\"). Pair with `[gte]` to bound a range; send alone for \"no activity since\" queries.",
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          },
+          {
+            "name": "search_filter[last_interaction_filter][range][gte]",
+            "in": "query",
+            "required": false,
+            "description": "Earliest last-message date to include, as `YYYY-MM-DD` (e.g., \"2026-07-30\"). Matches the most recent message in either direction, including messages sent by the business, and is the value returned as `last_interaction`. Use it only for correspondence questions (\"last time we messaged them\"), not as a stand-in for client activity. **Two different activity dates exist — pick by intent.** `last_client_activity_filter` matches activity by the *client* (any activity except messages the business sent) and is the field reported as `last_activity_time`, the same value the client card shows as \"Last active on\". `last_interaction_filter` matches the last message in *either* direction, so a reply sent by staff advances it. Filtering on `last_interaction_filter` while displaying `last_activity_time` yields records whose shown date falls outside the requested range.",
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          },
+          {
+            "name": "search_filter[last_interaction_filter][range][lte]",
+            "in": "query",
+            "required": false,
+            "description": "Latest last-message date to include, as `YYYY-MM-DD` (e.g., \"2026-08-13\"). Pair with `[gte]` to bound a range.",
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
           }
         ],
         "responses": {
           "200": {
-            "description": "Search completed successfully. The response format depends on the `entity` parameter:\n- **General search** (no entity): Returns `SearchResult` with `top_hits` and `counts`.\n- **entity=appointment**: Returns `AppointmentSearchResponse` with decorated appointments.\n- **entity=event_instance**: Returns `EventSearchResponse` with decorated events.",
+            "description": "Search completed successfully. The response format depends on the `entity` parameter:\n- **General search** (no entity): Returns `SearchResult` with `top_hits` and `counts`.\n- **entity=appointment**: Returns `AppointmentSearchResponse` with decorated appointments.\n- **entity=event_instance**: Returns `EventSearchResponse` with decorated events.\n- **new_decoration=true** (client search): Returns `MatterSearchResult` with `counts` and `matters`.",
             "content": {
               "application/json": {
                 "schema": {
                   "oneOf": [
                     {
                       "$ref": "#/components/schemas/SearchResult"
+                    },
+                    {
+                      "$ref": "#/components/schemas/MatterSearchResult"
                     },
                     {
                       "$ref": "#/components/schemas/AppointmentSearchResponse"


### PR DESCRIPTION
## Why

`GET /v2/search` documented 27 parameters but **neither activity date filter**. That left callers relying on the per-business filter catalog — which exposes a single activity row labelled **"Last activity time"** whose key is `last_interaction_filter`, the field that does *not* back the "Last active on" value shown on the client card. Following that label produces results whose displayed date falls outside the requested range.

This was found by a real consumer hitting exactly that trap: filtering `last_interaction_filter` for "clients active in the last 2 weeks", then rendering `last_activity_time`, and returning a client whose only in-window event was a staff-sent message.

## Verified through the search path, not inferred

- **`seeker/lib/searcher.rb:152-154`** dispatches the two filters to two distinct ES fields:
  ```ruby
  apply_date_filter(search_filter[:last_client_activity_filter], _, 'last_client_activity')
  apply_date_filter(search_filter[:last_interaction_filter],     _, 'last_interaction')
  ```
- **`seeker/app/models/client.rb:365-384`** populates them differently — `last_interaction` is the max time over `message_business_created` **and** `message_client_created`, while `last_client_activity` takes the most recent activity **excluding** `message_business_created`. So a message the business sends advances `last_interaction` but not `last_client_activity`.
- **`core/modules/search/app/decorators/matter_search_decorator.rb:187-226`** reports `last_activity_time` from `latest_client_activity[0].time` and `last_interaction` from the message-based field.

Observed in live responses, consistent with the above:

| | `last_activity_time` | `last_interaction` |
|---|---|---|
| client with a later staff reply | `2026-08-12T00:00:00Z` | `2026-08-12T13:08:52Z` |
| client who was never active | `null` | `2026-07-04T15:49:28Z` |

## What this adds

1. **Four range parameters** — `search_filter[last_client_activity_filter][range][gte|lte]` and `search_filter[last_interaction_filter][range][gte|lte]` — each stating which question it answers, with an explicit warning about the mismatch that mixing them causes.
2. **Activity sort keys on `sort_by`** — `last_client_activity` vs `last_interaction` (the default) — so ordering can be kept consistent with the filter applied.
3. **`MatterSearchHit` / `MatterSearchResult`** — the `new_decoration=true` response shape, previously undocumented even though the `new_decoration` parameter already promised `counts` and `matters`. This is where the two activity fields are defined with their precise semantics, alongside the identity, status, and tag fields the rows actually carry. Wired into the `200` `oneOf` and its description.

## Verification

- Valid JSON; `openapi` version and all existing parameters untouched.
- `npm run unify:dry-run` processes `search.json` with no errors and writes nothing.
- **`mcp_swagger/` is untouched** — it is script-generated and run manually.
- Field examples taken from live responses.

## Known gaps left for separate passes

- `created_at_filter` and several other `search_filter` keys seeker accepts are still undocumented here (same range shape).
- This file declares `openapi: 3.0.0` where the house convention is `3.0.3`.

## Note for the platform owners

The mislabel is upstream, in core's `view_filters` catalog: one activity row, labelled "Last activity time", keyed `last_interaction_filter`. That will mislead every consumer of this API regardless of this documentation. Worth correcting there, and/or exposing `last_client_activity_filter` as its own catalog row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)