### PR TITLE
docs: add legacy v2 ToDo (getting started checklist) API swagger

### DIFF
--- a/swagger/platform_administration/legacy/legacy_v2_todo.json
+++ b/swagger/platform_administration/legacy/legacy_v2_todo.json
@@ -1,0 +1,1005 @@
+{
+  "basePath": "/",
+  "host": "api.vcita.biz",
+  "info": {
+    "title": "Business ToDo (Getting Started Checklist) API",
+    "version": "v2.0",
+    "description": "Endpoints for reading and updating the business's onboarding \"todo\" flags \u2014 the state behind the **Getting Started / \"Let's personalize your account\"** checklist shown in the app. Each flag is a single business-level status (`done`, `skipped`, or `null`) describing whether an onboarding step was completed or dismissed.\n\nThe checklist rows and their order are composed by the client; this API only stores and returns the per-step status. On every read the server first re-evaluates the flags against actual business data (clients imported, invoices created, payment gateway connected, staff invited, site published, \u2026) and persists any newly satisfied step, so `GET` can return values that were never explicitly written.\n\nAvailable for **Staff & Directory tokens** \u2014 a Staff token of a staff member belonging to the business, or a Directory token of the owning directory. Directory tokens MUST send the business in the `X-On-Behalf-Of` header. Writes are accepted **only from the business owner**; a request from a non-owner staff member succeeds but changes nothing and returns the current state."
+  },
+  "paths": {
+    "/v2/todo": {
+      "get": {
+        "summary": "Get the business onboarding todo flags",
+        "description": "## Overview\nReturns the full set of onboarding todo flags for the business in context.\n\nBefore responding, the server refreshes the flags from live business data \u2014 for example `todo_clients` becomes `done` once the business has more than 5 clients, `todo_invoice` once any invoice exists, `todo_payments` once a payment gateway or payment wallet app is connected, `todo_staff` once more than one staff member exists, and `todo_website` once the site has been published. The refreshed values are persisted, so the response is always the authoritative current state.\n\nAvailable for **Staff & Directory tokens**. Directory tokens MUST send the business in the `X-On-Behalf-Of` header (a Directory token without it is rejected with 403).",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "description": "The business UID to act on behalf of. Required when authenticating with a Directory token; not needed for a Staff token (e.g., \"fyclhomrzdspdyk6\").",
+            "in": "header",
+            "name": "X-On-Behalf-Of",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The business onboarding todo flags.",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "todo_tour": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "Product tour was completed. Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                },
+                "todo_activation": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "Set to `done` when the business info page of the signup flow is submitted (both the new business-info step and the old second step). It is not set when a user registers with the `slim` flag. Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                },
+                "todo_scheduling": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "Set to `done` when the business reaches the last page of the scheduling wizard (the step before success / early upgrade call). Synced with HubSpot. Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                },
+                "todo_staff": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "Set to `done` after a staff member is invited (auto-refreshed when the business has more than one staff member). Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                },
+                "todo_availability": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "Set to `done` when the business connects a calendar to vcita. Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                },
+                "todo_services": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "Set to `done` when a service is created or an existing service is updated in the settings page; in the wizard it is set only when the services page is viewed. Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                },
+                "todo_payments": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "Set to `done` when the business successfully connects a payment gateway (PayPal / Stripe / Square / Braintree) or an external payment wallet app. Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                },
+                "todo_livesite": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "Set to `done` on completion of the LiveSite walk-me, or when the LiveSite editor is loaded from Frontage. Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                },
+                "todo_website": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "Set to `done` when the website-widgets page is loaded (auto-refreshed once the site has been published). Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                },
+                "todo_clients": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "Set to `done` when the business imports clients (including Square import) or has more than 5 clients. Synced with HubSpot. Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                },
+                "todo_campaigns": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "Set to `done` when a campaign is sent, an automatic campaign is visited, or the campaign wizard is completed. Synced with HubSpot. Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                },
+                "todo_mobile_app": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "Set to `done` after login from the mobile app only. Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                },
+                "todo_client_card": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "A client card was viewed. Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                },
+                "todo_scheduling_options": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "Scheduling options were configured. Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                },
+                "todo_notifications": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "Set to `done` when the business enters the notification settings page. Setting notifications during the scheduling wizard does not mark it as done. Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                },
+                "todo_yext_connect": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "Set to `done` when the user clicks connect to Yext. Thryv only. Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                },
+                "todo_yext_listing": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "Set to `done` when the Yext listing is approved. Thryv only. Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                },
+                "todo_yext_social": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "Set to `done` when Yext social is set up. Thryv only. Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                },
+                "todo_invoice": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "Set to `done` when the first invoice is sent (auto-refreshed when the business has any invoice). Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                },
+                "todo_business_needs": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "Set to `done` when the user fills in their business intents / onboarding tiles. Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                },
+                "todo_business_info": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "Set to `done` when any of phone, address, profession or website is entered for the business. Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                },
+                "todo_social_networks": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "Set to `done` when social networks are linked. Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                },
+                "todo_claim_keyword": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "Set to `done` when an SMS keyword is claimed (Zipwhip). Thryv only. Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                },
+                "todo_online_reputation": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "Set to `done` when the business connects to Soci. Thryv only. Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                },
+                "todo_estimate_with_deposit": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "Set to `done` once the business has an estimate that carries a deposit. Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                },
+                "todo_pdf_customization": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "PDF customization was configured. Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                },
+                "todo_scheduled_payments": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "A scheduled payment was set up. Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                },
+                "todo_tips_new_payment": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "The 'new payment' tip was seen. Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                },
+                "todo_tips_take_payment": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "The 'take payment' tip was seen. Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                },
+                "todo_tips_close_balance": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "The 'close balance' tip was seen. Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                },
+                "todo_tips_request_payment": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "The 'request payment' tip was seen. Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                }
+              }
+            },
+            "examples": {
+              "application/json": {
+                "todo_tour": null,
+                "todo_activation": "done",
+                "todo_scheduling": null,
+                "todo_staff": "done",
+                "todo_availability": null,
+                "todo_services": "done",
+                "todo_payments": "done",
+                "todo_livesite": "done",
+                "todo_website": "done",
+                "todo_clients": "done",
+                "todo_campaigns": "skipped",
+                "todo_mobile_app": "done",
+                "todo_client_card": null,
+                "todo_scheduling_options": null,
+                "todo_notifications": null,
+                "todo_yext_connect": null,
+                "todo_yext_listing": null,
+                "todo_yext_social": null,
+                "todo_invoice": "done",
+                "todo_business_needs": null,
+                "todo_business_info": "done",
+                "todo_social_networks": null,
+                "todo_claim_keyword": null,
+                "todo_online_reputation": null,
+                "todo_estimate_with_deposit": null,
+                "todo_pdf_customization": null,
+                "todo_scheduled_payments": null,
+                "todo_tips_new_payment": null,
+                "todo_tips_take_payment": null,
+                "todo_tips_close_balance": null,
+                "todo_tips_request_payment": null
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid access token."
+          },
+          "403": {
+            "description": "The token is not allowed to access this business \u2014 for example a Directory token sent without the `X-On-Behalf-Of` header, or a staff member without admin account access."
+          }
+        }
+      },
+      "put": {
+        "summary": "Update the business onboarding todo flags",
+        "description": "## Overview\nUpdates one or more onboarding todo flags for the business in context. Send only the flags you want to change; omitted flags keep their current value. The full, refreshed flag set is returned.\n\nAllowed values are `done` and `skipped` (`skipped` marks a step the business explicitly dismissed in the checklist). Sending any other value is rejected with 422.\n\n**Only the business owner may write.** A request from a staff member who is not the owner is accepted and returns 200, but no flag is changed.\n\nAvailable for **Staff & Directory tokens**. Directory tokens MUST send the business in the `X-On-Behalf-Of` header (a Directory token without it is rejected with 403).",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "description": "The business UID to act on behalf of. Required when authenticating with a Directory token; not needed for a Staff token (e.g., \"fyclhomrzdspdyk6\").",
+            "in": "header",
+            "name": "X-On-Behalf-Of",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "description": "The todo flags to update. Every property is optional.",
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "todo_tour": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "Product tour was completed. Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                },
+                "todo_activation": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "Set to `done` when the business info page of the signup flow is submitted (both the new business-info step and the old second step). It is not set when a user registers with the `slim` flag. Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                },
+                "todo_scheduling": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "Set to `done` when the business reaches the last page of the scheduling wizard (the step before success / early upgrade call). Synced with HubSpot. Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                },
+                "todo_staff": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "Set to `done` after a staff member is invited (auto-refreshed when the business has more than one staff member). Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                },
+                "todo_availability": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "Set to `done` when the business connects a calendar to vcita. Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                },
+                "todo_services": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "Set to `done` when a service is created or an existing service is updated in the settings page; in the wizard it is set only when the services page is viewed. Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                },
+                "todo_payments": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "Set to `done` when the business successfully connects a payment gateway (PayPal / Stripe / Square / Braintree) or an external payment wallet app. Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                },
+                "todo_livesite": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "Set to `done` on completion of the LiveSite walk-me, or when the LiveSite editor is loaded from Frontage. Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                },
+                "todo_website": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "Set to `done` when the website-widgets page is loaded (auto-refreshed once the site has been published). Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                },
+                "todo_clients": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "Set to `done` when the business imports clients (including Square import) or has more than 5 clients. Synced with HubSpot. Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                },
+                "todo_campaigns": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "Set to `done` when a campaign is sent, an automatic campaign is visited, or the campaign wizard is completed. Synced with HubSpot. Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                },
+                "todo_mobile_app": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "Set to `done` after login from the mobile app only. Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                },
+                "todo_client_card": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "A client card was viewed. Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                },
+                "todo_scheduling_options": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "Scheduling options were configured. Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                },
+                "todo_notifications": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "Set to `done` when the business enters the notification settings page. Setting notifications during the scheduling wizard does not mark it as done. Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                },
+                "todo_yext_connect": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "Set to `done` when the user clicks connect to Yext. Thryv only. Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                },
+                "todo_yext_listing": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "Set to `done` when the Yext listing is approved. Thryv only. Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                },
+                "todo_yext_social": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "Set to `done` when Yext social is set up. Thryv only. Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                },
+                "todo_invoice": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "Set to `done` when the first invoice is sent (auto-refreshed when the business has any invoice). Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                },
+                "todo_business_needs": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "Set to `done` when the user fills in their business intents / onboarding tiles. Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                },
+                "todo_business_info": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "Set to `done` when any of phone, address, profession or website is entered for the business. Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                },
+                "todo_social_networks": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "Set to `done` when social networks are linked. Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                },
+                "todo_claim_keyword": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "Set to `done` when an SMS keyword is claimed (Zipwhip). Thryv only. Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                },
+                "todo_online_reputation": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "Set to `done` when the business connects to Soci. Thryv only. Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                },
+                "todo_estimate_with_deposit": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "Set to `done` once the business has an estimate that carries a deposit. Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                },
+                "todo_pdf_customization": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "PDF customization was configured. Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                },
+                "todo_scheduled_payments": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "A scheduled payment was set up. Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                },
+                "todo_tips_new_payment": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "The 'new payment' tip was seen. Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                },
+                "todo_tips_take_payment": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "The 'take payment' tip was seen. Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                },
+                "todo_tips_close_balance": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "The 'close balance' tip was seen. Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                },
+                "todo_tips_request_payment": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "The 'request payment' tip was seen. Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The updated business onboarding todo flags.",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "todo_tour": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "Product tour was completed. Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                },
+                "todo_activation": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "Set to `done` when the business info page of the signup flow is submitted (both the new business-info step and the old second step). It is not set when a user registers with the `slim` flag. Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                },
+                "todo_scheduling": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "Set to `done` when the business reaches the last page of the scheduling wizard (the step before success / early upgrade call). Synced with HubSpot. Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                },
+                "todo_staff": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "Set to `done` after a staff member is invited (auto-refreshed when the business has more than one staff member). Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                },
+                "todo_availability": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "Set to `done` when the business connects a calendar to vcita. Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                },
+                "todo_services": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "Set to `done` when a service is created or an existing service is updated in the settings page; in the wizard it is set only when the services page is viewed. Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                },
+                "todo_payments": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "Set to `done` when the business successfully connects a payment gateway (PayPal / Stripe / Square / Braintree) or an external payment wallet app. Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                },
+                "todo_livesite": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "Set to `done` on completion of the LiveSite walk-me, or when the LiveSite editor is loaded from Frontage. Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                },
+                "todo_website": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "Set to `done` when the website-widgets page is loaded (auto-refreshed once the site has been published). Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                },
+                "todo_clients": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "Set to `done` when the business imports clients (including Square import) or has more than 5 clients. Synced with HubSpot. Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                },
+                "todo_campaigns": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "Set to `done` when a campaign is sent, an automatic campaign is visited, or the campaign wizard is completed. Synced with HubSpot. Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                },
+                "todo_mobile_app": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "Set to `done` after login from the mobile app only. Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                },
+                "todo_client_card": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "A client card was viewed. Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                },
+                "todo_scheduling_options": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "Scheduling options were configured. Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                },
+                "todo_notifications": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "Set to `done` when the business enters the notification settings page. Setting notifications during the scheduling wizard does not mark it as done. Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                },
+                "todo_yext_connect": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "Set to `done` when the user clicks connect to Yext. Thryv only. Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                },
+                "todo_yext_listing": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "Set to `done` when the Yext listing is approved. Thryv only. Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                },
+                "todo_yext_social": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "Set to `done` when Yext social is set up. Thryv only. Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                },
+                "todo_invoice": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "Set to `done` when the first invoice is sent (auto-refreshed when the business has any invoice). Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                },
+                "todo_business_needs": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "Set to `done` when the user fills in their business intents / onboarding tiles. Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                },
+                "todo_business_info": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "Set to `done` when any of phone, address, profession or website is entered for the business. Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                },
+                "todo_social_networks": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "Set to `done` when social networks are linked. Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                },
+                "todo_claim_keyword": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "Set to `done` when an SMS keyword is claimed (Zipwhip). Thryv only. Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                },
+                "todo_online_reputation": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "Set to `done` when the business connects to Soci. Thryv only. Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                },
+                "todo_estimate_with_deposit": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "Set to `done` once the business has an estimate that carries a deposit. Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                },
+                "todo_pdf_customization": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "PDF customization was configured. Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                },
+                "todo_scheduled_payments": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "A scheduled payment was set up. Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                },
+                "todo_tips_new_payment": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "The 'new payment' tip was seen. Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                },
+                "todo_tips_take_payment": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "The 'take payment' tip was seen. Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                },
+                "todo_tips_close_balance": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "The 'close balance' tip was seen. Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                },
+                "todo_tips_request_payment": {
+                  "type": "string",
+                  "enum": [
+                    "done",
+                    "skipped"
+                  ],
+                  "x-nullable": true,
+                  "description": "The 'request payment' tip was seen. Status of the item. `done` \u2014 completed; `skipped` \u2014 explicitly dismissed by the business; `null` \u2014 not started. The internally stored value `manual` is always translated to `done` in the response."
+                }
+              }
+            },
+            "examples": {
+              "application/json": {
+                "todo_tour": null,
+                "todo_activation": "done",
+                "todo_scheduling": null,
+                "todo_staff": "done",
+                "todo_availability": null,
+                "todo_services": "done",
+                "todo_payments": "done",
+                "todo_livesite": "done",
+                "todo_website": "done",
+                "todo_clients": "done",
+                "todo_campaigns": "skipped",
+                "todo_mobile_app": "done",
+                "todo_client_card": null,
+                "todo_scheduling_options": null,
+                "todo_notifications": null,
+                "todo_yext_connect": null,
+                "todo_yext_listing": null,
+                "todo_yext_social": null,
+                "todo_invoice": "done",
+                "todo_business_needs": null,
+                "todo_business_info": "done",
+                "todo_social_networks": null,
+                "todo_claim_keyword": null,
+                "todo_online_reputation": null,
+                "todo_estimate_with_deposit": null,
+                "todo_pdf_customization": null,
+                "todo_scheduled_payments": null,
+                "todo_tips_new_payment": null,
+                "todo_tips_take_payment": null,
+                "todo_tips_close_balance": null,
+                "todo_tips_request_payment": null
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid access token."
+          },
+          "403": {
+            "description": "The token is not allowed to access this business \u2014 for example a Directory token sent without the `X-On-Behalf-Of` header, or a staff member without admin account access."
+          },
+          "422": {
+            "description": "A flag was sent with a value other than `done` or `skipped`."
+          }
+        }
+      }
+    }
+  },
+  "swagger": "2.0"
+}


### PR DESCRIPTION
## What

Adds `swagger/platform_administration/legacy/legacy_v2_todo.json` documenting `GET /v2/todo` and `PUT /v2/todo` — the API behind the **"Let's personalize your account"** getting started checklist in the app.

## Details

- **GET** returns all 31 `todo_*` flags. Documents that Core re-evaluates the flags against live business data before responding (clients > 5, any invoice, connected payment gateway/wallet, staff > 1, site published, …) and persists them — so values can appear without ever having been written.
- **PUT** is a partial update; allowed values `done` / `skipped`. Writes are **owner-only**: a non-owner staff member gets 200 with no change (`Api::V2::ToDoController#todo_params`).
- Status enum documented as `done` / `skipped` / null; the internally stored `manual` is translated to `done` by `ToDoDecorator`.
- Style mirrors the sibling `legacy_v2_settings_businesses.json` (Swagger 2.0, `X-On-Behalf-Of` header, inline examples).

## Sources

- Confluence [ToDo meaning](https://myvcita.atlassian.net/wiki/spaces/PREZ/pages/413171717/ToDo+meaning)
- Core `Business::Flags#refresh_todo_status!`, `ToDoDecorator`, `Api::V2::ToDoController`

## Notes

- The Confluence table does not cover every flag the API returns (`todo_tour`, `todo_client_card`, `todo_scheduling_options`, `todo_pdf_customization`, `todo_scheduled_payments`, the four `todo_tips_*`). Their descriptions were inferred from the field names and are worth a review pass.
- `mcp_swagger/` is auto-generated and intentionally untouched — run `npm run unify` to regenerate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)