### PR TITLE
VCITA2-15616: credit note line tax_total is optional on create

### DIFF
--- a/entities/payments/creditNote.json
+++ b/entities/payments/creditNote.json
@@ -19,7 +19,7 @@
         },
         "total_amount": {
           "type": "number",
-          "description": "Line item total amount. Optional on create: when supplied it is stored as-is, which credits a line whose total is not divisible by its quantity (e.g., 100.00 over a quantity of 3). When omitted it is calculated as quantity × unit_amount"
+          "description": "Line item total amount (quantity × unit_amount). Auto-calculated, read-only"
         },
         "taxes": {
           "type": "array",

--- a/entities/payments/creditNote.json
+++ b/entities/payments/creditNote.json
@@ -19,7 +19,7 @@
         },
         "total_amount": {
           "type": "number",
-          "description": "Line item total amount (quantity × unit_amount). Auto-calculated, read-only"
+          "description": "Line item total amount. Optional on create: when supplied it is stored as-is, which credits a line whose total is not divisible by its quantity (e.g., 100.00 over a quantity of 3). When omitted it is calculated as quantity × unit_amount"
         },
         "taxes": {
           "type": "array",
@@ -45,10 +45,10 @@
         },
         "tax_total": {
           "type": "number",
-          "description": "Tax total amount"
+          "description": "Tax total amount. On a line item it is optional on create: when supplied it is stored as-is, so the credit note credits the tax the source invoice charged (e.g., 2.47 where the invoice rounded per tax group); when omitted or 0 it is calculated from the line net and the rate"
         }
       },
-      "required": ["name", "rate", "tax_total"]
+      "required": ["name", "rate"]
     }
   },
   "properties": {

--- a/mcp_swagger/sales.json
+++ b/mcp_swagger/sales.json
@@ -17122,9 +17122,8 @@
                   "line_items": [
                     {
                       "name": "Consulting Services Credit",
-                      "quantity": 3,
-                      "unit_amount": 16.67,
-                      "total_amount": 50,
+                      "quantity": 1,
+                      "unit_amount": 50,
                       "taxes": [
                         {
                           "name": "VAT",

--- a/mcp_swagger/sales.json
+++ b/mcp_swagger/sales.json
@@ -16741,7 +16741,7 @@
                                       },
                                       "total_amount": {
                                         "type": "number",
-                                        "description": "Line item total amount (quantity × unit_amount). Auto-calculated, read-only"
+                                        "description": "Line item total amount. Optional on create: when supplied it is stored as-is, which credits a line whose total is not divisible by its quantity (e.g., 100.00 over a quantity of 3). When omitted it is calculated as quantity × unit_amount"
                                       },
                                       "taxes": {
                                         "type": "array",
@@ -16760,13 +16760,12 @@
                                             },
                                             "tax_total": {
                                               "type": "number",
-                                              "description": "Tax total amount"
+                                              "description": "Tax total amount. On a line item it is optional on create: when supplied it is stored as-is, so the credit note credits the tax the source invoice charged (e.g., 2.47 where the invoice rounded per tax group); when omitted or 0 it is calculated from the line net and the rate"
                                             }
                                           },
                                           "required": [
                                             "name",
-                                            "rate",
-                                            "tax_total"
+                                            "rate"
                                           ]
                                         }
                                       }
@@ -16861,7 +16860,7 @@
                                         },
                                         "total_amount": {
                                           "type": "number",
-                                          "description": "Line item total amount (quantity × unit_amount). Auto-calculated, read-only"
+                                          "description": "Line item total amount. Optional on create: when supplied it is stored as-is, which credits a line whose total is not divisible by its quantity (e.g., 100.00 over a quantity of 3). When omitted it is calculated as quantity × unit_amount"
                                         },
                                         "taxes": {
                                           "type": "array",
@@ -16880,13 +16879,12 @@
                                               },
                                               "tax_total": {
                                                 "type": "number",
-                                                "description": "Tax total amount"
+                                                "description": "Tax total amount. On a line item it is optional on create: when supplied it is stored as-is, so the credit note credits the tax the source invoice charged (e.g., 2.47 where the invoice rounded per tax group); when omitted or 0 it is calculated from the line net and the rate"
                                               }
                                             },
                                             "required": [
                                               "name",
-                                              "rate",
-                                              "tax_total"
+                                              "rate"
                                             ]
                                           }
                                         }
@@ -16933,13 +16931,12 @@
                                         },
                                         "tax_total": {
                                           "type": "number",
-                                          "description": "Tax total amount"
+                                          "description": "Tax total amount. On a line item it is optional on create: when supplied it is stored as-is, so the credit note credits the tax the source invoice charged (e.g., 2.47 where the invoice rounded per tax group); when omitted or 0 it is calculated from the line net and the rate"
                                         }
                                       },
                                       "required": [
                                         "name",
-                                        "rate",
-                                        "tax_total"
+                                        "rate"
                                       ]
                                     }
                                   }
@@ -17066,7 +17063,7 @@
                         },
                         "total_amount": {
                           "type": "number",
-                          "description": "Line item total amount (quantity × unit_amount). Auto-calculated, read-only"
+                          "description": "Line item total amount. Optional on create: when supplied it is stored as-is, which credits a line whose total is not divisible by its quantity (e.g., 100.00 over a quantity of 3). When omitted it is calculated as quantity × unit_amount"
                         },
                         "taxes": {
                           "type": "array",
@@ -17085,13 +17082,12 @@
                               },
                               "tax_total": {
                                 "type": "number",
-                                "description": "Tax total amount"
+                                "description": "Tax total amount. On a line item it is optional on create: when supplied it is stored as-is, so the credit note credits the tax the source invoice charged (e.g., 2.47 where the invoice rounded per tax group); when omitted or 0 it is calculated from the line net and the rate"
                               }
                             },
                             "required": [
                               "name",
-                              "rate",
-                              "tax_total"
+                              "rate"
                             ]
                           }
                         }
@@ -17126,8 +17122,9 @@
                   "line_items": [
                     {
                       "name": "Consulting Services Credit",
-                      "quantity": 1,
-                      "unit_amount": 50,
+                      "quantity": 3,
+                      "unit_amount": 16.67,
+                      "total_amount": 50,
                       "taxes": [
                         {
                           "name": "VAT",
@@ -17226,7 +17223,7 @@
                                 },
                                 "total_amount": {
                                   "type": "number",
-                                  "description": "Line item total amount (quantity × unit_amount). Auto-calculated, read-only"
+                                  "description": "Line item total amount. Optional on create: when supplied it is stored as-is, which credits a line whose total is not divisible by its quantity (e.g., 100.00 over a quantity of 3). When omitted it is calculated as quantity × unit_amount"
                                 },
                                 "taxes": {
                                   "type": "array",
@@ -17245,13 +17242,12 @@
                                       },
                                       "tax_total": {
                                         "type": "number",
-                                        "description": "Tax total amount"
+                                        "description": "Tax total amount. On a line item it is optional on create: when supplied it is stored as-is, so the credit note credits the tax the source invoice charged (e.g., 2.47 where the invoice rounded per tax group); when omitted or 0 it is calculated from the line net and the rate"
                                       }
                                     },
                                     "required": [
                                       "name",
-                                      "rate",
-                                      "tax_total"
+                                      "rate"
                                     ]
                                   }
                                 }
@@ -17346,7 +17342,7 @@
                                   },
                                   "total_amount": {
                                     "type": "number",
-                                    "description": "Line item total amount (quantity × unit_amount). Auto-calculated, read-only"
+                                    "description": "Line item total amount. Optional on create: when supplied it is stored as-is, which credits a line whose total is not divisible by its quantity (e.g., 100.00 over a quantity of 3). When omitted it is calculated as quantity × unit_amount"
                                   },
                                   "taxes": {
                                     "type": "array",
@@ -17365,13 +17361,12 @@
                                         },
                                         "tax_total": {
                                           "type": "number",
-                                          "description": "Tax total amount"
+                                          "description": "Tax total amount. On a line item it is optional on create: when supplied it is stored as-is, so the credit note credits the tax the source invoice charged (e.g., 2.47 where the invoice rounded per tax group); when omitted or 0 it is calculated from the line net and the rate"
                                         }
                                       },
                                       "required": [
                                         "name",
-                                        "rate",
-                                        "tax_total"
+                                        "rate"
                                       ]
                                     }
                                   }
@@ -17418,13 +17413,12 @@
                                   },
                                   "tax_total": {
                                     "type": "number",
-                                    "description": "Tax total amount"
+                                    "description": "Tax total amount. On a line item it is optional on create: when supplied it is stored as-is, so the credit note credits the tax the source invoice charged (e.g., 2.47 where the invoice rounded per tax group); when omitted or 0 it is calculated from the line net and the rate"
                                   }
                                 },
                                 "required": [
                                   "name",
-                                  "rate",
-                                  "tax_total"
+                                  "rate"
                                 ]
                               }
                             }
@@ -17600,7 +17594,7 @@
                                 },
                                 "total_amount": {
                                   "type": "number",
-                                  "description": "Line item total amount (quantity × unit_amount). Auto-calculated, read-only"
+                                  "description": "Line item total amount. Optional on create: when supplied it is stored as-is, which credits a line whose total is not divisible by its quantity (e.g., 100.00 over a quantity of 3). When omitted it is calculated as quantity × unit_amount"
                                 },
                                 "taxes": {
                                   "type": "array",
@@ -17619,13 +17613,12 @@
                                       },
                                       "tax_total": {
                                         "type": "number",
-                                        "description": "Tax total amount"
+                                        "description": "Tax total amount. On a line item it is optional on create: when supplied it is stored as-is, so the credit note credits the tax the source invoice charged (e.g., 2.47 where the invoice rounded per tax group); when omitted or 0 it is calculated from the line net and the rate"
                                       }
                                     },
                                     "required": [
                                       "name",
-                                      "rate",
-                                      "tax_total"
+                                      "rate"
                                     ]
                                   }
                                 }
@@ -17720,7 +17713,7 @@
                                   },
                                   "total_amount": {
                                     "type": "number",
-                                    "description": "Line item total amount (quantity × unit_amount). Auto-calculated, read-only"
+                                    "description": "Line item total amount. Optional on create: when supplied it is stored as-is, which credits a line whose total is not divisible by its quantity (e.g., 100.00 over a quantity of 3). When omitted it is calculated as quantity × unit_amount"
                                   },
                                   "taxes": {
                                     "type": "array",
@@ -17739,13 +17732,12 @@
                                         },
                                         "tax_total": {
                                           "type": "number",
-                                          "description": "Tax total amount"
+                                          "description": "Tax total amount. On a line item it is optional on create: when supplied it is stored as-is, so the credit note credits the tax the source invoice charged (e.g., 2.47 where the invoice rounded per tax group); when omitted or 0 it is calculated from the line net and the rate"
                                         }
                                       },
                                       "required": [
                                         "name",
-                                        "rate",
-                                        "tax_total"
+                                        "rate"
                                       ]
                                     }
                                   }
@@ -17792,13 +17784,12 @@
                                   },
                                   "tax_total": {
                                     "type": "number",
-                                    "description": "Tax total amount"
+                                    "description": "Tax total amount. On a line item it is optional on create: when supplied it is stored as-is, so the credit note credits the tax the source invoice charged (e.g., 2.47 where the invoice rounded per tax group); when omitted or 0 it is calculated from the line net and the rate"
                                   }
                                 },
                                 "required": [
                                   "name",
-                                  "rate",
-                                  "tax_total"
+                                  "rate"
                                 ]
                               }
                             }

--- a/mcp_swagger/sales.json
+++ b/mcp_swagger/sales.json
@@ -16741,7 +16741,7 @@
                                       },
                                       "total_amount": {
                                         "type": "number",
-                                        "description": "Line item total amount. Optional on create: when supplied it is stored as-is, which credits a line whose total is not divisible by its quantity (e.g., 100.00 over a quantity of 3). When omitted it is calculated as quantity × unit_amount"
+                                        "description": "Line item total amount (quantity × unit_amount). Auto-calculated, read-only"
                                       },
                                       "taxes": {
                                         "type": "array",
@@ -16860,7 +16860,7 @@
                                         },
                                         "total_amount": {
                                           "type": "number",
-                                          "description": "Line item total amount. Optional on create: when supplied it is stored as-is, which credits a line whose total is not divisible by its quantity (e.g., 100.00 over a quantity of 3). When omitted it is calculated as quantity × unit_amount"
+                                          "description": "Line item total amount (quantity × unit_amount). Auto-calculated, read-only"
                                         },
                                         "taxes": {
                                           "type": "array",
@@ -17063,7 +17063,7 @@
                         },
                         "total_amount": {
                           "type": "number",
-                          "description": "Line item total amount. Optional on create: when supplied it is stored as-is, which credits a line whose total is not divisible by its quantity (e.g., 100.00 over a quantity of 3). When omitted it is calculated as quantity × unit_amount"
+                          "description": "Line item total amount (quantity × unit_amount). Auto-calculated, read-only"
                         },
                         "taxes": {
                           "type": "array",
@@ -17222,7 +17222,7 @@
                                 },
                                 "total_amount": {
                                   "type": "number",
-                                  "description": "Line item total amount. Optional on create: when supplied it is stored as-is, which credits a line whose total is not divisible by its quantity (e.g., 100.00 over a quantity of 3). When omitted it is calculated as quantity × unit_amount"
+                                  "description": "Line item total amount (quantity × unit_amount). Auto-calculated, read-only"
                                 },
                                 "taxes": {
                                   "type": "array",
@@ -17341,7 +17341,7 @@
                                   },
                                   "total_amount": {
                                     "type": "number",
-                                    "description": "Line item total amount. Optional on create: when supplied it is stored as-is, which credits a line whose total is not divisible by its quantity (e.g., 100.00 over a quantity of 3). When omitted it is calculated as quantity × unit_amount"
+                                    "description": "Line item total amount (quantity × unit_amount). Auto-calculated, read-only"
                                   },
                                   "taxes": {
                                     "type": "array",
@@ -17593,7 +17593,7 @@
                                 },
                                 "total_amount": {
                                   "type": "number",
-                                  "description": "Line item total amount. Optional on create: when supplied it is stored as-is, which credits a line whose total is not divisible by its quantity (e.g., 100.00 over a quantity of 3). When omitted it is calculated as quantity × unit_amount"
+                                  "description": "Line item total amount (quantity × unit_amount). Auto-calculated, read-only"
                                 },
                                 "taxes": {
                                   "type": "array",
@@ -17712,7 +17712,7 @@
                                   },
                                   "total_amount": {
                                     "type": "number",
-                                    "description": "Line item total amount. Optional on create: when supplied it is stored as-is, which credits a line whose total is not divisible by its quantity (e.g., 100.00 over a quantity of 3). When omitted it is calculated as quantity × unit_amount"
+                                    "description": "Line item total amount (quantity × unit_amount). Auto-calculated, read-only"
                                   },
                                   "taxes": {
                                     "type": "array",

--- a/swagger/sales/creditNote.json
+++ b/swagger/sales/creditNote.json
@@ -144,8 +144,9 @@
                   "line_items": [
                     {
                       "name": "Consulting Services Credit",
-                      "quantity": 1,
-                      "unit_amount": 50,
+                      "quantity": 3,
+                      "unit_amount": 16.67,
+                      "total_amount": 50,
                       "taxes": [
                         {
                           "name": "VAT",

--- a/swagger/sales/creditNote.json
+++ b/swagger/sales/creditNote.json
@@ -144,9 +144,8 @@
                   "line_items": [
                     {
                       "name": "Consulting Services Credit",
-                      "quantity": 3,
-                      "unit_amount": 16.67,
-                      "total_amount": 50,
+                      "quantity": 1,
+                      "unit_amount": 50,
                       "taxes": [
                         {
                           "name": "VAT",


### PR DESCRIPTION
> **How to review**
>
> Documentation only, and it is one change repeated: `tax_total` stops being required on a credit-note line item's tax, and its description says what a supplied value does.
>
> 1. `entities/payments/creditNote.json` — the entity. Everything else `$ref`s this.
> 2. `mcp_swagger/sales.json` — the same shape, inlined ten times across the credit-note create and update paths. Check they all match the entity.
>
> **The one thing to check:** the description matches the service — a supplied `tax_total` is stored as-is; an omitted or `0` value is recomputed from the line net and the rate. That behaviour is einvoicing [#78](https://github.com/vcita/einvoicing/pull/78).
>
> `swagger/sales/creditNote.json` is untouched on purpose: its `line_items` is a `$ref` to the entity, so it inherits the change.

## What

- `line_items[].taxes[].tax_total` is no longer in the tax object's `required` list, and its description says a supplied value is stored as-is while an omitted or `0` value is recomputed from the line net and the rate.
- Applied in the entity and in all ten inlined copies of the line-item shape in `mcp_swagger/sales.json`.

## Why

`POST /v3/payments/credit_notes` now honours a supplied `tax_total` (einvoicing [#78](https://github.com/vcita/einvoicing/pull/78)). The docs said the opposite — `tax_total` was marked **required**, described only as "Tax total amount" — so an integrator had no way to know that sending the invoice's own per-group tax is what makes a credit note credit exactly what the invoice charged.

A per-line recompute cannot reproduce an invoice that rounded its tax once per group: the invoice's lines can read 2.48 and 2.47 where a recompute gives 2.48 twice.

## Implementation

Every inlined copy in `mcp_swagger/sales.json` is updated so the MCP spec and the published swagger agree. `total_amount` stays documented as auto-calculated and read-only — einvoicing does not accept it on create.

No endpoint, field name or type changed — only descriptions and one `required` list, which is the part that was wrong.

## Risk

Documentation only. Removing `tax_total` from `required` relaxes what a validator generated from this spec would reject, and matches the service, which treats an absent or `0` value as "recompute".

Ticket: [VCITA2-15616](https://myvcita.atlassian.net/browse/VCITA2-15616), part of [VCITA2-14581](https://myvcita.atlassian.net/browse/VCITA2-14581)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[VCITA2-15616]: https://myvcita.atlassian.net/browse/VCITA2-15616?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ