### PR TITLE
fix(ci): grant actions:read so the Pages deploy can list its artifact

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -14,6 +14,9 @@ permissions:
   contents: read
   pages: write
   id-token: write
+  # deploy-pages needs to list the uploaded artifact via the Actions API.
+  # Without this the deploy step fails with "Failed to ListArtifacts ... (403)".
+  actions: read
 
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.


### PR DESCRIPTION
The Pages deploy on master has been failing since the merge of #327 ([run 33642965496](https://github.com/vcita/developers-hub/actions/runs/33642965496)).

## Symptom

`Upload artifact` succeeds (2.5 MB, artifact finalized), then the last step fails immediately:

```
##[error]Listing artifact metadata failed
##[error]HttpError: Failed to ListArtifacts: Received non-retryable error:
         Failed request: (403) Forbidden: Error from intermediary with HTTP status code 403
##[error]Error: Failed to create deployment (status: 403)
```

## Cause

Not the content of #327, and not a transient outage — githubstatus.com reports all systems operational, and a re-run failed identically.

The workflow declares an explicit `permissions:` block. Declaring one sets **every unlisted scope to `none`**, including `actions`. `actions/deploy-pages` resolves the artifact it is about to deploy through the Actions artifacts API, so with `actions: none` that lookup is rejected with 403. The upload step doesn't need the scope, which is why the failure only surfaces at the very last step.

## Fix

Add `actions: read` to the permissions block. Everything else is unchanged.

## Note

I couldn't verify this end to end from a branch — the workflow only triggers on pushes to `master`, so it will run for the first time when this merges. If it still fails afterwards, the next thing to check is Settings → Pages, that the source is still set to "GitHub Actions".

🤖 Generated with [Claude Code](https://claude.com/claude-code)