### PR TITLE
docs: category_code on the business rules list API accepts a list

### DIFF
--- a/entities/ai/BusinessRule.json
+++ b/entities/ai/BusinessRule.json
@@ -116,13 +116,14 @@
     },
     "category_code": {
       "type": "string",
-      "description": "The category of the business rule. Determines how the AI agent uses this rule.\n\n* `tone_of_voice` - Rules about communication style, language, and tone the AI should adopt when interacting with clients.\n* `policies_and_info` - Rules about business operations, pricing, scheduling policies, and other operational guidelines.\n* `things_to_avoid` - Rules about topics, phrases, or actions the AI should not mention or perform.\n* `faq` - Frequently asked questions and their answers. When this category is used, the metadata field should contain structured `question` and `answer` fields.\n* `client_facing_bot_policies` - Rules specifically for client-facing bot interactions, defining bot behavior, limitations, and escalation policies.",
+      "description": "The category of the business rule. Determines how the AI agent uses this rule.\n\n* `tone_of_voice` - Rules about communication style, language, and tone the AI should adopt when interacting with clients.\n* `policies_and_info` - Rules about business operations, pricing, scheduling policies, and other operational guidelines.\n* `things_to_avoid` - Rules about topics, phrases, or actions the AI should not mention or perform.\n* `faq` - Frequently asked questions and their answers. When this category is used, the metadata field should contain structured `question` and `answer` fields.\n* `client_facing_bot_policies` - Rules specifically for client-facing bot interactions, defining bot behavior, limitations, and escalation policies.\n* `lead_handling` - Rules about how incoming leads should be qualified, prioritized, and followed up.",
       "enum": [
         "tone_of_voice",
         "policies_and_info",
         "things_to_avoid",
         "faq",
-        "client_facing_bot_policies"
+        "client_facing_bot_policies",
+        "lead_handling"
       ]
     }
   },

--- a/mcp_swagger/ai.json
+++ b/mcp_swagger/ai.json
@@ -2038,13 +2038,14 @@
                   },
                   "category_code": {
                     "type": "string",
-                    "description": "The category of business rules to extract from the content. All extracted rules will be assigned to this category. If no category supplied, the system will attempt to infer the category based on the content.\n\nAvailable values:\n* `tone_of_voice` - Rules about communication style and tone.\n* `policies_and_info` - Rules about business operations and policies.\n* `things_to_avoid` - Rules about what the AI should not do or say.\n* `faq` - Frequently asked questions and their answers.\n* `client_facing_bot_policies` - Rules specifically for client-facing bot interactions.",
+                    "description": "The category of business rules to extract from the content. All extracted rules will be assigned to this category. If no category supplied, the system will attempt to infer the category based on the content.\n\nAvailable values:\n* `tone_of_voice` - Rules about communication style and tone.\n* `policies_and_info` - Rules about business operations and policies.\n* `things_to_avoid` - Rules about what the AI should not do or say.\n* `faq` - Frequently asked questions and their answers.\n* `client_facing_bot_policies` - Rules specifically for client-facing bot interactions.\n* `lead_handling` - Rules about how incoming leads should be qualified, prioritized, and followed up.",
                     "enum": [
                       "tone_of_voice",
                       "policies_and_info",
                       "things_to_avoid",
                       "faq",
-                      "client_facing_bot_policies"
+                      "client_facing_bot_policies",
+                      "lead_handling"
                     ],
                     "example": "policies_and_info"
                   },
@@ -2239,17 +2240,23 @@
             "name": "category_code",
             "required": false,
             "in": "query",
-            "description": "Filter by rule category code",
+            "description": "Filter by rule category code(s). Accepts a single value, a repeated parameter, or a comma-separated list (e.g., \"?category_code=faq\", \"?category_code=faq&category_code=tone_of_voice\", \"?category_code=faq,tone_of_voice\"). Omit to retrieve every category.",
             "schema": {
-              "type": "string",
-              "enum": [
-                "tone_of_voice",
-                "policies_and_info",
-                "things_to_avoid",
-                "faq",
-                "client_facing_bot_policies"
-              ]
-            }
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "tone_of_voice",
+                  "policies_and_info",
+                  "things_to_avoid",
+                  "faq",
+                  "client_facing_bot_policies",
+                  "lead_handling"
+                ]
+              }
+            },
+            "style": "form",
+            "explode": true
           }
         ],
         "responses": {
@@ -2570,13 +2577,14 @@
                             },
                             "category_code": {
                               "type": "string",
-                              "description": "The category of the business rule. Determines how the AI agent uses this rule.\n\n* `tone_of_voice` - Rules about communication style, language, and tone the AI should adopt when interacting with clients.\n* `policies_and_info` - Rules about business operations, pricing, scheduling policies, and other operational guidelines.\n* `things_to_avoid` - Rules about topics, phrases, or actions the AI should not mention or perform.\n* `faq` - Frequently asked questions and their answers. When this category is used, the metadata field should contain structured `question` and `answer` fields.\n* `client_facing_bot_policies` - Rules specifically for client-facing bot interactions, defining bot behavior, limitations, and escalation policies.",
+                              "description": "The category of the business rule. Determines how the AI agent uses this rule.\n\n* `tone_of_voice` - Rules about communication style, language, and tone the AI should adopt when interacting with clients.\n* `policies_and_info` - Rules about business operations, pricing, scheduling policies, and other operational guidelines.\n* `things_to_avoid` - Rules about topics, phrases, or actions the AI should not mention or perform.\n* `faq` - Frequently asked questions and their answers. When this category is used, the metadata field should contain structured `question` and `answer` fields.\n* `client_facing_bot_policies` - Rules specifically for client-facing bot interactions, defining bot behavior, limitations, and escalation policies.\n* `lead_handling` - Rules about how incoming leads should be qualified, prioritized, and followed up.",
                               "enum": [
                                 "tone_of_voice",
                                 "policies_and_info",
                                 "things_to_avoid",
                                 "faq",
-                                "client_facing_bot_policies"
+                                "client_facing_bot_policies",
+                                "lead_handling"
                               ]
                             }
                           },
@@ -3282,13 +3290,14 @@
                             },
                             "category_code": {
                               "type": "string",
-                              "description": "The category of the business rule. Determines how the AI agent uses this rule.\n\n* `tone_of_voice` - Rules about communication style, language, and tone the AI should adopt when interacting with clients.\n* `policies_and_info` - Rules about business operations, pricing, scheduling policies, and other operational guidelines.\n* `things_to_avoid` - Rules about topics, phrases, or actions the AI should not mention or perform.\n* `faq` - Frequently asked questions and their answers. When this category is used, the metadata field should contain structured `question` and `answer` fields.\n* `client_facing_bot_policies` - Rules specifically for client-facing bot interactions, defining bot behavior, limitations, and escalation policies.",
+                              "description": "The category of the business rule. Determines how the AI agent uses this rule.\n\n* `tone_of_voice` - Rules about communication style, language, and tone the AI should adopt when interacting with clients.\n* `policies_and_info` - Rules about business operations, pricing, scheduling policies, and other operational guidelines.\n* `things_to_avoid` - Rules about topics, phrases, or actions the AI should not mention or perform.\n* `faq` - Frequently asked questions and their answers. When this category is used, the metadata field should contain structured `question` and `answer` fields.\n* `client_facing_bot_policies` - Rules specifically for client-facing bot interactions, defining bot behavior, limitations, and escalation policies.\n* `lead_handling` - Rules about how incoming leads should be qualified, prioritized, and followed up.",
                               "enum": [
                                 "tone_of_voice",
                                 "policies_and_info",
                                 "things_to_avoid",
                                 "faq",
-                                "client_facing_bot_policies"
+                                "client_facing_bot_policies",
+                                "lead_handling"
                               ]
                             }
                           },
@@ -3590,13 +3599,14 @@
                             },
                             "category_code": {
                               "type": "string",
-                              "description": "The category of the business rule. Determines how the AI agent uses this rule.\n\n* `tone_of_voice` - Rules about communication style, language, and tone the AI should adopt when interacting with clients.\n* `policies_and_info` - Rules about business operations, pricing, scheduling policies, and other operational guidelines.\n* `things_to_avoid` - Rules about topics, phrases, or actions the AI should not mention or perform.\n* `faq` - Frequently asked questions and their answers. When this category is used, the metadata field should contain structured `question` and `answer` fields.\n* `client_facing_bot_policies` - Rules specifically for client-facing bot interactions, defining bot behavior, limitations, and escalation policies.",
+                              "description": "The category of the business rule. Determines how the AI agent uses this rule.\n\n* `tone_of_voice` - Rules about communication style, language, and tone the AI should adopt when interacting with clients.\n* `policies_and_info` - Rules about business operations, pricing, scheduling policies, and other operational guidelines.\n* `things_to_avoid` - Rules about topics, phrases, or actions the AI should not mention or perform.\n* `faq` - Frequently asked questions and their answers. When this category is used, the metadata field should contain structured `question` and `answer` fields.\n* `client_facing_bot_policies` - Rules specifically for client-facing bot interactions, defining bot behavior, limitations, and escalation policies.\n* `lead_handling` - Rules about how incoming leads should be qualified, prioritized, and followed up.",
                               "enum": [
                                 "tone_of_voice",
                                 "policies_and_info",
                                 "things_to_avoid",
                                 "faq",
-                                "client_facing_bot_policies"
+                                "client_facing_bot_policies",
+                                "lead_handling"
                               ]
                             }
                           },
@@ -9241,13 +9251,14 @@
           },
           "category_code": {
             "type": "string",
-            "description": "The category code of the business rule. Determines how the AI agent uses this rule.\n\nAvailable values:\n* `tone_of_voice` - Rules about communication style and tone the AI should adopt when interacting with clients.\n* `policies_and_info` - Rules about business operations, pricing, and scheduling policies.\n* `things_to_avoid` - Rules about topics, phrases, or actions the AI should not mention or perform.\n* `faq` - Frequently asked questions and their answers.\n* `client_facing_bot_policies` - Rules specifically for client-facing bot interactions, defining bot behavior, limitations, and escalation policies.",
+            "description": "The category code of the business rule. Determines how the AI agent uses this rule.\n\nAvailable values:\n* `tone_of_voice` - Rules about communication style and tone the AI should adopt when interacting with clients.\n* `policies_and_info` - Rules about business operations, pricing, and scheduling policies.\n* `things_to_avoid` - Rules about topics, phrases, or actions the AI should not mention or perform.\n* `faq` - Frequently asked questions and their answers.\n* `client_facing_bot_policies` - Rules specifically for client-facing bot interactions, defining bot behavior, limitations, and escalation policies.\n* `lead_handling` - Rules about how incoming leads should be qualified, prioritized, and followed up.",
             "enum": [
               "tone_of_voice",
               "policies_and_info",
               "things_to_avoid",
               "faq",
-              "client_facing_bot_policies"
+              "client_facing_bot_policies",
+              "lead_handling"
             ],
             "example": "tone_of_voice"
           }
@@ -9279,13 +9290,14 @@
           },
           "category_code": {
             "type": "string",
-            "description": "The category code of the business rule. Determines how the AI agent uses this rule.\n\nAvailable values:\n* `tone_of_voice` - Rules about communication style and tone.\n* `policies_and_info` - Rules about business operations and policies.\n* `things_to_avoid` - Rules about what the AI should not do or say.\n* `faq` - Frequently asked questions and their answers.\n* `client_facing_bot_policies` - Rules specifically for client-facing bot interactions.",
+            "description": "The category code of the business rule. Determines how the AI agent uses this rule.\n\nAvailable values:\n* `tone_of_voice` - Rules about communication style and tone.\n* `policies_and_info` - Rules about business operations and policies.\n* `things_to_avoid` - Rules about what the AI should not do or say.\n* `faq` - Frequently asked questions and their answers.\n* `client_facing_bot_policies` - Rules specifically for client-facing bot interactions.\n* `lead_handling` - Rules about how incoming leads should be qualified, prioritized, and followed up.",
             "enum": [
               "tone_of_voice",
               "policies_and_info",
               "things_to_avoid",
               "faq",
-              "client_facing_bot_policies"
+              "client_facing_bot_policies",
+              "lead_handling"
             ]
           }
         }
@@ -9530,13 +9542,14 @@
                 },
                 "category_code": {
                   "type": "string",
-                  "description": "The category of the business rule. Determines how the AI agent uses this rule.\n\n* `tone_of_voice` - Rules about communication style, language, and tone the AI should adopt when interacting with clients.\n* `policies_and_info` - Rules about business operations, pricing, scheduling policies, and other operational guidelines.\n* `things_to_avoid` - Rules about topics, phrases, or actions the AI should not mention or perform.\n* `faq` - Frequently asked questions and their answers. When this category is used, the metadata field should contain structured `question` and `answer` fields.\n* `client_facing_bot_policies` - Rules specifically for client-facing bot interactions, defining bot behavior, limitations, and escalation policies.",
+                  "description": "The category of the business rule. Determines how the AI agent uses this rule.\n\n* `tone_of_voice` - Rules about communication style, language, and tone the AI should adopt when interacting with clients.\n* `policies_and_info` - Rules about business operations, pricing, scheduling policies, and other operational guidelines.\n* `things_to_avoid` - Rules about topics, phrases, or actions the AI should not mention or perform.\n* `faq` - Frequently asked questions and their answers. When this category is used, the metadata field should contain structured `question` and `answer` fields.\n* `client_facing_bot_policies` - Rules specifically for client-facing bot interactions, defining bot behavior, limitations, and escalation policies.\n* `lead_handling` - Rules about how incoming leads should be qualified, prioritized, and followed up.",
                   "enum": [
                     "tone_of_voice",
                     "policies_and_info",
                     "things_to_avoid",
                     "faq",
-                    "client_facing_bot_policies"
+                    "client_facing_bot_policies",
+                    "lead_handling"
                   ]
                 }
               },

--- a/swagger/ai/business_rules.json
+++ b/swagger/ai/business_rules.json
@@ -62,13 +62,14 @@
           },
           "category_code": {
             "type": "string",
-            "description": "The category code of the business rule. Determines how the AI agent uses this rule.\n\nAvailable values:\n* `tone_of_voice` - Rules about communication style and tone the AI should adopt when interacting with clients.\n* `policies_and_info` - Rules about business operations, pricing, and scheduling policies.\n* `things_to_avoid` - Rules about topics, phrases, or actions the AI should not mention or perform.\n* `faq` - Frequently asked questions and their answers.\n* `client_facing_bot_policies` - Rules specifically for client-facing bot interactions, defining bot behavior, limitations, and escalation policies.",
+            "description": "The category code of the business rule. Determines how the AI agent uses this rule.\n\nAvailable values:\n* `tone_of_voice` - Rules about communication style and tone the AI should adopt when interacting with clients.\n* `policies_and_info` - Rules about business operations, pricing, and scheduling policies.\n* `things_to_avoid` - Rules about topics, phrases, or actions the AI should not mention or perform.\n* `faq` - Frequently asked questions and their answers.\n* `client_facing_bot_policies` - Rules specifically for client-facing bot interactions, defining bot behavior, limitations, and escalation policies.\n* `lead_handling` - Rules about how incoming leads should be qualified, prioritized, and followed up.",
             "enum": [
               "tone_of_voice",
               "policies_and_info",
               "things_to_avoid",
               "faq",
-              "client_facing_bot_policies"
+              "client_facing_bot_policies",
+              "lead_handling"
             ],
             "example": "tone_of_voice"
           }
@@ -100,13 +101,14 @@
           },
           "category_code": {
             "type": "string",
-            "description": "The category code of the business rule. Determines how the AI agent uses this rule.\n\nAvailable values:\n* `tone_of_voice` - Rules about communication style and tone.\n* `policies_and_info` - Rules about business operations and policies.\n* `things_to_avoid` - Rules about what the AI should not do or say.\n* `faq` - Frequently asked questions and their answers.\n* `client_facing_bot_policies` - Rules specifically for client-facing bot interactions.",
+            "description": "The category code of the business rule. Determines how the AI agent uses this rule.\n\nAvailable values:\n* `tone_of_voice` - Rules about communication style and tone.\n* `policies_and_info` - Rules about business operations and policies.\n* `things_to_avoid` - Rules about what the AI should not do or say.\n* `faq` - Frequently asked questions and their answers.\n* `client_facing_bot_policies` - Rules specifically for client-facing bot interactions.\n* `lead_handling` - Rules about how incoming leads should be qualified, prioritized, and followed up.",
             "enum": [
               "tone_of_voice",
               "policies_and_info",
               "things_to_avoid",
               "faq",
-              "client_facing_bot_policies"
+              "client_facing_bot_policies",
+              "lead_handling"
             ]
           }
         }
@@ -199,13 +201,14 @@
                   },
                   "category_code": {
                     "type": "string",
-                    "description": "The category of business rules to extract from the content. All extracted rules will be assigned to this category. If no category supplied, the system will attempt to infer the category based on the content.\n\nAvailable values:\n* `tone_of_voice` - Rules about communication style and tone.\n* `policies_and_info` - Rules about business operations and policies.\n* `things_to_avoid` - Rules about what the AI should not do or say.\n* `faq` - Frequently asked questions and their answers.\n* `client_facing_bot_policies` - Rules specifically for client-facing bot interactions.",
+                    "description": "The category of business rules to extract from the content. All extracted rules will be assigned to this category. If no category supplied, the system will attempt to infer the category based on the content.\n\nAvailable values:\n* `tone_of_voice` - Rules about communication style and tone.\n* `policies_and_info` - Rules about business operations and policies.\n* `things_to_avoid` - Rules about what the AI should not do or say.\n* `faq` - Frequently asked questions and their answers.\n* `client_facing_bot_policies` - Rules specifically for client-facing bot interactions.\n* `lead_handling` - Rules about how incoming leads should be qualified, prioritized, and followed up.",
                     "enum": [
                       "tone_of_voice",
                       "policies_and_info",
                       "things_to_avoid",
                       "faq",
-                      "client_facing_bot_policies"
+                      "client_facing_bot_policies",
+                      "lead_handling"
                     ],
                     "example": "policies_and_info"
                   },
@@ -357,17 +360,23 @@
             "name": "category_code",
             "required": false,
             "in": "query",
-            "description": "Filter by rule category code",
+            "description": "Filter by rule category code(s). Accepts a single value, a repeated parameter, or a comma-separated list (e.g., \"?category_code=faq\", \"?category_code=faq&category_code=tone_of_voice\", \"?category_code=faq,tone_of_voice\"). Omit to retrieve every category.",
             "schema": {
-              "type": "string",
-              "enum": [
-                "tone_of_voice",
-                "policies_and_info",
-                "things_to_avoid",
-                "faq",
-                "client_facing_bot_policies"
-              ]
-            }
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "tone_of_voice",
+                  "policies_and_info",
+                  "things_to_avoid",
+                  "faq",
+                  "client_facing_bot_policies",
+                  "lead_handling"
+                ]
+              }
+            },
+            "style": "form",
+            "explode": true
           }
         ],
         "responses": {


### PR DESCRIPTION
GET /v3/ai/business_rules takes category_code as a repeatable query parameter (style: form, explode: true), so document it as an array.

Also adds lead_handling, which the service has supported for a while, to every category_code enum and description in the spec and entity.