### PR TITLE
VCITA2-13171: document is_template on the features packages catalog

### DIFF
--- a/entities/license/featuresPackage.json
+++ b/entities/license/featuresPackage.json
@@ -138,6 +138,11 @@
     "deprecated": {
       "type": "boolean",
       "description": "Whether the package is deprecated and no longer offered to new businesses (e.g., true, false)"
+    },
+    "is_template": {
+      "type": "boolean",
+      "description": "Whether the package is a reusable configuration template rather than a package businesses subscribe to (e.g., true, false)",
+      "default": false
     }
   },
   "required": [
@@ -190,7 +195,8 @@
         "name": "invoicing_features",
         "description": "Allow invoicing for an account (payments module sub feature)"
       }
-    ]
+    ],
+    "is_template": false
   },
   "description": "Defines a plan package's quotas, settings, and included features."
 }

--- a/swagger/platform_administration/license.json
+++ b/swagger/platform_administration/license.json
@@ -2243,6 +2243,14 @@
               "default": "updated_at:desc"
             },
             "description": "Sort by fields, e.g., \"created_at:asc,updated_at:desc\""
+          },
+          {
+            "in": "query",
+            "name": "is_template",
+            "schema": {
+              "type": "boolean"
+            },
+            "description": "Return only template packages (true) or only non-template packages (false). Omit to return both. Only \"true\" and \"false\" are accepted - any other value, including 0 and 1, returns 400 (e.g., true, false)"
           }
         ],
         "responses": {
@@ -2402,6 +2410,10 @@
                         "description": "Feature names to detach (e.g., [\"sms_reminders\"])"
                       }
                     }
+                  },
+                  "is_template": {
+                    "type": "boolean",
+                    "description": "Whether the package is a reusable configuration template rather than a package businesses subscribe to. Must be a JSON boolean - 0, 1 and the quoted forms \"true\"/\"false\" are rejected with 400. Defaults to false when omitted (e.g., true, false)"
                   }
                 }
               },
@@ -2471,7 +2483,8 @@
                           "name": "online_scheduling",
                           "description": "Online scheduling for clients"
                         }
-                      ]
+                      ],
+                      "is_template": false
                     }
                   }
                 }
@@ -3208,7 +3221,8 @@
                           "name": "online_scheduling",
                           "description": "Online scheduling for clients"
                         }
-                      ]
+                      ],
+                      "is_template": false
                     }
                   }
                 }
@@ -3345,6 +3359,10 @@
                         "description": "Feature names to detach (e.g., [\"sms_reminders\"])"
                       }
                     }
+                  },
+                  "is_template": {
+                    "type": "boolean",
+                    "description": "Whether the package is a reusable configuration template rather than a package businesses subscribe to. Must be a JSON boolean - 0, 1 and the quoted forms \"true\"/\"false\" are rejected with 400. Defaults to false when omitted (e.g., true, false)"
                   }
                 }
               },
@@ -3409,7 +3427,8 @@
                           "name": "online_scheduling",
                           "description": "Online scheduling for clients"
                         }
-                      ]
+                      ],
+                      "is_template": false
                     }
                   }
                 }


### PR DESCRIPTION
[VCITA2-13171](https://myvcita.atlassian.net/browse/VCITA2-13171) · core: https://github.com/vcita/core/pull/29366

Documents `is_template` on `/v3/license/features_packages`. The flag marks a
package as a reusable configuration template rather than one a business
subscribes to.

## ⚠️ Base branch

This targets **`VCITA2-14608-license-catalog-admin-api`** (PR #331), not master.
The `POST`/`PUT` operations this annotates exist only on that branch — master
still has just the `GET` collection. **#331 has to merge first.**

## Changes

**`entities/license/featuresPackage.json`** — `is_template` property (boolean,
default false) plus the example. `FeaturesPackageList` `$ref`s this entity, so
index and show are both covered by the one addition.

**`swagger/platform_administration/license.json`**
- `GET /license/features_packages` — new `is_template` query filter
- `POST /license/features_packages` and `PUT /license/features_packages/{id}` — `is_template` in the request body
- the three response examples that carry a package object

## The contract is stricter than `deprecated`

The write shapes take a **JSON boolean only** — `0`, `1` and the quoted
`"true"`/`"false"` are rejected with 400, unlike `deprecated`, which still
accepts all of them. The descriptions say so explicitly, since the asymmetry
between two adjacent booleans on the same object is otherwise a trap.

The query filter is the exception the transport forces: a URL cannot carry a
JSON boolean, so it reads `"true"`/`"false"` and rejects everything else.

## Note for the reviewer

The index operation already documents `name`, `page`, `per_page` and `sort`
query parameters that the controller ignores entirely — pre-existing, not from
this PR. `is_template` is currently the only filter on that endpoint that does
anything. Happy to delete the other four in a follow-up if you want.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[VCITA2-13171]: https://myvcita.atlassian.net/browse/VCITA2-13171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ