### PR TITLE
VCITA2-15400 docs(ai): document display.body_markdown on AIRecommendedAction

### DIFF
--- a/entities/ai/AIRecommendedAction.json
+++ b/entities/ai/AIRecommendedAction.json
@@ -13,11 +13,15 @@
       },
       "display": {
         "type": "object",
-        "description": "Contains display-related information for the recommendation.",
+        "description": "Presentation-only information for the recommendation.",
         "properties": {
           "btn_text": {
             "type": "string",
-            "description": "A human-readable title describing the recommendation."
+            "description": "Label for the control that triggers the action (e.g., \"Generate Reply\")."
+          },
+          "body_markdown": {
+            "type": "string",
+            "description": "Markdown describing what the action proposes, for the consumer to render. Optional and available for every action type; absent is valid, and the consumer decides how to present the recommendation without it. Presentation only - execution always reads `payload`, never this field, so a mismatch between the two is a producer bug. Consumers must sanitise it before rendering it as markup. Not a copy of `reason`: `reason` explains why the recommendation surfaced (e.g., \"**Suggested reply:**\\n\\nHi Elizabeth - Friday 6:00PM works for a 2 hour slot.\")."
           }
         }
       },
@@ -46,7 +50,8 @@
       "uid": "act-456",
       "action": "reply",
       "display": {
-        "btn_text": "Generate Reply"
+        "btn_text": "Generate Reply",
+        "body_markdown": "**Suggested reply:**\n\nHi Elizabeth - Friday 6:00PM works for a 2 hour slot."
       },
       "reason": "User needs clarification on pricing",
       "evidence": ["User asked for price estimate"],

--- a/entities/ai/md/AIRecommendedAction.md
+++ b/entities/ai/md/AIRecommendedAction.md
@@ -7,26 +7,19 @@ Represents a recommended action based on AI analysis.
 | Name | Description | Type | Required |
 | --- | --- | --- | --- |
 | uid | A unique identifier for the recommended action. | string | Yes |
-| action | The type of action recommended. Possible values:<br />- 'reply': Suggests responding to a user message.<br />- 'estimate': Suggests providing a price estimate.<br />- 'schedule': Suggests scheduling an appointment or meeting.<br />- 'acknowledge': No action or artifact is prepared; the user reviews the item and then completes or dismisses it. | string (enum: `reply`, `estimate`, `schedule`, `acknowledge`) | Yes |
-| display | Contains display-related information for the recommendation. | object |  |
+| action | The type of action recommended. Possible values:<br />- 'reply': Suggests responding to a user message.<br />- 'estimate': Suggests providing a price estimate.<br />- 'schedule': Suggests scheduling an appointment or meeting.<br />- 'acknowledge': No action or artifact is prepared; the user reviews the item and then completes or dismisses it.<br />- 'chat_with_bizai': Hands the item off to BizAI (the business AI chat assistant) to handle on the user's behalf. | string (enum: `reply`, `estimate`, `schedule`, `acknowledge`, `chat_with_bizai`) | Yes |
+| display | Presentation-only information for the recommendation. | object |  |
 | reason | The reason why this action is recommended, providing context for decision-making. | string |  |
 | payload | Additional data related to the recommended action. The structure depends on the action type. | object |  |
 | evidence | A list of supporting statements or facts justifying the recommendation. | array of strings |  |
-| context | The context in which the recommendation was generated. | object |  |
 | confidence | A confidence score (0-1) indicating how confident the AI is in this recommendation. | number |  |
 
 ### Display Properties
 
 | Name | Description | Type | Required |
 | --- | --- | --- | --- |
-| btn_text | A human-readable title describing the recommendation. | string |  |
-
-### Context Properties
-
-| Name | Description | Type | Required |
-| --- | --- | --- | --- |
-| context_uid | A unique identifier for the context associated with this recommendation. | string |  |
-| context_type | The type of context (e.g., 'matter','client', 'business'). | string (enum: `matter`, `client`, `business`) |  |
+| btn_text | Label for the control that triggers the action (e.g., "Generate Reply"). | string |  |
+| body_markdown | Markdown describing what the action proposes, for the consumer to render. Optional and available for every action type; absent is valid, and the consumer decides how to present the recommendation without it. Presentation only - execution always reads `payload`, never this field, so a mismatch between the two is a producer bug. Consumers must sanitise it before rendering it as markup. Not a copy of `reason`: `reason` explains why the recommendation surfaced (e.g., "**Suggested reply:**\n\nHi Elizabeth - Friday 6:00PM works for a 2 hour slot."). | string |  |
 
 ## Example
 
@@ -37,7 +30,8 @@ JSON
   "uid": "act-456",
   "action": "reply",
   "display": {
-    "btn_text": "Generate Reply"
+    "btn_text": "Generate Reply",
+    "body_markdown": "**Suggested reply:**\n\nHi Elizabeth - Friday 6:00PM works for a 2 hour slot."
   },
   "reason": "User needs clarification on pricing",
   "evidence": [
@@ -46,9 +40,6 @@ JSON
   "payload": {
     "message": "Hi please send some more details"
   },
-  "context": {
-    "context_uid": "ctx-456",
-    "context_type": "client"
-  }
+  "confidence": 0.85
 }
 ```

--- a/swagger/ai/recommendations.json
+++ b/swagger/ai/recommendations.json
@@ -530,12 +530,20 @@
           },
           "display": {
             "type": "object",
-            "description": "Contains display-related information for the recommendation.",
+            "description": "Presentation-only information for the recommendation.",
             "properties": {
               "btn_text": {
                 "type": "string",
-                "description": "A human-readable title describing the recommendation."
+                "description": "Label for the control that triggers the action (e.g., \"Generate Reply\")."
+              },
+              "body_markdown": {
+                "type": "string",
+                "description": "Markdown describing what the action proposes, for the consumer to render. Optional and available for every action type; absent is valid, and the consumer decides how to present the recommendation without it. Presentation only - execution always reads `payload`, never this field, so a mismatch between the two is a producer bug. Consumers must sanitise it before rendering it as markup. Not a copy of `reason`: `reason` explains why the recommendation surfaced (e.g., \"**Suggested reply:**\\n\\nHi Elizabeth - Friday 6:00PM works for a 2 hour slot.\")."
               }
+            },
+            "example": {
+              "btn_text": "Generate Reply",
+              "body_markdown": "**Suggested reply:**\n\nHi Elizabeth - Friday 6:00PM works for a 2 hour slot."
             }
           },
           "reason": {


### PR DESCRIPTION
Add the optional markdown card-body field to the AIRecommendedAction entity and the AIRecommendationActionRequest schema, with the contract rules: optional, all action types, presentation-only (execution reads payload), consumer sanitises before render, not a copy of reason.

Also fixes btn_text's description, which was copy-pasted from title. Regenerates entities/ai/md/AIRecommendedAction.md.