### PR TITLE
docs(feature-flags): rename the work order flag and add promote (SUPPORT-13318)

### DIFF
--- a/api-validation/docs/packagable-feature-flags.md
+++ b/api-validation/docs/packagable-feature-flags.md
@@ -49,7 +49,6 @@ detailed_reports
 disable_messages_notifications
 documents_enabled
 documents quota logic
-eligible_for_work_order
 enable_client_status_customization
 enable_forms_customization
 enable_reviews_auto_publishing
@@ -98,6 +97,8 @@ pkg.crm.limit_bulk_actions
 pkg.documents.promote
 pkg.marketing.promote
 pkg.payments.promote
+pkg.payments.work_order
+pkg.payments.work_order.promote
 pkg.sch.resources
 pro_campaigns
 purchase_sms_credits


### PR DESCRIPTION
```
  eligible_for_work_order -> pkg.payments.work_order
  pkg.payments.work_order.promote (new)
```

The first means the business has the work order feature; the second means it is shown an upgrade offer instead. Neither means the option is hidden, which is what partners who do not sell work orders need.