### PR TITLE
docs: group /v2/todo under the Business Settings tag

### DIFF
--- a/mcp_swagger/platform_administration.json
+++ b/mcp_swagger/platform_administration.json
@@ -387,6 +387,9 @@
   "paths": {
     "/v2/todo": {
       "get": {
+        "tags": [
+          "Business Settings"
+        ],
         "summary": "Get the business onboarding todo flags",
         "description": "## Overview\nReturns the full set of onboarding todo flags for the business in context.\n\nBefore responding, the server refreshes the flags from live business data — for example `todo_clients` becomes `done` once the business has more than 5 clients, `todo_invoice` once any invoice exists, `todo_payments` once a payment gateway or payment wallet app is connected, `todo_staff` once more than one staff member exists, and `todo_website` once the site has been published. The refreshed values are persisted, so the response is always the authoritative current state.\n\nAvailable for **Staff & Directory tokens**. Directory tokens MUST send the business in the `X-On-Behalf-Of` header (a Directory token without it is rejected with 403).",
         "parameters": [
@@ -739,6 +742,9 @@
         ]
       },
       "put": {
+        "tags": [
+          "Business Settings"
+        ],
         "summary": "Update the business onboarding todo flags",
         "description": "## Overview\nUpdates one or more onboarding todo flags for the business in context. Send only the flags you want to change; omitted flags keep their current value. The full, refreshed flag set is returned.\n\nAllowed values are `done` and `skipped` (`skipped` marks a step the business explicitly dismissed in the checklist). Sending any other value is rejected with 422.\n\n**Only the business owner may write.** A request from a staff member who is not the owner is accepted and returns 200, but no flag is changed.\n\nAvailable for **Staff & Directory tokens**. Directory tokens MUST send the business in the `X-On-Behalf-Of` header (a Directory token without it is rejected with 403).",
         "parameters": [

--- a/swagger/platform_administration/legacy/legacy_v2_todo.json
+++ b/swagger/platform_administration/legacy/legacy_v2_todo.json
@@ -9,6 +9,9 @@
   "paths": {
     "/v2/todo": {
       "get": {
+        "tags": [
+          "Business Settings"
+        ],
         "summary": "Get the business onboarding todo flags",
         "description": "## Overview\nReturns the full set of onboarding todo flags for the business in context.\n\nBefore responding, the server refreshes the flags from live business data \u2014 for example `todo_clients` becomes `done` once the business has more than 5 clients, `todo_invoice` once any invoice exists, `todo_payments` once a payment gateway or payment wallet app is connected, `todo_staff` once more than one staff member exists, and `todo_website` once the site has been published. The refreshed values are persisted, so the response is always the authoritative current state.\n\nAvailable for **Staff & Directory tokens**. Directory tokens MUST send the business in the `X-On-Behalf-Of` header (a Directory token without it is rejected with 403).",
         "consumes": [
@@ -358,6 +361,9 @@
         }
       },
       "put": {
+        "tags": [
+          "Business Settings"
+        ],
         "summary": "Update the business onboarding todo flags",
         "description": "## Overview\nUpdates one or more onboarding todo flags for the business in context. Send only the flags you want to change; omitted flags keep their current value. The full, refreshed flag set is returned.\n\nAllowed values are `done` and `skipped` (`skipped` marks a step the business explicitly dismissed in the checklist). Sending any other value is rejected with 422.\n\n**Only the business owner may write.** A request from a staff member who is not the owner is accepted and returns 200, but no flag is changed.\n\nAvailable for **Staff & Directory tokens**. Directory tokens MUST send the business in the `X-On-Behalf-Of` header (a Directory token without it is rejected with 403).",
         "consumes": [


### PR DESCRIPTION
## Problem

After import, the ToDo endpoints rendered as their own sidebar group named after the raw path, `/v2/todo`, instead of nesting under **Business Settings**.

## Cause

The docs sidebar groups operations by their `tags`. `legacy_v2_todo.json` did not set any, so the renderer fell back to the path.

## Fix

Tag both operations `Business Settings` — the same tag `legacy_v2_settings_businesses.json` already uses — so they join the existing section alongside Show / Update Business Settings.

Regenerated `mcp_swagger/platform_administration.json` with `npm run unify:flatten`; the diff is exactly the two added `tags` blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)