### PR TITLE
fix(unify): convert Swagger 2.0 responses without produces, keep path params an array

### DIFF
--- a/mcp_swagger/platform_administration.json
+++ b/mcp_swagger/platform_administration.json
@@ -5407,41 +5407,47 @@
         "responses": {
           "200": {
             "description": "Packages retrieved",
-            "schema": {
-              "$ref": "#/components/schemas/PackageListResponse"
-            },
-            "examples": {
+            "content": {
               "application/json": {
-                "status": "OK",
-                "data": [
-                  {
-                    "id": 42,
-                    "name": "essentials",
-                    "display_name": "Essentials",
-                    "free": false,
-                    "deprecated": false,
-                    "is_template": false,
-                    "created_at": "2024-01-14T09:12:33Z",
-                    "updated_at": "2026-02-02T11:40:05Z"
-                  },
-                  {
-                    "id": 77,
-                    "name": "tier_medium_template",
-                    "display_name": "Tier Medium (template)",
-                    "free": false,
-                    "deprecated": false,
-                    "is_template": true,
-                    "created_at": "2026-05-03T08:00:00Z",
-                    "updated_at": "2026-05-03T08:00:00Z"
-                  }
-                ]
+                "schema": {
+                  "$ref": "#/components/schemas/PackageListResponse"
+                },
+                "example": {
+                  "status": "OK",
+                  "data": [
+                    {
+                      "id": 42,
+                      "name": "essentials",
+                      "display_name": "Essentials",
+                      "free": false,
+                      "deprecated": false,
+                      "is_template": false,
+                      "created_at": "2024-01-14T09:12:33Z",
+                      "updated_at": "2026-02-02T11:40:05Z"
+                    },
+                    {
+                      "id": 77,
+                      "name": "tier_medium_template",
+                      "display_name": "Tier Medium (template)",
+                      "free": false,
+                      "deprecated": false,
+                      "is_template": true,
+                      "created_at": "2026-05-03T08:00:00Z",
+                      "updated_at": "2026-05-03T08:00:00Z"
+                    }
+                  ]
+                }
               }
             }
           },
           "400": {
             "description": "Business-logic error",
-            "schema": {
-              "$ref": "#/components/schemas/ErrorResponse"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
             }
           },
           "401": {
@@ -5449,8 +5455,12 @@
           },
           "403": {
             "description": "Operator lacks the required package ability",
-            "schema": {
-              "$ref": "#/components/schemas/ErrorResponse"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
             }
           }
         },
@@ -5470,45 +5480,49 @@
         "responses": {
           "200": {
             "description": "Package created — returns the full ActiveRecord representation of the new package",
-            "schema": {
-              "$ref": "#/components/schemas/PackageResponse"
-            },
-            "examples": {
+            "content": {
               "application/json": {
-                "status": "OK",
-                "data": {
-                  "id": 78,
-                  "uid": "a1b2c3d4e5f6g7h8",
-                  "name": "tier_high_template",
-                  "display_name": "Tier High (template)",
-                  "description": null,
-                  "staff_slots": 5,
-                  "free": false,
-                  "deprecated": false,
-                  "is_template": true,
-                  "rank": 1,
-                  "quotas": {
-                    "invoice_monthly_quota": 100,
-                    "storage_quota": 1024
-                  },
-                  "settings": {
-                    "disable_add_staff_button": false
-                  },
-                  "created_at": "2026-08-31T10:00:00Z",
-                  "updated_at": "2026-08-31T10:00:00Z"
+                "schema": {
+                  "$ref": "#/components/schemas/PackageResponse"
+                },
+                "example": {
+                  "status": "OK",
+                  "data": {
+                    "id": 78,
+                    "uid": "a1b2c3d4e5f6g7h8",
+                    "name": "tier_high_template",
+                    "display_name": "Tier High (template)",
+                    "description": null,
+                    "staff_slots": 5,
+                    "free": false,
+                    "deprecated": false,
+                    "is_template": true,
+                    "rank": 1,
+                    "quotas": {
+                      "invoice_monthly_quota": 100,
+                      "storage_quota": 1024
+                    },
+                    "settings": {
+                      "disable_add_staff_button": false
+                    },
+                    "created_at": "2026-08-31T10:00:00Z",
+                    "updated_at": "2026-08-31T10:00:00Z"
+                  }
                 }
               }
             }
           },
           "400": {
             "description": "Validation or business-logic error (duplicate name, invalid quota, non-boolean `is_template`, …)",
-            "schema": {
-              "$ref": "#/components/schemas/ErrorResponse"
-            },
-            "examples": {
+            "content": {
               "application/json": {
-                "status": "ERROR",
-                "message": "Package with the name essentials already exists"
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "status": "ERROR",
+                  "message": "Package with the name essentials already exists"
+                }
               }
             }
           },
@@ -5517,8 +5531,12 @@
           },
           "403": {
             "description": "Operator lacks the `manage` package ability",
-            "schema": {
-              "$ref": "#/components/schemas/ErrorResponse"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
             }
           }
         },
@@ -5539,8 +5557,8 @@
       }
     },
     "/api/operator_api/v1/packages/{id}": {
-      "parameters": {
-        "0": {
+      "parameters": [
+        {
           "name": "id",
           "in": "path",
           "required": true,
@@ -5548,13 +5566,8 @@
           "schema": {
             "type": "integer"
           }
-        },
-        "security": [
-          {
-            "Bearer": []
-          }
-        ]
-      },
+        }
+      ],
       "get": {
         "tags": [
           "Packages"
@@ -5564,62 +5577,68 @@
         "responses": {
           "200": {
             "description": "Package retrieved",
-            "schema": {
-              "$ref": "#/components/schemas/PackageDetailsResponse"
-            },
-            "examples": {
+            "content": {
               "application/json": {
-                "status": "OK",
-                "data": [
-                  {
-                    "id": 42,
-                    "name": "essentials",
-                    "display_name": "Essentials",
-                    "staff_slots": 3,
-                    "quotas": {
-                      "invoice_monthly_quota": 100,
-                      "estimate_monthly_quota": 100,
-                      "storage_quota": 1024,
-                      "campaign_recipients_monthly_quota": 500,
-                      "clients_credit": 0,
-                      "campaigns_credit": 0,
-                      "booking_credit": 0,
-                      "sms_monthly_quota": {
-                        "us_canada": 50,
-                        "other": 10
-                      }
-                    },
-                    "settings": {
-                      "disable_add_staff_button": false,
-                      "disable_staff_slots": false,
-                      "disable_sms_purchase_button": false
-                    },
-                    "free": false,
-                    "deprecated": false,
-                    "is_template": false,
-                    "created_at": "2024-01-14T09:12:33Z",
-                    "updated_at": "2026-02-02T11:40:05Z",
-                    "features": [
-                      {
-                        "id": 12,
-                        "name": "invoices",
-                        "description": "Invoicing module"
+                "schema": {
+                  "$ref": "#/components/schemas/PackageDetailsResponse"
+                },
+                "example": {
+                  "status": "OK",
+                  "data": [
+                    {
+                      "id": 42,
+                      "name": "essentials",
+                      "display_name": "Essentials",
+                      "staff_slots": 3,
+                      "quotas": {
+                        "invoice_monthly_quota": 100,
+                        "estimate_monthly_quota": 100,
+                        "storage_quota": 1024,
+                        "campaign_recipients_monthly_quota": 500,
+                        "clients_credit": 0,
+                        "campaigns_credit": 0,
+                        "booking_credit": 0,
+                        "sms_monthly_quota": {
+                          "us_canada": 50,
+                          "other": 10
+                        }
                       },
-                      {
-                        "id": 31,
-                        "name": "campaigns",
-                        "description": "Email campaigns"
-                      }
-                    ]
-                  }
-                ]
+                      "settings": {
+                        "disable_add_staff_button": false,
+                        "disable_staff_slots": false,
+                        "disable_sms_purchase_button": false
+                      },
+                      "free": false,
+                      "deprecated": false,
+                      "is_template": false,
+                      "created_at": "2024-01-14T09:12:33Z",
+                      "updated_at": "2026-02-02T11:40:05Z",
+                      "features": [
+                        {
+                          "id": 12,
+                          "name": "invoices",
+                          "description": "Invoicing module"
+                        },
+                        {
+                          "id": 31,
+                          "name": "campaigns",
+                          "description": "Email campaigns"
+                        }
+                      ]
+                    }
+                  ]
+                }
               }
             }
           },
           "400": {
             "description": "Business-logic error",
-            "schema": {
-              "$ref": "#/components/schemas/ErrorResponse"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
             }
           },
           "401": {
@@ -5627,8 +5646,12 @@
           },
           "403": {
             "description": "Operator lacks the required package ability",
-            "schema": {
-              "$ref": "#/components/schemas/ErrorResponse"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
             }
           }
         },
@@ -5648,24 +5671,28 @@
         "responses": {
           "200": {
             "description": "Package updated (no payload)",
-            "schema": {
-              "$ref": "#/components/schemas/StatusOnlyResponse"
-            },
-            "examples": {
+            "content": {
               "application/json": {
-                "status": "OK"
+                "schema": {
+                  "$ref": "#/components/schemas/StatusOnlyResponse"
+                },
+                "example": {
+                  "status": "OK"
+                }
               }
             }
           },
           "400": {
             "description": "Validation or business-logic error",
-            "schema": {
-              "$ref": "#/components/schemas/ErrorResponse"
-            },
-            "examples": {
+            "content": {
               "application/json": {
-                "status": "ERROR",
-                "message": "is_template must be boolean"
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "status": "ERROR",
+                  "message": "is_template must be boolean"
+                }
               }
             }
           },
@@ -5674,8 +5701,12 @@
           },
           "403": {
             "description": "Operator lacks the `manage` package ability",
-            "schema": {
-              "$ref": "#/components/schemas/ErrorResponse"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
             }
           }
         },
@@ -5703,19 +5734,25 @@
         "responses": {
           "200": {
             "description": "Package deleted",
-            "schema": {
-              "$ref": "#/components/schemas/StatusOnlyResponse"
-            },
-            "examples": {
+            "content": {
               "application/json": {
-                "status": "OK"
+                "schema": {
+                  "$ref": "#/components/schemas/StatusOnlyResponse"
+                },
+                "example": {
+                  "status": "OK"
+                }
               }
             }
           },
           "400": {
             "description": "Package not found or deletion failed",
-            "schema": {
-              "$ref": "#/components/schemas/ErrorResponse"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
             }
           },
           "401": {
@@ -5723,8 +5760,12 @@
           },
           "403": {
             "description": "Operator lacks the `manage` package ability",
-            "schema": {
-              "$ref": "#/components/schemas/ErrorResponse"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
             }
           }
         },
@@ -5746,24 +5787,28 @@
         "responses": {
           "200": {
             "description": "Feature attached",
-            "schema": {
-              "$ref": "#/components/schemas/StatusOnlyResponse"
-            },
-            "examples": {
+            "content": {
               "application/json": {
-                "status": "OK"
+                "schema": {
+                  "$ref": "#/components/schemas/StatusOnlyResponse"
+                },
+                "example": {
+                  "status": "OK"
+                }
               }
             }
           },
           "400": {
             "description": "Feature is not packageable, or a package id does not exist",
-            "schema": {
-              "$ref": "#/components/schemas/ErrorResponse"
-            },
-            "examples": {
+            "content": {
               "application/json": {
-                "status": "ERROR",
-                "message": "Error in add feature to packages: feature is not packageable"
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "status": "ERROR",
+                  "message": "Error in add feature to packages: feature is not packageable"
+                }
               }
             }
           },
@@ -5772,8 +5817,12 @@
           },
           "403": {
             "description": "Operator lacks the `manage` package ability",
-            "schema": {
-              "$ref": "#/components/schemas/ErrorResponse"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
             }
           }
         },
@@ -5876,31 +5925,37 @@
         "responses": {
           "200": {
             "description": "Feature flags retrieved",
-            "schema": {
-              "$ref": "#/components/schemas/FeatureListResponse"
-            },
-            "examples": {
+            "content": {
               "application/json": {
-                "status": "OK",
-                "data": [
-                  {
-                    "id": 12,
-                    "name": "invoices",
-                    "description": "Invoicing module",
-                    "packageable": true,
-                    "removable": false,
-                    "domain": "financial_ops",
-                    "created_at": "2023-04-01T00:00:00Z",
-                    "updated_at": "2023-04-01T00:00:00Z"
-                  }
-                ]
+                "schema": {
+                  "$ref": "#/components/schemas/FeatureListResponse"
+                },
+                "example": {
+                  "status": "OK",
+                  "data": [
+                    {
+                      "id": 12,
+                      "name": "invoices",
+                      "description": "Invoicing module",
+                      "packageable": true,
+                      "removable": false,
+                      "domain": "financial_ops",
+                      "created_at": "2023-04-01T00:00:00Z",
+                      "updated_at": "2023-04-01T00:00:00Z"
+                    }
+                  ]
+                }
               }
             }
           },
           "400": {
             "description": "Business-logic error",
-            "schema": {
-              "$ref": "#/components/schemas/ErrorResponse"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
             }
           },
           "401": {
@@ -5908,8 +5963,12 @@
           },
           "403": {
             "description": "Operator lacks the required feature ability",
-            "schema": {
-              "$ref": "#/components/schemas/ErrorResponse"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
             }
           }
         },
@@ -5928,14 +5987,22 @@
         "responses": {
           "200": {
             "description": "Feature flag created",
-            "schema": {
-              "$ref": "#/components/schemas/FeatureResponse"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FeatureResponse"
+                }
+              }
             }
           },
           "400": {
             "description": "Validation error",
-            "schema": {
-              "$ref": "#/components/schemas/ErrorResponse"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
             }
           },
           "401": {
@@ -5943,8 +6010,12 @@
           },
           "403": {
             "description": "Operator lacks the required feature ability",
-            "schema": {
-              "$ref": "#/components/schemas/ErrorResponse"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
             }
           }
         },
@@ -5965,8 +6036,8 @@
       }
     },
     "/api/operator_api/v1/features/{id}": {
-      "parameters": {
-        "0": {
+      "parameters": [
+        {
           "name": "id",
           "in": "path",
           "required": true,
@@ -5974,13 +6045,8 @@
           "schema": {
             "type": "integer"
           }
-        },
-        "security": [
-          {
-            "Bearer": []
-          }
-        ]
-      },
+        }
+      ],
       "get": {
         "tags": [
           "Feature Flags"
@@ -5989,14 +6055,22 @@
         "responses": {
           "200": {
             "description": "Feature flag retrieved",
-            "schema": {
-              "$ref": "#/components/schemas/FeatureResponse"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FeatureResponse"
+                }
+              }
             }
           },
           "400": {
             "description": "Not found or business-logic error",
-            "schema": {
-              "$ref": "#/components/schemas/ErrorResponse"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
             }
           },
           "401": {
@@ -6004,8 +6078,12 @@
           },
           "403": {
             "description": "Operator lacks the required feature ability",
-            "schema": {
-              "$ref": "#/components/schemas/ErrorResponse"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
             }
           }
         },
@@ -6024,14 +6102,22 @@
         "responses": {
           "200": {
             "description": "Feature flag updated",
-            "schema": {
-              "$ref": "#/components/schemas/FeatureResponse"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FeatureResponse"
+                }
+              }
             }
           },
           "400": {
             "description": "Validation error",
-            "schema": {
-              "$ref": "#/components/schemas/ErrorResponse"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
             }
           },
           "401": {
@@ -6039,8 +6125,12 @@
           },
           "403": {
             "description": "Operator lacks the required feature ability",
-            "schema": {
-              "$ref": "#/components/schemas/ErrorResponse"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
             }
           }
         },
@@ -6068,19 +6158,23 @@
         "responses": {
           "200": {
             "description": "Feature flag deleted",
-            "schema": {
-              "type": "object",
-              "properties": {
-                "status": {
-                  "type": "string",
-                  "example": "OK"
-                },
-                "data": {
+            "content": {
+              "application/json": {
+                "schema": {
                   "type": "object",
                   "properties": {
-                    "feature_id": {
-                      "type": "integer",
-                      "example": 12
+                    "status": {
+                      "type": "string",
+                      "example": "OK"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "feature_id": {
+                          "type": "integer",
+                          "example": 12
+                        }
+                      }
                     }
                   }
                 }
@@ -6089,13 +6183,15 @@
           },
           "400": {
             "description": "Flag not found, or attached to a package and therefore not removable",
-            "schema": {
-              "$ref": "#/components/schemas/ErrorResponse"
-            },
-            "examples": {
+            "content": {
               "application/json": {
-                "status": "Warning",
-                "message": "Feature flag with id 12 could not be deleted"
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "status": "Warning",
+                  "message": "Feature flag with id 12 could not be deleted"
+                }
               }
             }
           },
@@ -6104,8 +6200,12 @@
           },
           "403": {
             "description": "Operator lacks the required feature ability",
-            "schema": {
-              "$ref": "#/components/schemas/ErrorResponse"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
             }
           }
         },

--- a/scripts/unify-openapi.js
+++ b/scripts/unify-openapi.js
@@ -236,6 +236,28 @@ function convertSwaggerToOpenAPI(operation, fileName) {
     delete converted.consumes;
     delete converted.produces;
   }
+
+  // Fallback: convert any remaining Swagger 2.0 response `schema`/`examples` into
+  // OpenAPI 3 `content` (handles operations that declare neither consumes nor produces)
+  if (converted.responses) {
+    for (const [statusCode, response] of Object.entries(converted.responses)) {
+      if (!response || (!response.schema && !response.examples)) continue;
+
+      const { schema, examples, ...rest } = response;
+      const content = { ...(response.content || {}) };
+      const mediaTypes = examples ? Object.keys(examples) : ['application/json'];
+
+      mediaTypes.forEach(mediaType => {
+        content[mediaType] = {
+          ...(content[mediaType] || {}),
+          ...(schema && { schema }),
+          ...(examples && examples[mediaType] !== undefined && { example: examples[mediaType] })
+        };
+      });
+
+      converted.responses[statusCode] = { ...rest, content };
+    }
+  }
   
   // Fallback: Convert any remaining body parameters to requestBody (handles cases without consumes)
   if (converted.parameters && !converted.requestBody) {
@@ -1043,6 +1065,13 @@ async function processDomain(domainPath, domainName) {
     const securityScheme = fileToSchemeName[sourceFile] || 'Bearer';
     
     for (const [method, operation] of Object.entries(pathMethods)) {
+      // Path-level parameters are not an operation - carry them through untouched
+      // (spreading the array here would turn it into an object keyed "0", "1", ...)
+      if (method === 'parameters') {
+        pathsWithSecurity[pathKey].parameters = operation;
+        continue;
+      }
+
       // Remove any existing security definition from the operation
       // We'll add the correct one based on our rules
       const { security: existingSecurity, ...operationWithoutSecurity } = operation;


### PR DESCRIPTION
Fixes the OpenAPI schema validation failures on `mcp_swagger/platform_administration.json` (33 × `UNEVALUATED PROPERTY … schema is not expected to be here!`, 2 × `TYPE must be array`).

## Root cause

Both are bugs in `scripts/unify-openapi.js`, surfaced by `swagger/platform_administration/legacy/operator-portal.json` (added in 2d3054bd) — the only Swagger 2.0 source that hits them. The source file is fine; the generator produced invalid OpenAPI 3.1.

1. **`schema` left under responses.** The Swagger 2.0 → OpenAPI 3 response conversion (`schema` → `content['application/json'].schema`) lives entirely inside `if (operation.consumes || operation.produces)`. Every operator-portal operation declares neither, so all 33 responses kept the Swagger 2.0 `schema` key.
2. **Path-level `parameters` turned into an object.** The security pass iterated `Object.entries(pathMethods)` treating each key as an operation and spreading it, so the `parameters` array on `/packages/{id}` and `/features/{id}` became `{"0": {...}}`.

## Fix

1. Added an ungated fallback after the consumes/produces block that moves any remaining response `schema`/`examples` into `content` (media types from `examples` keys, else `application/json`).
2. The security loop now passes a path-level `parameters` array through untouched instead of spreading it.

## Verification

- Regenerated with `npm run unify:flatten` — **only** `platform_administration.json` changes; the other 10 domain files are byte-identical, confirming the fix is scoped to the affected operations.
- Across all generated specs: 0 responses with a stray `schema`, 0 path items with object-shaped `parameters` (was 33 and 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)