### PR TITLE
VCITA2-13177: document domain and uid on the v3 license features API

### DIFF
--- a/entities/license/feature.json
+++ b/entities/license/feature.json
@@ -7,6 +7,11 @@
       "readOnly": true,
       "description": "Unique identifier of the feature (e.g., 2231)"
     },
+    "uid": {
+      "type": "string",
+      "readOnly": true,
+      "description": "Unique identifier of the feature and the key used to address it on this API (e.g., \"a1b2c3d4e5f6g7h8\")"
+    },
     "name": {
       "type": "string",
       "description": "Internal name of the feature, unique across features and case-insensitive (e.g., \"online_scheduling\", \"3_services_limitation\")"
@@ -20,6 +25,31 @@
       "type": "boolean",
       "default": false,
       "description": "Whether the feature may be attached to a package. Only packageable features can be added via POST /v3/license/packages/add_feature (e.g., true, false)"
+    },
+    "domain": {
+      "type": "string",
+      "nullable": true,
+      "enum": [
+        "communication",
+        "clients",
+        "assets",
+        "campaigns",
+        "online_presence",
+        "sales",
+        "financial_ops",
+        "payments",
+        "catalog",
+        "scheduling",
+        "business_administration",
+        "verticals",
+        "access_control",
+        "licensing",
+        "operators",
+        "apps",
+        "ai",
+        "integration"
+      ],
+      "description": "Functional domain the feature flag belongs to, from the R&D Domain-Driven Design domain list (the same key used as the domain's API path segment). At most one per flag. Optional -- null for flags that have not been classified yet (e.g., \"financial_ops\", \"scheduling\")"
     },
     "removable": {
       "type": "boolean",
@@ -42,9 +72,11 @@
   ],
   "example": {
     "id": 2231,
+    "uid": "a1b2c3d4e5f6g7h8",
     "name": "3_services_limitation",
     "description": "3 service limitation per account",
     "packageable": true,
+    "domain": "catalog",
     "removable": false,
     "created_at": "Wed, May 29, 2013 at 12:21pm",
     "updated_at": "Thu, September 03 at 9:50am"

--- a/swagger/platform_administration/license.json
+++ b/swagger/platform_administration/license.json
@@ -2564,6 +2564,35 @@
               "type": "boolean"
             },
             "description": "Return only features that may (or may not) be attached to a package (e.g., true, false)"
+          },
+          {
+            "in": "query",
+            "name": "domain",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "communication",
+                "clients",
+                "assets",
+                "campaigns",
+                "online_presence",
+                "sales",
+                "financial_ops",
+                "payments",
+                "catalog",
+                "scheduling",
+                "business_administration",
+                "verticals",
+                "access_control",
+                "licensing",
+                "operators",
+                "apps",
+                "ai",
+                "integration"
+              ],
+              "description": "Functional domain the feature flag belongs to, from the R&D Domain-Driven Design domain list. Optional -- null for flags that have not been classified yet (e.g., \"financial_ops\", \"scheduling\")"
+            },
+            "description": "Return only features in this domain. Composable with `packageable` and `filter`; a value outside the enum is rejected with HTTP 400 (e.g., \"financial_ops\")"
           }
         ],
         "responses": {
@@ -2599,9 +2628,11 @@
                     "features": [
                       {
                         "id": 2231,
+                        "uid": "a1b2c3d4e5f6g7h8",
                         "name": "3_services_limitation",
                         "description": "3 service limitation per account",
                         "packageable": true,
+                        "domain": "catalog",
                         "removable": false,
                         "created_at": "Wed, May 29, 2013 at 12:21pm",
                         "updated_at": "Thu, September 03 at 9:50am"
@@ -2670,13 +2701,38 @@
                     "type": "boolean",
                     "default": false,
                     "description": "Whether the feature may be attached to a package (e.g., true, false)"
+                  },
+                  "domain": {
+                    "type": "string",
+                    "enum": [
+                      "communication",
+                      "clients",
+                      "assets",
+                      "campaigns",
+                      "online_presence",
+                      "sales",
+                      "financial_ops",
+                      "payments",
+                      "catalog",
+                      "scheduling",
+                      "business_administration",
+                      "verticals",
+                      "access_control",
+                      "licensing",
+                      "operators",
+                      "apps",
+                      "ai",
+                      "integration"
+                    ],
+                    "description": "Optional. When supplied it must be one of the enum values; an unknown value is rejected with HTTP 400. Omitting it on update leaves the current value untouched -- it is never cleared implicitly (e.g., \"financial_ops\")"
                   }
                 }
               },
               "example": {
                 "name": "online_scheduling",
                 "description": "Online scheduling for clients",
-                "packageable": true
+                "packageable": true,
+                "domain": "scheduling"
               }
             }
           }
@@ -2710,9 +2766,11 @@
                   "data": {
                     "feature": {
                       "id": 2231,
+                      "uid": "a1b2c3d4e5f6g7h8",
                       "name": "3_services_limitation",
                       "description": "3 service limitation per account",
                       "packageable": true,
+                      "domain": "catalog",
                       "removable": false,
                       "created_at": "Wed, May 29, 2013 at 12:21pm",
                       "updated_at": "Thu, September 03 at 9:50am"
@@ -2766,7 +2824,7 @@
         }
       }
     },
-    "/license/features/{id}": {
+    "/license/features/{uid}": {
       "get": {
         "tags": [
           "License Features"
@@ -2782,12 +2840,12 @@
         "parameters": [
           {
             "in": "path",
-            "name": "id",
+            "name": "uid",
             "required": true,
             "schema": {
-              "type": "integer"
+              "type": "string"
             },
-            "description": "Numeric identifier of the record (e.g., 1, 2231)"
+            "description": "Unique identifier of the feature (e.g., \"a1b2c3d4e5f6g7h8\")"
           }
         ],
         "responses": {
@@ -2819,9 +2877,11 @@
                   "data": {
                     "feature": {
                       "id": 2231,
+                      "uid": "a1b2c3d4e5f6g7h8",
                       "name": "3_services_limitation",
                       "description": "3 service limitation per account",
                       "packageable": true,
+                      "domain": "catalog",
                       "removable": false,
                       "created_at": "Wed, May 29, 2013 at 12:21pm",
                       "updated_at": "Thu, September 03 at 9:50am"
@@ -2865,7 +2925,7 @@
                   "errors": [
                     {
                       "code": "not_found",
-                      "message": "Feature with id 0 doesn't exist"
+                      "message": "Feature with uid nosuchuid0000000 doesn't exist"
                     }
                   ]
                 }
@@ -2889,12 +2949,12 @@
         "parameters": [
           {
             "in": "path",
-            "name": "id",
+            "name": "uid",
             "required": true,
             "schema": {
-              "type": "integer"
+              "type": "string"
             },
-            "description": "Numeric identifier of the record (e.g., 1, 2231)"
+            "description": "Unique identifier of the feature (e.g., \"a1b2c3d4e5f6g7h8\")"
           }
         ],
         "requestBody": {
@@ -2915,12 +2975,37 @@
                   "packageable": {
                     "type": "boolean",
                     "description": "Whether the feature may be attached to a package (e.g., true, false)"
+                  },
+                  "domain": {
+                    "type": "string",
+                    "enum": [
+                      "communication",
+                      "clients",
+                      "assets",
+                      "campaigns",
+                      "online_presence",
+                      "sales",
+                      "financial_ops",
+                      "payments",
+                      "catalog",
+                      "scheduling",
+                      "business_administration",
+                      "verticals",
+                      "access_control",
+                      "licensing",
+                      "operators",
+                      "apps",
+                      "ai",
+                      "integration"
+                    ],
+                    "description": "Optional. When supplied it must be one of the enum values; an unknown value is rejected with HTTP 400. Omitting it on update leaves the current value untouched -- it is never cleared implicitly (e.g., \"financial_ops\")"
                   }
                 }
               },
               "example": {
                 "description": "Online scheduling for clients",
-                "packageable": true
+                "packageable": true,
+                "domain": "scheduling"
               }
             }
           }
@@ -2954,9 +3039,11 @@
                   "data": {
                     "feature": {
                       "id": 2231,
+                      "uid": "a1b2c3d4e5f6g7h8",
                       "name": "3_services_limitation",
                       "description": "3 service limitation per account",
                       "packageable": true,
+                      "domain": "catalog",
                       "removable": false,
                       "created_at": "Wed, May 29, 2013 at 12:21pm",
                       "updated_at": "Thu, September 03 at 9:50am"
@@ -3019,7 +3106,7 @@
                   "errors": [
                     {
                       "code": "not_found",
-                      "message": "Feature with id 0 doesn't exist"
+                      "message": "Feature with uid nosuchuid0000000 doesn't exist"
                     }
                   ]
                 }
@@ -3043,12 +3130,12 @@
         "parameters": [
           {
             "in": "path",
-            "name": "id",
+            "name": "uid",
             "required": true,
             "schema": {
-              "type": "integer"
+              "type": "string"
             },
-            "description": "Numeric identifier of the record (e.g., 1, 2231)"
+            "description": "Unique identifier of the feature (e.g., \"a1b2c3d4e5f6g7h8\")"
           }
         ],
         "responses": {
@@ -3100,7 +3187,7 @@
                   "errors": [
                     {
                       "code": "not_found",
-                      "message": "Feature with id 0 doesn't exist"
+                      "message": "Feature with uid nosuchuid0000000 doesn't exist"
                     }
                   ]
                 }


### PR DESCRIPTION
Documents [VCITA2-13177](https://myvcita.atlassian.net/browse/VCITA2-13177) — the `domain` and `uid` columns added to `features` in vcita/core#29370.

## Changes

**`entities/license/feature.json`**
- `uid` — read-only string, the key this API addresses features by
- `domain` — nullable string, the 18-value DDD enum
- example updated with both

**`swagger/platform_administration/license.json`**
- `/license/features/{id}` → **`/license/features/{uid}`**, path param `id` (integer) → `uid` (string) on GET/PUT/DELETE
- `GET /license/features` — new `domain` query filter, composable with `packageable` and `filter`, 400 on a value outside the enum
- `POST` and `PUT` — `domain` as an optional write param
- 4 response examples gain `uid` + `domain`; the 3 404 examples reworded to quote a uid

## Notes

- **The legacy `operator-portal.json` needs no change.** It already documents `domain` on master with the identical enum, optionality and 400-on-unknown wording — the docs were written ahead of the code, and the implementation matches the published contract. `uid` is v3-only and is deliberately absent there.
- **Based on `VCITA2-14608-license-catalog-admin-api`, not master**, because `/license/features` and `entities/license/feature.json` exist only on that branch (#331). This cannot merge until #331 does.
- `mcp_swagger/` is generated and intentionally untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[VCITA2-13177]: https://myvcita.atlassian.net/browse/VCITA2-13177?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
