### PR TITLE
VCITA2-13177: the domain enum becomes the 10 Package Manager categories

### DIFF
--- a/entities/license/feature.json
+++ b/entities/license/feature.json
@@ -30,26 +30,18 @@
       "type": "string",
       "nullable": true,
       "enum": [
-        "communication",
-        "clients",
-        "assets",
-        "campaigns",
-        "online_presence",
-        "sales",
-        "financial_ops",
-        "payments",
-        "catalog",
-        "scheduling",
-        "business_administration",
-        "verticals",
-        "access_control",
-        "licensing",
-        "operators",
-        "apps",
+        "bundles",
         "ai",
-        "integration"
+        "client_management",
+        "scheduling",
+        "payments",
+        "communication",
+        "marketing",
+        "business_administration",
+        "spam_prevention",
+        "other"
       ],
-      "description": "Functional domain the feature flag belongs to, from the R&D Domain-Driven Design domain list (the same key used as the domain's API path segment). At most one per flag. Optional -- null for flags that have not been classified yet (e.g., \"financial_ops\", \"scheduling\")"
+      "description": "Functional area the feature flag belongs to, matching the Package Manager category grouping. At most one per flag. Optional -- null for flags that have not been classified yet (e.g., \"payments\", \"scheduling\")"
     },
     "removable": {
       "type": "boolean",
@@ -76,7 +68,7 @@
     "name": "3_services_limitation",
     "description": "3 service limitation per account",
     "packageable": true,
-    "domain": "catalog",
+    "domain": "scheduling",
     "removable": false,
     "created_at": "Wed, May 29, 2013 at 12:21pm",
     "updated_at": "Thu, September 03 at 9:50am"

--- a/swagger/platform_administration/legacy/operator-portal.json
+++ b/swagger/platform_administration/legacy/operator-portal.json
@@ -464,24 +464,16 @@
             "in": "query",
             "type": "string",
             "enum": [
-              "communication",
-              "clients",
-              "assets",
-              "campaigns",
-              "online_presence",
-              "sales",
-              "financial_ops",
-              "payments",
-              "catalog",
-              "scheduling",
-              "business_administration",
-              "verticals",
-              "access_control",
-              "licensing",
-              "operators",
-              "apps",
+              "bundles",
               "ai",
-              "integration"
+              "client_management",
+              "scheduling",
+              "payments",
+              "communication",
+              "marketing",
+              "business_administration",
+              "spam_prevention",
+              "other"
             ],
             "required": false,
             "description": "When present, returns only feature flags in this domain"
@@ -503,7 +495,7 @@
                     "description": "Invoicing module",
                     "packageable": true,
                     "removable": false,
-                    "domain": "financial_ops",
+                    "domain": "scheduling",
                     "created_at": "2023-04-01T00:00:00Z",
                     "updated_at": "2023-04-01T00:00:00Z"
                   }
@@ -1019,27 +1011,19 @@
         "domain": {
           "type": "string",
           "enum": [
-            "communication",
-            "clients",
-            "assets",
-            "campaigns",
-            "online_presence",
-            "sales",
-            "financial_ops",
-            "payments",
-            "catalog",
-            "scheduling",
-            "business_administration",
-            "verticals",
-            "access_control",
-            "licensing",
-            "operators",
-            "apps",
+            "bundles",
             "ai",
-            "integration"
+            "client_management",
+            "scheduling",
+            "payments",
+            "communication",
+            "marketing",
+            "business_administration",
+            "spam_prevention",
+            "other"
           ],
-          "description": "Functional domain the feature flag belongs to, from the R&D Domain-Driven Design domain list (the same key used as the domain's API path segment). At most one per flag. **Optional** — `null` for flags that have not been classified yet; the field is purely additive and existing clients that never send it keep working unchanged.",
-          "example": "financial_ops"
+          "description": "Functional area the feature flag belongs to, matching the Package Manager category grouping. At most one per flag. Optional -- null for flags that have not been classified yet (e.g., \"payments\", \"scheduling\")",
+          "example": "payments"
         }
       }
     },
@@ -1085,24 +1069,16 @@
         "domain": {
           "type": "string",
           "enum": [
-            "communication",
-            "clients",
-            "assets",
-            "campaigns",
-            "online_presence",
-            "sales",
-            "financial_ops",
-            "payments",
-            "catalog",
-            "scheduling",
-            "business_administration",
-            "verticals",
-            "access_control",
-            "licensing",
-            "operators",
-            "apps",
+            "bundles",
             "ai",
-            "integration"
+            "client_management",
+            "scheduling",
+            "payments",
+            "communication",
+            "marketing",
+            "business_administration",
+            "spam_prevention",
+            "other"
           ],
           "description": "Optional. When supplied it must be one of the enum values; an unknown value is rejected with HTTP 400. Omitting it on update leaves the current value untouched — it is never cleared implicitly."
         }

--- a/swagger/platform_administration/license.json
+++ b/swagger/platform_administration/license.json
@@ -2571,26 +2571,18 @@
             "schema": {
               "type": "string",
               "enum": [
-                "communication",
-                "clients",
-                "assets",
-                "campaigns",
-                "online_presence",
-                "sales",
-                "financial_ops",
-                "payments",
-                "catalog",
-                "scheduling",
-                "business_administration",
-                "verticals",
-                "access_control",
-                "licensing",
-                "operators",
-                "apps",
+                "bundles",
                 "ai",
-                "integration"
+                "client_management",
+                "scheduling",
+                "payments",
+                "communication",
+                "marketing",
+                "business_administration",
+                "spam_prevention",
+                "other"
               ],
-              "description": "Functional domain the feature flag belongs to, from the R&D Domain-Driven Design domain list. Optional -- null for flags that have not been classified yet (e.g., \"financial_ops\", \"scheduling\")"
+              "description": "Functional area the feature flag belongs to, matching the Package Manager category grouping. At most one per flag. Optional -- null for flags that have not been classified yet (e.g., \"payments\", \"scheduling\")"
             },
             "description": "Return only features in this domain. Composable with `packageable` and `filter`; a value outside the enum is rejected with HTTP 400 (e.g., \"financial_ops\")"
           }
@@ -2632,7 +2624,7 @@
                         "name": "3_services_limitation",
                         "description": "3 service limitation per account",
                         "packageable": true,
-                        "domain": "catalog",
+                        "domain": "scheduling",
                         "removable": false,
                         "created_at": "Wed, May 29, 2013 at 12:21pm",
                         "updated_at": "Thu, September 03 at 9:50am"
@@ -2705,24 +2697,16 @@
                   "domain": {
                     "type": "string",
                     "enum": [
-                      "communication",
-                      "clients",
-                      "assets",
-                      "campaigns",
-                      "online_presence",
-                      "sales",
-                      "financial_ops",
-                      "payments",
-                      "catalog",
-                      "scheduling",
-                      "business_administration",
-                      "verticals",
-                      "access_control",
-                      "licensing",
-                      "operators",
-                      "apps",
+                      "bundles",
                       "ai",
-                      "integration"
+                      "client_management",
+                      "scheduling",
+                      "payments",
+                      "communication",
+                      "marketing",
+                      "business_administration",
+                      "spam_prevention",
+                      "other"
                     ],
                     "description": "Optional. When supplied it must be one of the enum values; an unknown value is rejected with HTTP 400. Omitting it on update leaves the current value untouched -- it is never cleared implicitly (e.g., \"financial_ops\")"
                   }
@@ -2770,7 +2754,7 @@
                       "name": "3_services_limitation",
                       "description": "3 service limitation per account",
                       "packageable": true,
-                      "domain": "catalog",
+                      "domain": "scheduling",
                       "removable": false,
                       "created_at": "Wed, May 29, 2013 at 12:21pm",
                       "updated_at": "Thu, September 03 at 9:50am"
@@ -2881,7 +2865,7 @@
                       "name": "3_services_limitation",
                       "description": "3 service limitation per account",
                       "packageable": true,
-                      "domain": "catalog",
+                      "domain": "scheduling",
                       "removable": false,
                       "created_at": "Wed, May 29, 2013 at 12:21pm",
                       "updated_at": "Thu, September 03 at 9:50am"
@@ -2979,24 +2963,16 @@
                   "domain": {
                     "type": "string",
                     "enum": [
-                      "communication",
-                      "clients",
-                      "assets",
-                      "campaigns",
-                      "online_presence",
-                      "sales",
-                      "financial_ops",
-                      "payments",
-                      "catalog",
-                      "scheduling",
-                      "business_administration",
-                      "verticals",
-                      "access_control",
-                      "licensing",
-                      "operators",
-                      "apps",
+                      "bundles",
                       "ai",
-                      "integration"
+                      "client_management",
+                      "scheduling",
+                      "payments",
+                      "communication",
+                      "marketing",
+                      "business_administration",
+                      "spam_prevention",
+                      "other"
                     ],
                     "description": "Optional. When supplied it must be one of the enum values; an unknown value is rejected with HTTP 400. Omitting it on update leaves the current value untouched -- it is never cleared implicitly (e.g., \"financial_ops\")"
                   }
@@ -3043,7 +3019,7 @@
                       "name": "3_services_limitation",
                       "description": "3 service limitation per account",
                       "packageable": true,
-                      "domain": "catalog",
+                      "domain": "scheduling",
                       "removable": false,
                       "created_at": "Wed, May 29, 2013 at 12:21pm",
                       "updated_at": "Thu, September 03 at 9:50am"


### PR DESCRIPTION
Follow-up to vcita/developers-hub#333 (merged). Code side: vcita/core#29382 (master) and vcita/core#29383 (integration).

The `domain` enum changes from the 18 DDD domains to the **10 Package Manager categories**:

```
bundles  ai  client_management  scheduling  payments
communication  marketing  business_administration  spam_prevention  other
```

## Why this reverses the ticket

[VCITA2-13177](https://myvcita.atlassian.net/browse/VCITA2-13177) §1.2 specifies the 18 official DDD domains, and §5 explicitly rejects the spreadsheet's `Category` column as "the Package Manager's ad-hoc UI grouping [that does] not match the official domains". The updated list from the product side supplies exactly those categories as the domain values, so the enum follows the list. Worth a conscious sign-off — `other` and `bundles` are not domains in any DDD sense.

## Changes

7 enum arrays, 3 descriptions and 7 examples across three files:

| File | What |
|---|---|
| `entities/license/feature.json` | enum, description, example |
| `swagger/platform_administration/license.json` | v3 query filter + POST/PUT bodies, examples |
| `swagger/platform_administration/legacy/operator-portal.json` | **already on master** — see below |

The descriptions no longer call these DDD domains, because they aren't.

> [!IMPORTANT]
> **The legacy spec is currently wrong on master.** `operator-portal.json` documented the 18-value enum *ahead of* the implementation — it was written before any code existed. With the enum now settled as the 10 categories, that published spec describes an API that does not exist, so this PR corrects it. Values like `financial_ops` and `catalog` would be rejected with HTTP 400 by the implementation.

Every example that used a now-invalid value (`catalog`, `financial_ops`) was updated too, so no example in the specs would fail validation against its own enum.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[VCITA2-13177]: https://myvcita.atlassian.net/browse/VCITA2-13177?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ