### PR TITLE
VCITA2-14581: platform v1 invoices carry net_total, tax_total, taxes and tax_mode

### DIFF
--- a/mcp_swagger/sales.json
+++ b/mcp_swagger/sales.json
@@ -2463,16 +2463,20 @@
                             "amount": 10,
                             "description": "Service Description",
                             "discount": 2,
+                            "grand_total": 8.8,
+                            "net_total": 8,
                             "quantity": 1,
                             "taxes": [
                               {
                                 "name": "10 tax",
-                                "rate": 10
+                                "rate": 10,
+                                "tax_total": 0.8
                               }
                             ],
                             "title": "Item title"
                           }
                         ],
+                        "net_total": 8,
                         "note": "Invoice for your service",
                         "payment_balance": 5,
                         "payment_state": "pending",
@@ -2484,6 +2488,15 @@
                         },
                         "staff_id": "mg9d91uh92bclwzg",
                         "status": "issued/draft",
+                        "tax_mode": "exclude",
+                        "tax_total": 0.8,
+                        "taxes": [
+                          {
+                            "name": "10 tax",
+                            "rate": 10,
+                            "tax_total": 0.8
+                          }
+                        ],
                         "title": "Invoice Title"
                       }
                     ]
@@ -2545,16 +2558,20 @@
                           "amount": 10,
                           "description": "Service Description",
                           "discount": 2,
+                          "grand_total": 8.8,
+                          "net_total": 8,
                           "quantity": 1,
                           "taxes": [
                             {
                               "name": "10 tax",
-                              "rate": 10
+                              "rate": 10,
+                              "tax_total": 0.8
                             }
                           ],
                           "title": "Service"
                         }
                       ],
+                      "net_total": 8,
                       "note": "Invoice for your service",
                       "payment_balance": 8.8,
                       "payment_state": "pending",
@@ -2566,6 +2583,15 @@
                       },
                       "staff_id": "mg9d91uh92bclwzg",
                       "status": "issued",
+                      "tax_mode": "exclude",
+                      "tax_total": 0.8,
+                      "taxes": [
+                        {
+                          "name": "10 tax",
+                          "rate": 10,
+                          "tax_total": 0.8
+                        }
+                      ],
                       "title": "INVOICE #0000097"
                     }
                   },
@@ -2781,16 +2807,20 @@
                           "amount": 10,
                           "description": "Service Description",
                           "discount": 2,
+                          "grand_total": 8.8,
+                          "net_total": 8,
                           "quantity": 1,
                           "taxes": [
                             {
                               "name": "10 tax",
-                              "rate": 10
+                              "rate": 10,
+                              "tax_total": 0.8
                             }
                           ],
                           "title": "Item title"
                         }
                       ],
+                      "net_total": 8,
                       "note": "Invoice for your service",
                       "payment_balance": 5,
                       "payment_state": "pending",
@@ -2802,6 +2832,15 @@
                       },
                       "staff_id": "mg9d91uh92bclwzg",
                       "status": "issued/draft",
+                      "tax_mode": "exclude",
+                      "tax_total": 0.8,
+                      "taxes": [
+                        {
+                          "name": "10 tax",
+                          "rate": 10,
+                          "tax_total": 0.8
+                        }
+                      ],
                       "title": "Invoice Title"
                     }
                   },

--- a/swagger/sales/legacy/legacy_v1_sales.json
+++ b/swagger/sales/legacy/legacy_v1_sales.json
@@ -746,16 +746,20 @@
                           "amount": 10,
                           "description": "Service Description",
                           "discount": 2,
+                          "grand_total": 8.8,
+                          "net_total": 8,
                           "quantity": 1,
                           "taxes": [
                             {
                               "name": "10 tax",
-                              "rate": 10
+                              "rate": 10,
+                              "tax_total": 0.8
                             }
                           ],
                           "title": "Item title"
                         }
                       ],
+                      "net_total": 8,
                       "note": "Invoice for your service",
                       "payment_balance": 5,
                       "payment_state": "pending",
@@ -767,6 +771,15 @@
                       },
                       "staff_id": "mg9d91uh92bclwzg",
                       "status": "issued/draft",
+                      "tax_mode": "exclude",
+                      "tax_total": 0.8,
+                      "taxes": [
+                        {
+                          "name": "10 tax",
+                          "rate": 10,
+                          "tax_total": 0.8
+                        }
+                      ],
                       "title": "Invoice Title"
                     }
                   ]
@@ -976,16 +989,20 @@
                         "amount": 10,
                         "description": "Service Description",
                         "discount": 2,
+                        "grand_total": 8.8,
+                        "net_total": 8,
                         "quantity": 1,
                         "taxes": [
                           {
                             "name": "10 tax",
-                            "rate": 10
+                            "rate": 10,
+                            "tax_total": 0.8
                           }
                         ],
                         "title": "Service"
                       }
                     ],
+                    "net_total": 8,
                     "note": "Invoice for your service",
                     "payment_balance": 8.8,
                     "payment_state": "pending",
@@ -997,6 +1014,15 @@
                     },
                     "staff_id": "mg9d91uh92bclwzg",
                     "status": "issued",
+                    "tax_mode": "exclude",
+                    "tax_total": 0.8,
+                    "taxes": [
+                      {
+                        "name": "10 tax",
+                        "rate": 10,
+                        "tax_total": 0.8
+                      }
+                    ],
                     "title": "INVOICE #0000097"
                   }
                 },
@@ -1073,16 +1099,20 @@
                         "amount": 10,
                         "description": "Service Description",
                         "discount": 2,
+                        "grand_total": 8.8,
+                        "net_total": 8,
                         "quantity": 1,
                         "taxes": [
                           {
                             "name": "10 tax",
-                            "rate": 10
+                            "rate": 10,
+                            "tax_total": 0.8
                           }
                         ],
                         "title": "Item title"
                       }
                     ],
+                    "net_total": 8,
                     "note": "Invoice for your service",
                     "payment_balance": 5,
                     "payment_state": "pending",
@@ -1094,6 +1124,15 @@
                     },
                     "staff_id": "mg9d91uh92bclwzg",
                     "status": "issued/draft",
+                    "tax_mode": "exclude",
+                    "tax_total": 0.8,
+                    "taxes": [
+                      {
+                        "name": "10 tax",
+                        "rate": 10,
+                        "tax_total": 0.8
+                      }
+                    ],
                     "title": "Invoice Title"
                   }
                 },


### PR DESCRIPTION
> **How to review**
>
> Documentation only. Both files get the same edit — the second is the MCP mirror of the first.
>
> 1. `swagger/sales/legacy/legacy_v1_sales.json` — the response examples for `GET /invoices`, `GET /invoices/{invoice_id}` and `POST /invoices`.
> 2. `mcp_swagger/sales.json` — the same three examples, patched by hand.
>
> **The one thing to check:** the example numbers add up. Item amount 10 − discount 2 = 8 net, 10% tax = 0.80, grand total 8.80.
>
> **Why the MCP file was hand-patched:** `npm run unify` reorders the whole file and produces a ~25k-line diff, which would bury this change.
>
> **Depends on** the Core half, PR1: [#29300](https://github.com/vcita/core/pull/29300) (merged to integration) and [#29301](https://github.com/vcita/core/pull/29301) (open on master). These fields exist on integration today and reach production with #29301.

## What

Documents four new invoice-level fields — `net_total`, `tax_total`, `taxes[]` (with `tax_total` per group) and `tax_mode` — plus per-item `net_total` and `grand_total` and `tax_total` inside each item tax, on the platform v1 invoices list, show and create responses.

## Why

Core groups an invoice's taxes and rounds each group once, then splits the cents over the lines, so applying the rate to a single line no longer reproduces the cent the invoice stores. An app reading an invoice has to take the totals Core decided rather than compute its own.

The webhook payload already carried the invoice's own tax; `GET /platform/v1/invoices` carried none of it, so an app syncing from that path applied the rate itself and landed a cent away. app-quickbooks is the first consumer to depend on this — [#879](https://github.com/vcita/app-quickbooks/pull/879).

## Implementation

- `swagger/sales/legacy/legacy_v1_sales.json` — the three response examples.
- `mcp_swagger/sales.json` — the same three, patched by hand rather than through `npm run unify`, which reorders the whole file.

The example numbers add up: item amount 10 − discount 2 = 8 net, 10% tax = 0.80, grand total 8.80.

## Risk

Documentation only. Additive fields; no existing field changed or removed.

Ticket: [VCITA2-14581](https://myvcita.atlassian.net/browse/VCITA2-14581)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[VCITA2-14581]: https://myvcita.atlassian.net/browse/VCITA2-14581?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ