### PR TITLE
VCITA2-15343 Document payment_method_type and payment_method_uid filters on payment plans

### DIFF
--- a/swagger/sales/payment_plans.json
+++ b/swagger/sales/payment_plans.json
@@ -157,6 +157,29 @@
               "type": "string"
             },
             "example": "cl1cl2cl3cl4cl5c"
+          },
+          {
+            "name": "payment_method_type",
+            "required": false,
+            "in": "query",
+            "description": "Return only plans charging this kind of payment method (e.g., \"card\").",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "card"
+              ]
+            },
+            "example": "card"
+          },
+          {
+            "name": "payment_method_uid",
+            "required": false,
+            "in": "query",
+            "description": "Return only plans charging this payment method. Combine with `status=active` to check whether a card is still in use before removing it.",
+            "schema": {
+              "type": "string"
+            },
+            "example": "pm1pm2pm3pm4pm5p"
           }
         ],
         "responses": {


### PR DESCRIPTION
## What

Documents two existing query filters on `GET /v3/sales/payment_plans` in the Swagger spec:

- `payment_method_type` — return only plans charging this kind of payment method (enum: `card`)
- `payment_method_uid` — return only plans charging this payment method; combine with `status=active` to check whether a card is still in use before removing it

## Why

Keeps developers-hub in sync with the payment plans API contract (VCITA2-15343).

🤖 Generated with [Claude Code](https://claude.com/claude-code)