### PR TITLE
docs: add query search param to the directories list spec (VCITA2-15681)

### DIFF
--- a/swagger/platform_administration/directory.json
+++ b/swagger/platform_administration/directory.json
@@ -748,6 +748,16 @@
             "example": "abc"
           },
           {
+            "name": "query",
+            "in": "query",
+            "required": false,
+            "description": "Search term that partially matches the directory name or partner_name, applied on top of any other filter",
+            "schema": {
+              "type": "string"
+            },
+            "example": "acme"
+          },
+          {
             "name": "page",
             "in": "query",
             "required": false,


### PR DESCRIPTION
## Summary
Documents the new optional `query` string parameter on `GET /v3/business_administration/directories` ([VCITA2-15681](https://myvcita.atlassian.net/browse/VCITA2-15681)): partial match on `name` or `partner_name`, applied on top of the other filters.

Implementation PR: https://github.com/vcita/core/pull/29377

## Validation
- `@apidevtools/swagger-parser` full validation: spec valid
- `npm run unify:dry-run`: platform_administration merges cleanly, no new conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[VCITA2-15681]: https://myvcita.atlassian.net/browse/VCITA2-15681?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ