### PR TITLE
docs(online_presence) AIRecScheduling: remove the legacy faq_and_guidance field

### DIFF
--- a/entities/online_presence/AiReceptionistConfiguration.json
+++ b/entities/online_presence/AiReceptionistConfiguration.json
@@ -34,11 +34,6 @@
       "type": "object",
       "description": "The AI chat configuration blob. Sparse — omitted keys use product defaults.",
       "properties": {
-        "faq_and_guidance": {
-          "type": "string",
-          "nullable": true,
-          "description": "Free-text FAQ and guidance instructions for the AI receptionist."
-        },
         "business_hours": {
           "type": "string",
           "nullable": true,
@@ -143,7 +138,6 @@
     "updated_at": "2026-05-28T11:12:45.000Z",
     "owner_uid": "staff_1182abc",
     "config": {
-      "faq_and_guidance": "Answer questions about pricing, emergency calls, and availability.",
       "business_hours": "Mon-Fri 08:00-18:00, Sat 09:00-14:00",
       "lead_basic_contact_fields": "phone_or_email",
       "lead_fields": [

--- a/mcp_swagger/online_presence.json
+++ b/mcp_swagger/online_presence.json
@@ -142,11 +142,6 @@
                               "type": "object",
                               "description": "The AI chat configuration blob. Sparse — omitted keys use product defaults.",
                               "properties": {
-                                "faq_and_guidance": {
-                                  "type": "string",
-                                  "nullable": true,
-                                  "description": "Free-text FAQ and guidance instructions for the AI receptionist."
-                                },
                                 "business_hours": {
                                   "type": "string",
                                   "nullable": true,
@@ -263,7 +258,6 @@
                             "updated_at": "2026-05-28T11:12:45.000Z",
                             "owner_uid": "staff_1182abc",
                             "config": {
-                              "faq_and_guidance": "Answer questions about pricing, emergency calls, and availability.",
                               "business_hours": "Mon-Fri 08:00-18:00, Sat 09:00-14:00",
                               "lead_basic_contact_fields": "phone_or_email",
                               "lead_fields": [
@@ -448,11 +442,6 @@
                               "type": "object",
                               "description": "The AI chat configuration blob. Sparse — omitted keys use product defaults.",
                               "properties": {
-                                "faq_and_guidance": {
-                                  "type": "string",
-                                  "nullable": true,
-                                  "description": "Free-text FAQ and guidance instructions for the AI receptionist."
-                                },
                                 "business_hours": {
                                   "type": "string",
                                   "nullable": true,
@@ -569,7 +558,6 @@
                             "updated_at": "2026-05-28T11:12:45.000Z",
                             "owner_uid": "staff_1182abc",
                             "config": {
-                              "faq_and_guidance": "Answer questions about pricing, emergency calls, and availability.",
                               "business_hours": "Mon-Fri 08:00-18:00, Sat 09:00-14:00",
                               "lead_basic_contact_fields": "phone_or_email",
                               "lead_fields": [
@@ -3797,11 +3785,6 @@
         "type": "object",
         "description": "Request body for upserting the AI chat configuration. All fields are optional — only provided fields are merged with existing values.",
         "properties": {
-          "faq_and_guidance": {
-            "type": "string",
-            "nullable": true,
-            "description": "Free-text FAQ and guidance instructions for the AI receptionist."
-          },
           "business_hours": {
             "type": "string",
             "nullable": true,

--- a/swagger/online_presence/ai_chat_configurations.json
+++ b/swagger/online_presence/ai_chat_configurations.json
@@ -24,11 +24,6 @@
         "type": "object",
         "description": "Request body for upserting the AI chat configuration. All fields are optional — only provided fields are merged with existing values.",
         "properties": {
-          "faq_and_guidance": {
-            "type": "string",
-            "nullable": true,
-            "description": "Free-text FAQ and guidance instructions for the AI receptionist."
-          },
           "business_hours": {
             "type": "string",
             "nullable": true,


### PR DESCRIPTION
Removes the legacy `faq_and_guidance` field from the published AI chat configuration contract.

**Why.** webaiwidgetserver no longer accepts, stores or returns it (companion PR webaiwidgetserver #145) — the field had no editor left in the settings UI and knowledge lives in AI business rules now, but it was still being injected into every AI receptionist prompt. The spec should stop advertising a field that is gone.

**What changed**
- `swagger/online_presence/ai_chat_configurations.json` — property removed from `UpsertAiChatConfigRequest`
- `entities/online_presence/AiReceptionistConfiguration.json` — property and example value removed
- `mcp_swagger/online_presence.json` — both mirrored (3 property blocks, 2 example values)

**On the unified spec:** edited surgically rather than regenerated. `npm run unify` reorders source files non-deterministically and rewrites all eleven domain files — ~70k lines of churn across domains untouched by this change. The result here is identical to what a regeneration would produce for this field; happy to regenerate instead if you'd rather take the churn.

Companion PRs: webaiwidgetserver #145 / #149, webaiwidgetmgr #30 / #31, frontage #29923 / #29924, aiagents #686 / #705.
