### PR TITLE
docs: ai_chat_configurations — add allow_online_scheduling

### DIFF
--- a/swagger/online_presence/ai_chat_configurations.json
+++ b/swagger/online_presence/ai_chat_configurations.json
@@ -88,6 +88,12 @@
             "nullable": true,
             "description": "Whether to include terms of service in AI guidance context."
           },
+          "allow_online_scheduling": {
+            "type": "boolean",
+            "nullable": true,
+            "default": true,
+            "description": "Whether the AI receptionist may complete a booking inside the chat. Independent of the business's own online-scheduling setting \u2014 both must be on for in-chat booking to run; when off, the receptionist offers a link to the booking screen instead. Defaults to true. (e.g., true, false)"
+          },
           "guidance_urls": {
             "type": "array",
             "nullable": true,

--- a/swagger/online_presence/ai_chat_configurations.json
+++ b/swagger/online_presence/ai_chat_configurations.json
@@ -88,7 +88,7 @@
             "nullable": true,
             "description": "Whether to include terms of service in AI guidance context."
           },
-          "allow_online_scheduling": {
+          "allow_chat_based_online_scheduling": {
             "type": "boolean",
             "nullable": true,
             "default": true,


### PR DESCRIPTION
Documents the new AI Receptionist setting: whether the receptionist may complete a booking inside the chat, as opposed to offering a link to the booking screen.

Kept separate from the business's own online-scheduling setting on purpose — a business can take bookings through its portal and still want the chat to hand over rather than book. Both must be on for in-chat booking to run, so this can only ever narrow what the business already allows.

Defaults to true, so businesses that never touch it keep today's behaviour.